### PR TITLE
Fix windows running.

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -759,6 +759,7 @@ void HDRViewApp::draw_menus()
                 if (ImGui::MenuItem(fmt::format("{}##File{}", short_name, i).c_str()))
                 {
                     load_image(*f);
+                    break;
                 }
             }
 

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -83,7 +83,7 @@ template <typename T, typename... Args>
 IMGUI_API void TextFmt(T &&fmt, const Args &...args)
 {
     std::string str = fmt::format(std::forward<T>(fmt), args...);
-    ImGui::TextUnformatted(&*str.begin(), &*str.end());
+    ImGui::TextUnformatted(&*str.begin(), &*str.begin() + str.size());
 }
 
 // return true when activated.


### PR DESCRIPTION
Just noticed that this may overlap with #125 
 * Fix `TextFmt()` dereferences end iterator.
 * Fix open recent image crash.