### PR TITLE
add an explicit step to clean up textures

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -361,7 +361,11 @@ HDRViewApp::HDRViewApp(std::optional<float> force_exposure, std::optional<float>
 
         setup_rendering();
     };
-    m_params.callbacks.BeforeExit = [this] { save_settings(); };
+    m_params.callbacks.BeforeExit = [this]
+    {
+        Image::cleanup_default_textures();
+        save_settings();
+    };
 
     // Change style
     m_params.callbacks.SetupImGuiStyle = []()

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -71,6 +71,13 @@ void Image::make_default_textures()
     s_dither_texture->upload((const uint8_t *)dither_matrix256);
 }
 
+void Image::cleanup_default_textures()
+{
+    s_black_texture.reset();
+    s_white_texture.reset();
+    s_dither_texture.reset();
+}
+
 Texture *Image::black_texture() { return s_black_texture.get(); }
 Texture *Image::white_texture() { return s_white_texture.get(); }
 Texture *Image::dither_texture() { return s_dither_texture.get(); }

--- a/src/image.h
+++ b/src/image.h
@@ -194,6 +194,7 @@ public:
     static std::set<std::string> loadable_formats(); /// Set of supported formats for image loading
     static std::set<std::string> savable_formats();  /// Set of supported formats for image saving
     static void                  make_default_textures();
+    static void                  cleanup_default_textures();
     static Texture              *black_texture();
     static Texture              *white_texture();
     static Texture              *dither_texture();


### PR DESCRIPTION
if we rely on the default destruction of the static textures, the destroy happens after the GL (or other) context has been destroyed, and so the call to destroy the gpu texture resource will fail, and in some cases, crash. Avoid this by explicitly cleaning up the textures at exit