### PR TITLE
Fix macOS app bundle naming convention (remove version suffix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1554,26 +1554,16 @@ if(APPLE)
   
   # Strip leading 'v' from GIT_TAG to get full version with prerelease suffix
   string(REGEX REPLACE "^v" "" VERSION_NO_V "${GIT_TAG}")
-  
-  # Rename app bundle to include version
-  set(VERSIONED_APP_NAME "HDRView ${VERSION_NO_V}.app")
-  install(CODE "
-    if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/HDRView.app\")
-      file(RENAME 
-        \"\${CMAKE_INSTALL_PREFIX}/HDRView.app\"
-        \"\${CMAKE_INSTALL_PREFIX}/${VERSIONED_APP_NAME}\")
-    endif()
-  " COMPONENT Runtime)
 
   # Clear extended attributes (resource forks/quarantine) from the bundle before bundling/signing
   install(CODE "
     execute_process(
-      COMMAND xattr -rc \"\${CMAKE_INSTALL_PREFIX}/${VERSIONED_APP_NAME}\"
+      COMMAND xattr -rc \"\${CMAKE_INSTALL_PREFIX}/HDRView.app\"
       RESULT_VARIABLE _XATTR_RESULT
       OUTPUT_QUIET ERROR_QUIET
     )
     if(NOT _XATTR_RESULT EQUAL 0)
-      message(WARNING \"xattr -rc returned \${_XATTR_RESULT} for ${VERSIONED_APP_NAME}\")
+      message(WARNING \"xattr -rc returned \${_XATTR_RESULT} for HDRView.app\")
     endif()
   " COMPONENT Runtime)
   
@@ -1583,8 +1573,8 @@ if(APPLE)
     install(CODE "
       execute_process(
         COMMAND ${DYLIBBUNDLER_EXECUTABLE} -od -b 
-          -x \"\${CMAKE_INSTALL_PREFIX}/${VERSIONED_APP_NAME}/Contents/MacOS/HDRView\"
-          -d \"\${CMAKE_INSTALL_PREFIX}/${VERSIONED_APP_NAME}/Contents/libs/\"
+          -x \"\${CMAKE_INSTALL_PREFIX}/HDRView.app/Contents/MacOS/HDRView\"
+          -d \"\${CMAKE_INSTALL_PREFIX}/HDRView.app/Contents/libs/\"
         RESULT_VARIABLE DYLIB_RESULT
       )
       if(NOT DYLIB_RESULT EQUAL 0)

--- a/cmake/DMGSetup.scpt.in
+++ b/cmake/DMGSetup.scpt.in
@@ -14,7 +14,7 @@ on run argv
             set text size of viewOptions to 14
             
             -- Position the app bundle on the left
-            set position of item "HDRView @VERSION_NO_V@.app" of container window to {130, 105}
+            set position of item "HDRView.app" of container window to {130, 105}
             
             -- Position the Applications symlink on the right
             set position of item "Applications" of container window to {360, 105}


### PR DESCRIPTION
Hi @wkjarosz, thanks for the tool!

I noticed that the `CMakeLists.txt` forces the macOS app bundle to be renamed to `HDRView <version>.app`. In the macOS ecosystem, appending version numbers to the `.app` bundle name is considered an anti-pattern. 

It causes a few UX issues for Mac users:
1. It breaks the Dock icon on every update (the old icon becomes a `?`).
2. It breaks default file associations (e.g., `.exr` files) after an update, as the OS looks for the specific old app name.
3. It complicates package managers like Homebrew Cask, which expect a static `HDRView.app` name for automation.

This PR removes the `install(CODE ...)` block that renames the `.app` and updates the subsequent `xattr`, `dylibbundler`, and `DMGSetup.scpt.in` scripts to reference the clean `HDRView.app`. 

The outer DMG file generated by CPack will still correctly retain the version number and architecture (e.g., `HDRView-2.8.0-arm64.dmg`), which is the recommended Apple standard. Version information remains preserved inside the `Info.plist`.

Addresses issue #152