### PR TITLE
Raise osx-post-install.cmake minimum to 3.5 for CMake 4.x

### DIFF
--- a/cmake/osx-post-install.cmake
+++ b/cmake/osx-post-install.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 # Add a symlink to /usr/local/bin so we can launch HDRView from the commandline
 execute_process(COMMAND rm -f /usr/local/bin/hdrview)


### PR DESCRIPTION
## What

`cmake/osx-post-install.cmake` still declares `cmake_minimum_required(VERSION 3.1)`. CMake 4.0 removed compatibility with minimums below 3.5, so this file now hard-errors:

```
CMake Error at cmake/osx-post-install.cmake:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

Because this file is executed as a standalone script through `install(SCRIPT cmake/osx-post-install.cmake)`, it has its own policy scope — the top-level `cmake_minimum_required(VERSION 3.13)` doesn't cover it — so the `/usr/local/bin` symlink step fails at install time for macOS users building with CMake 4.x.

## Fix

Bump the minimum to `VERSION 3.5`, the lowest value CMake 4.x still accepts. This mirrors the same fix already applied to `cmake/VersionFromGit.cmake` and has no effect on older CMake.

This was the last remaining `cmake_minimum_required` below 3.5 in the tree, so with this change the project configures/installs cleanly on CMake 4.x.

