### PR TITLE
Fix crash loading images larger than the GPU's max texture size

### DIFF
--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -414,6 +414,10 @@ void HDRViewApp::setup_rendering()
 {
     try
     {
+        // Query (and cache) the backend's max texture size while a graphics context is guaranteed to be current on
+        // this (the main) thread. Image::finalize() relies on the cached value from background loader threads.
+        spdlog::info("Maximum supported texture size: {}", Texture::max_size());
+
         m_render_pass = new RenderPass(false, true);
         m_render_pass->set_cull_mode(RenderPass::CullMode::Disabled);
         m_render_pass->set_depth_test(RenderPass::DepthTest::Always, false);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1106,6 +1106,13 @@ void Image::finalize()
                 fmt::format("All channels must have the same size as the data window. ({}:{}x{} != {}x{})", c.name,
                             c.size().x, c.size().y, data_window.size().x, data_window.size().y)};
 
+    // reject images whose channels can't be uploaded as a texture on this graphics backend (e.g. Metal aborts
+    // outright rather than failing gracefully when asked to create an oversized texture)
+    if (int lim = Texture::max_size(); data_window.size().x > lim || data_window.size().y > lim)
+        throw runtime_error{fmt::format("Image dimensions {}x{} exceed the maximum texture size ({}) supported by "
+                                        "your graphics hardware.",
+                                        data_window.size().x, data_window.size().y, lim)};
+
     build_layers_and_groups();
 
     if (!orientation_applied)

--- a/src/texture.h
+++ b/src/texture.h
@@ -138,6 +138,16 @@ public:
     /// Generates the mipmap. Done automatically upon upload if manual mipmapping is disabled.
     void generate_mipmap();
 
+    /**
+        Maximum supported width or height for a 2D texture on the active graphics backend.
+
+        \note
+            On the OpenGL backend this queries the driver and requires a current GL context on the calling thread; it
+            is cached after the first call, which must happen on the main/render thread (e.g. during \ref
+            HDRViewApp::setup_rendering()) before any other thread relies on the cached value.
+    */
+    static int max_size();
+
 #if defined(HELLOIMGUI_HAS_OPENGL)
     uint32_t texture_handle() const { return m_texture_handle; }
     uint32_t renderbuffer_handle() const { return m_renderbuffer_handle; }

--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -271,6 +271,16 @@ void Texture::resize(const int2 &size)
     upload(nullptr);
 }
 
+int Texture::max_size()
+{
+    // Cached after the first call. That first call must happen on the main/render thread while a GL context is
+    // current (see HDRViewApp::setup_rendering()); afterwards this is just a plain read, safe from any thread.
+    static GLint s_max_size = 0;
+    if (s_max_size == 0)
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &s_max_size);
+    return (int)s_max_size;
+}
+
 void Texture::generate_mipmap()
 {
     spdlog::info("Generating mipmap");

--- a/src/texture_metal.mm
+++ b/src/texture_metal.mm
@@ -312,6 +312,32 @@ void Texture::resize(const int2 &size)
     m_texture_handle       = (__bridge_retained void *)texture;
 }
 
+int Texture::max_size()
+{
+    // Requesting a texture larger than the GPU's max 2D texture dimension doesn't fail gracefully: MTLTextureDescriptor
+    // validation calls abort() directly, which is why this must be checked before ever constructing a Texture of this
+    // size (see Image::finalize()). Max size depends on GPU family and isn't exposed as a simple property, so we
+    // check supportsFamily: from the highest (newest) tier down; families are cumulative, so a device supporting a
+    // higher family also supports all lower ones in the same group.
+    //   Apple10 (M5, A19+): 32768
+    //   Apple3-Apple9 (A9-M4) and Mac1/Mac2 (all other Apple Silicon and Intel Macs): 16384
+    //   Apple1/Apple2 (oldest, pre-A9): 8192
+    // MTLGPUFamilyApple10 (raw value 1010) is referenced by its integer value rather than the symbolic name, since it
+    // is only defined in very recent SDKs; supportsFamily: safely returns NO for any family value the running
+    // OS/SDK/hardware doesn't recognize, so this degrades correctly on older toolchains and devices.
+    // Sources:
+    //   https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+    //   https://ikyle.me/blog/2026/metal-texture-tiling
+    auto         &gMetalGlobals = GetMetalGlobals();
+    id<MTLDevice> device        = gMetalGlobals.caMetalLayer.device;
+
+    if ([device supportsFamily:(MTLGPUFamily)1010]) // MTLGPUFamilyApple10
+        return 32768;
+    if ([device supportsFamily:MTLGPUFamilyApple3] || [device supportsFamily:MTLGPUFamilyMac2])
+        return 16384;
+    return 8192;
+}
+
 void Texture::generate_mipmap()
 {
     auto &gMetalGlobals = GetMetalGlobals();


### PR DESCRIPTION
## Summary
Loading an image whose dimensions exceed the graphics backend's maximum 2D texture size (e.g. the 24576x12288 EXR from #151) crashed the app. Metal's texture descriptor validation aborts the process outright rather than failing gracefully, and OpenGL silently produces an incomplete texture with no error at all in release builds (`CHK` is a no-op under `NDEBUG`).

- Add `Texture::max_size()`: queries `GL_MAX_TEXTURE_SIZE` on the OpenGL backend (cached after first call, primed in `setup_rendering()` while a GL context is guaranteed current on the main thread), and queries the device's supported GPU family tier on Metal (`supportsFamily:`, checked from Apple10/32768 down to Apple2-and-earlier/8192).
- `Image::finalize()` now rejects oversized images with a clear, logged error instead of ever attempting to create the texture — reusing the existing per-image load-error handling, so the image is simply skipped rather than crashing or partially loading.

Confirmed against the actual EXR from the issue report, in both Debug (under lldb, to capture the original crash's backtrace for root-causing) and Release builds on Apple Silicon: loads, decodes, gets rejected with a clear message, no crash.

Fixes #151

## Test plan
- [x] Reproduced the original crash under `lldb` on the Debug build against the exact file from #151, confirmed root cause via backtrace (`MTLTextureDescriptor` validation abort in `Texture::resize` during `Channel::get_texture`)
- [x] Verified the fix against the same file in both Debug and Release builds on Apple Silicon (macOS, Metal backend) — loads cleanly, no crash, clear error logged
- [ ] CI: Linux/Windows (OpenGL backend) — unverified locally, relying on CI for this build