### PR TITLE
Yang: Fixed win32 build problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,9 @@ if (APPLE)
     # HDRVIEW is unlikely to switch away from openGL anytime soon
     set(HDRVIEW_DEFINITIONS ${HDRVIEW_DEFINITIONS} -DGL_SILENCE_DEPRECATION)
 endif()
+if (WIN32)
+    set(HDRVIEW_DEFINITIONS ${HDRVIEW_DEFINITIONS} -DNOMINMAX)
+endif()
 
 add_definitions(${HDRVIEW_DEFINITIONS} ${NANOGUI_EXTRA_DEFS})
 
@@ -291,8 +294,8 @@ add_executable(hdrbatch
 # add_dependencies(hdrbatch version_info)
 
 add_executable(force-random-dither
-    src/forced-random-dither.cpp)          
-    
+    src/forced-random-dither.cpp)
+
 
 # set_target_properties(force-random-dither PROPERTIES CXX_VISIBILITY_PRESET hidden)
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ On Linux and macOS, compiling should be as simple as
 
 On Windows, a few extra steps are needed.
 
-Since MSVC's regex implementation is buggy, you first need to have the Boost regex library installed. You can find binary installers for Windows on the [Boost website](http://www.boost.org/). You need at least Boost version 1.53. Once installed, you can run:
+Since MSVC's regex implementation is buggy, you first need to have the Boost regex library installed. You can find binary installers for Windows on the [Boost website](http://www.boost.org/). Click the "More Downloads..." link and make sure to download the "Prebuilt windows binaries". You need at least Boost version 1.53. Once installed, you can run:
 
     git clone --recursive https://bitbucket.org/wkjarosz/hdrview.git
     cd hdrview
     mkdir build
     cd build
     cmake ../
-        -G"Visual Studio 15 2017 Win64" 
+        -G"Visual Studio 15 2017 Win64"
         -DBOOST_ROOT="C:\where_you_installed_boost"
         -DUSE_BOOST_REGEX=true
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  
+
   if("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
     message(STATUS "Using C++17 standard")
     set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard to use")
@@ -49,8 +49,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
   else()
     message(FATAL_ERROR "Unsupported compiler -- HDRView requires at least C++11!")
   endif()
-  
-  
+
+
   # Prefer libc++ in conjunction with Clang
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     CHECK_CXX_COMPILER_FLAG("-stdlib=libc++" HAS_LIBCPP)
@@ -108,24 +108,27 @@ endif()
 # Build ZLIB on Windows (needed for OpenEXR)
 #============================================================================
 if (WIN32)
-  # Build zlib (only on Windows)
-  set(ZLIB_BUILD_STATIC_LIBS ON CACHE BOOL " " FORCE)
-  set(ZLIB_BUILD_SHARED_LIBS OFF CACHE BOOL " " FORCE)
-  add_subdirectory(zlib)
+  set(ZLIB_EXT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zlib)
+  set(ZLIB_EXT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zlib)
+  set(ZLIB_EXT_CONFIG Release)
 
+  include(ExternalProject)
+  externalproject_add(zlibstatic
+    SOURCE_DIR        ${ZLIB_EXT_SOURCE_DIR}
+    BINARY_DIR        ${ZLIB_EXT_BINARY_DIR}
+    CMAKE_ARGS        -DZLIB_BUILD_STATIC_LIBS=TRUE -DZLIB_BUILD_SHARED_LIBS=FALSE
+    BUILD_COMMAND     ${CMAKE_COMMAND} -E echo "Starting zlib build"
+    COMMAND           ${CMAKE_COMMAND} --build ${ZLIB_EXT_BINARY_DIR} --config ${ZLIB_EXT_CONFIG}
+    COMMAND           ${CMAKE_COMMAND} -E echo "zlib build complete"
+    INSTALL_COMMAND   ""
+  )
 
-  set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/zlib;${CMAKE_CURRENT_BINARY_DIR}/zlib" CACHE PATH " " FORCE)
-  set(ZLIB_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/zlib/Release/zlibstatic.lib" CACHE FILEPATH " " FORCE)
-
-  # set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/zlib" CACHE PATH " " FORCE)
-  # if (CMAKE_GENERATOR STREQUAL "Ninja")
-  #   set(ZLIB_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/zlib/zlibstatic.lib" CACHE FILEPATH " " FORCE)
-  # else()
-  #   set(ZLIB_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/zlib/$<CONFIG>/zlibstatic.lib" CACHE FILEPATH " " FORCE)
-  # endif()
+  set(ZLIB_INCLUDE_DIR "${ZLIB_EXT_SOURCE_DIR};${ZLIB_EXT_BINARY_DIR}" CACHE PATH " " FORCE)
+  set(ZLIB_LIBRARY "${ZLIB_EXT_BINARY_DIR}/${ZLIB_EXT_CONFIG}/zlibstatic.lib" CACHE FILEPATH " " FORCE)
 
   set_property(TARGET zlibstatic PROPERTY FOLDER "dependencies")
-  include_directories(${ZLIB_INCLUDE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/zlib")
+
+  include_directories(${ZLIB_INCLUDE_DIR})
 endif()
 
 
@@ -195,11 +198,7 @@ set (OPENEXR_INCLUDE_DIRS
   ${CMAKE_CURRENT_BINARY_DIR}/openexr/OpenEXR/config
 )
 
-if (WIN32)
-  set (OPENEXR_LIBS OpenEXR::IlmImf IlmBase::Imath IlmBase::Half zlibstatic)
-else ()
-  set (OPENEXR_LIBS OpenEXR::IlmImf IlmBase::Imath IlmBase::Half)
-endif ()
+set (OPENEXR_LIBS OpenEXR::IlmImf IlmBase::Imath IlmBase::Half)
 
 set(GLFW_INCLUDE_DIR
   ${CMAKE_CURRENT_SOURCE_DIR}/nanogui/ext/glfw/include)

--- a/src/color.h
+++ b/src/color.h
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <iostream>
 #include <nanogui/vector.h>
+#include <algorithm>
 // #include "fwd.h"
 
 class Color3

--- a/src/hdrviewscreen.cpp
+++ b/src/hdrviewscreen.cpp
@@ -4,8 +4,6 @@
 // be found in the LICENSE.txt file.
 //
 
-#define NOMINMAX
-
 #include "hdrviewscreen.h"
 #include "commandhistory.h"
 #include "common.h"


### PR DESCRIPTION
* Added `NOMINMAX` define in CMake on Win32 to avoid `Color3::min()` colliding with Microsoft's min macro
* Building zlib: using `externalproject_add()` function to force CMake to only build the Release configuration on Win32, supporting configurations other than Release for HDRView on Windows
* Added details about getting boost on Win32 in README.

Note:
* When building hdrbatch the linker will now throw warnings because we are linking a release library to a debug executable. This might be an issue but it's still better than not being able to build at all.

```
[build] LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library [C:\Ghost\repos\hdrview-jarosz\build\hdrbatch.vcxproj]
[build] LINK : warning LNK4217: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'zlibstatic.lib(zutil.obj)' in function 'zcfree' [C:\Ghost\repos\hdrview-jarosz\build\hdrbatch.vcxproj]
[build] LINK : warning LNK4217: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'zlibstatic.lib(zutil.obj)' in function 'zcalloc' [C:\Ghost\repos\hdrview-jarosz\build\hdrbatch.vcxproj]
```

Testing:
Built hdrview, hdrbatch on Windows via VSCode.