### PR TITLE
Fix broken libtiff CPM dependency pin

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -74,7 +74,17 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: brew install --quiet ninja create-dmg dylibbundler jpeg-xl libjpeg-turbo little-cms2 libultrahdr libheif zlib libpng imath openexr cli11 spdlog fmt aom libde265 x265 libexif libraw openjpeg openh264
+        run: brew install --quiet ninja create-dmg dylibbundler libjpeg-turbo little-cms2 libultrahdr libheif zlib libpng imath openexr cli11 spdlog fmt aom libde265 x265 libexif libraw openjpeg openh264
+
+      # jpeg-xl is only needed as a system package for -local presets (which link against it via
+      # find_package); -cpm/-universal presets build it from source via CPM. Installing it
+      # unconditionally leaks /usr/local/include/jxl/decode.h into the CPM build's implicit
+      # compiler search path on Intel runners (where /usr/local/include is a default system
+      # include dir, unlike /opt/homebrew on Apple Silicon), shadowing CPM's own internal jxl
+      # headers and breaking the build.
+      - name: Install jpeg-xl (local presets only)
+        if: contains(matrix.config.preset, 'local')
+        run: brew install --quiet jpeg-xl
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -74,17 +74,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: brew install --quiet ninja create-dmg dylibbundler libjpeg-turbo little-cms2 libultrahdr libheif zlib libpng imath openexr cli11 spdlog fmt aom libde265 x265 libexif libraw openjpeg openh264
-
-      # jpeg-xl is only needed as a system package for -local presets (which link against it via
-      # find_package); -cpm/-universal presets build it from source via CPM. Installing it
-      # unconditionally leaks /usr/local/include/jxl/decode.h into the CPM build's implicit
-      # compiler search path on Intel runners (where /usr/local/include is a default system
-      # include dir, unlike /opt/homebrew on Apple Silicon), shadowing CPM's own internal jxl
-      # headers and breaking the build.
-      - name: Install jpeg-xl (local presets only)
-        if: contains(matrix.config.preset, 'local')
-        run: brew install --quiet jpeg-xl
+        run: brew install --quiet ninja create-dmg dylibbundler jpeg-xl libjpeg-turbo little-cms2 libultrahdr libheif zlib libpng imath openexr cli11 spdlog fmt aom libde265 x265 libexif libraw openjpeg openh264
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -74,7 +74,19 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: brew install --quiet ninja create-dmg dylibbundler jpeg-xl libjpeg-turbo little-cms2 libultrahdr libheif zlib libpng imath openexr cli11 spdlog fmt aom libde265 x265 libexif libraw openjpeg openh264
+        run: brew install --quiet ninja create-dmg dylibbundler libjpeg-turbo little-cms2 zlib aom libde265 x265 openjpeg openh264
+
+      # The packages below are each also built from source by CPM for -cpm/-universal presets (which don't set
+      # CPM_USE_LOCAL_PACKAGES, so CPM always fetches regardless of what's installed system-wide). Installing them
+      # via Homebrew unconditionally is not just redundant for those presets but actively breaks the build: on
+      # Intel runners, /usr/local/include is one of AppleClang's implicit default header search locations (unlike
+      # /opt/homebrew on Apple Silicon), so the Homebrew copy's headers can silently shadow CPM's own fetched
+      # copies mid-build, causing incomplete-type/ABI-mismatch failures (seen with jpeg-xl and spdlog/fmt) that
+      # depend on what happens to be installed. -local presets, on the other hand, explicitly want these to come
+      # from Homebrew (that's the whole point of CPM_USE_LOCAL_PACKAGES=ON there), so only install them there.
+      - name: Install dependencies also built by CPM (local presets only)
+        if: contains(matrix.config.preset, 'local')
+        run: brew install --quiet jpeg-xl libultrahdr libheif libpng imath openexr cli11 spdlog fmt libexif libraw
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,8 @@ jobs:
             }
 
     steps:
-      # jpeg-xl is deliberately not installed here: both configs in this matrix use -cpm presets,
-      # which build JPEG XL from source via CPM. Installing the Homebrew package leaks
-      # /usr/local/include/jxl/decode.h into the CPM build's implicit compiler search path on the
-      # Intel runner (where /usr/local/include is a default system include dir, unlike
-      # /opt/homebrew on Apple Silicon), shadowing CPM's own internal jxl headers and breaking
-      # the build.
       - name: Install dependencies
-        run: brew install ninja create-dmg dylibbundler little-cms2 libultrahdr libheif libpng imath cli11 spdlog fmt aom libde265 x265
+        run: brew install ninja create-dmg dylibbundler jpeg-xl little-cms2 libultrahdr libheif libpng imath cli11 spdlog fmt aom libde265 x265
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,13 @@ jobs:
             }
 
     steps:
+      # jpeg-xl/libultrahdr/libheif/libpng/imath/cli11/spdlog/fmt are deliberately not installed here: both
+      # configs in this matrix use -cpm presets, which build them from source via CPM regardless. Installing the
+      # Homebrew packages leaks /usr/local/include into the CPM build's implicit compiler search path on the
+      # Intel runner (where /usr/local/include is a default system include dir, unlike /opt/homebrew on Apple
+      # Silicon), shadowing CPM's own internal headers for those packages and breaking the build.
       - name: Install dependencies
-        run: brew install ninja create-dmg dylibbundler jpeg-xl little-cms2 libultrahdr libheif libpng imath cli11 spdlog fmt aom libde265 x265
+        run: brew install ninja create-dmg dylibbundler little-cms2 aom libde265 x265
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,14 @@ jobs:
             }
 
     steps:
+      # jpeg-xl is deliberately not installed here: both configs in this matrix use -cpm presets,
+      # which build JPEG XL from source via CPM. Installing the Homebrew package leaks
+      # /usr/local/include/jxl/decode.h into the CPM build's implicit compiler search path on the
+      # Intel runner (where /usr/local/include is a default system include dir, unlike
+      # /opt/homebrew on Apple Silicon), shadowing CPM's own internal jxl headers and breaking
+      # the build.
       - name: Install dependencies
-        run: brew install ninja create-dmg dylibbundler jpeg-xl little-cms2 libultrahdr libheif libpng imath cli11 spdlog fmt aom libde265 x265
+        run: brew install ninja create-dmg dylibbundler little-cms2 libultrahdr libheif libpng imath cli11 spdlog fmt aom libde265 x265
 
       - uses: actions/checkout@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1163,9 +1163,9 @@ endif()
 if(HDRVIEW_ENABLE_LIBTIFF)
   CPMAddPackage(
     NAME TIFF
-    VERSION 4.5.1 # version in ubuntu 24.04
+    VERSION 4.7.1
     GITHUB_REPOSITORY Tom94/libtiff
-    GIT_TAG b6446af165a5a4177eb9a4f6834bb948d4f89d39
+    GIT_TAG 392d93518a813fe407e119aeb8596eb4891f3fd1
     OPTIONS "BUILD_SHARED_LIBS OFF"
             # "HAVE_JPEGTURBO_DUAL_MODE_8_12 TRUE"
             "tiff-tools OFF"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,21 @@
 cmake_minimum_required(VERSION 3.13)
 
+if(APPLE)
+  # On macOS, package managers like Homebrew (particularly on Intel, where the install prefix /usr/local is one of
+  # AppleClang's implicit default header/library search locations) can leak CPATH/LIBRARY_PATH-style environment
+  # variables into every compiler invocation. When CPM builds a dependency from source that a user also happens to
+  # have installed system-wide (e.g. jpeg-xl, spdlog), this can silently shadow CPM's own fetched headers with the
+  # system copy, causing incomplete-type or ABI-mismatch build failures that depend on what's installed locally.
+  # Wrap the compiler invocation to clear these variables so CPM builds are reproducible regardless of what
+  # package managers are present, without requiring anyone to uninstall anything.
+  foreach(_hdrview_lang C CXX OBJC)
+    set(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER
+        "${CMAKE_COMMAND};-E;env;CPATH=;C_INCLUDE_PATH=;CPLUS_INCLUDE_PATH=;OBJC_INCLUDE_PATH=;LIBRARY_PATH=;${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER}"
+        CACHE STRING "" FORCE
+    )
+  endforeach()
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules" "${CMAKE_SOURCE_DIR}/cmake/")
 
 include(VersionFromGit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,16 @@ if(APPLE)
   # Wrap the compiler invocation to clear these variables so CPM builds are reproducible regardless of what
   # package managers are present, without requiring anyone to uninstall anything.
   foreach(_hdrview_lang C CXX OBJC)
-    set(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER
-        "${CMAKE_COMMAND};-E;env;CPATH=;C_INCLUDE_PATH=;CPLUS_INCLUDE_PATH=;OBJC_INCLUDE_PATH=;LIBRARY_PATH=;${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER}"
-        CACHE STRING "" FORCE
-    )
+    set(_hdrview_env_launcher "${CMAKE_COMMAND};-E;env;CPATH=;C_INCLUDE_PATH=;CPLUS_INCLUDE_PATH=;OBJC_INCLUDE_PATH=;LIBRARY_PATH=")
+    # Only append the existing launcher (e.g. ccache) if one is actually set: an unconditional trailing
+    # ${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER} leaves a trailing empty list element when it's unset (as it is
+    # for OBJC, since CI only sets a launcher for C/CXX), which CMake then passes to `cmake -E env` as a literal
+    # empty-string argument, breaking the compiler invocation entirely ("permission denied").
+    if(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER)
+      list(APPEND _hdrview_env_launcher ${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER})
+    endif()
+    set(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER "${_hdrview_env_launcher}" CACHE STRING "" FORCE)
+    unset(_hdrview_env_launcher)
   endforeach()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
 
-if(APPLE)
-  # On macOS, package managers like Homebrew (particularly on Intel, where the install prefix /usr/local is one of
-  # AppleClang's implicit default header/library search locations) can leak CPATH/LIBRARY_PATH-style environment
-  # variables into every compiler invocation. When CPM builds a dependency from source that a user also happens to
-  # have installed system-wide (e.g. jpeg-xl, spdlog), this can silently shadow CPM's own fetched headers with the
-  # system copy, causing incomplete-type or ABI-mismatch build failures that depend on what's installed locally.
-  # Wrap the compiler invocation to clear these variables so CPM builds are reproducible regardless of what
-  # package managers are present, without requiring anyone to uninstall anything.
-  foreach(_hdrview_lang C CXX OBJC)
-    set(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER
-        "${CMAKE_COMMAND};-E;env;CPATH=;C_INCLUDE_PATH=;CPLUS_INCLUDE_PATH=;OBJC_INCLUDE_PATH=;LIBRARY_PATH=;${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER}"
-        CACHE STRING "" FORCE
-    )
-  endforeach()
-endif()
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules" "${CMAKE_SOURCE_DIR}/cmake/")
 
 include(VersionFromGit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,16 +9,10 @@ if(APPLE)
   # Wrap the compiler invocation to clear these variables so CPM builds are reproducible regardless of what
   # package managers are present, without requiring anyone to uninstall anything.
   foreach(_hdrview_lang C CXX OBJC)
-    set(_hdrview_env_launcher "${CMAKE_COMMAND};-E;env;CPATH=;C_INCLUDE_PATH=;CPLUS_INCLUDE_PATH=;OBJC_INCLUDE_PATH=;LIBRARY_PATH=")
-    # Only append the existing launcher (e.g. ccache) if one is actually set: an unconditional trailing
-    # ${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER} leaves a trailing empty list element when it's unset (as it is
-    # for OBJC, since CI only sets a launcher for C/CXX), which CMake then passes to `cmake -E env` as a literal
-    # empty-string argument, breaking the compiler invocation entirely ("permission denied").
-    if(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER)
-      list(APPEND _hdrview_env_launcher ${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER})
-    endif()
-    set(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER "${_hdrview_env_launcher}" CACHE STRING "" FORCE)
-    unset(_hdrview_env_launcher)
+    set(CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER
+        "${CMAKE_COMMAND};-E;env;CPATH=;C_INCLUDE_PATH=;CPLUS_INCLUDE_PATH=;OBJC_INCLUDE_PATH=;LIBRARY_PATH=;${CMAKE_${_hdrview_lang}_COMPILER_LAUNCHER}"
+        CACHE STRING "" FORCE
+    )
   endforeach()
 endif()
 


### PR DESCRIPTION
## Summary
The pinned commit for the `Tom94/libtiff` fork (`b6446af1`) is no longer reachable from any branch in that repo (the fork's `master`/`tev`/`tev2` branches have all moved on), so `git clone`-by-SHA fails outright:

```
fatal: unable to read tree (b6446af165a5a4177eb9a4f6834bb948d4f89d39)
```

This breaks every CPM-based preset at CMake configure time, before any compilation happens. `-local` presets (system-installed libtiff, no CPM fetch) are unaffected, which is why they're the only ones that pass. This is pre-existing and unrelated to any other current work — confirmed the exact same failure already occurred on `master`'s CI back on 2026-05-08, well before this fix.

- Bump the pin from `b6446af1` to the fork's current tip (`392d9351`, libtiff `4.7.1`). Confirmed the multi-bit-depth JPEG patch this fork specifically carries (`feat(jpeg): support 9-11 bit jpeg`) is still present in the new tip's `tif_jpeg.c`, just as a different commit object (consistent with the fork having rebased onto a newer upstream libtiff release at some point).
- Also corrected the adjacent `VERSION` field, which was already stale before this change (labeled `4.5.1 "version in ubuntu 24.04"` while the actual pinned commit was libtiff `4.7.0`).

### Follow-up: macOS 15 Intel CPM build failures uncovered by this fix
With the libtiff pin fixed, CI on this PR reached the actual compile stage for CPM presets for the first time in a while, surfacing a class of previously-hidden bugs on `macOS 15 Intel CPM` (Debug + Release):

1. `member access into incomplete type 'JxlDecoder'` while building CPM's own JPEG XL from source.
2. After working around (1), `undefined symbols ... fmt::v12::detail::allocate` at link time while linking CPM's own spdlog.

Both traced back to the compiler resolving headers from a Homebrew-installed copy of the same package (`jpeg-xl`, `spdlog`/`fmt`) at `/usr/local/include` instead of CPM's own fetched copies. `/usr/local/include` is one of AppleClang's implicit default search locations on Intel Macs (unlike `/opt/homebrew` on Apple Silicon, which is why only the Intel CPM jobs failed).

Tried a more "principled" fix first: wrapping the compiler invocation to explicitly clear `CPATH`/`C_INCLUDE_PATH`/`CPLUS_INCLUDE_PATH`/`LIBRARY_PATH` via `cmake -E env`, so CPM builds wouldn't depend on what's installed system-wide at all. CI ruled this out conclusively — the identical `JxlDecoder` error persisted even with those variables confirmed cleared for the exact failing compile invocation, meaning the collision isn't environment-variable-driven; it's AppleClang's own implicit default search of `/usr/local/include`, baked into the compiler driver itself and not suppressible from the build side.

Falling back to the proven approach instead, extended to the full set of packages CPM independently builds from source for `-cpm`/`-universal` presets that also appear in the Homebrew install list: `jpeg-xl`, `libultrahdr`, `libheif`, `libpng`, `imath`, `openexr`, `cli11`, `spdlog`, `fmt`, `libexif`, `libraw`. Only `jpeg-xl` and `spdlog`/`fmt` have actually broken a build so far, but all of them risk the same Intel-only collision.

- `ci-mac.yml`: moved these into a separate step gated on `-local` presets (which explicitly want the Homebrew copies via `CPM_USE_LOCAL_PACKAGES=ON`); the common install step is now limited to build tools and packages CPM never builds itself (`libjpeg-turbo`, `little-cms2`, `zlib`, `aom`, `libde265`, `x265`, `openjpeg`, `openh264`).
- `release.yml`'s `build_macos` job: both matrix configs are `-cpm` presets, so the overlapping packages are dropped entirely rather than gated.

## Test plan
- [x] `cmake --preset macos-arm64-cpm` — confirms the new libtiff pin fetches successfully (`CPM: Adding package TIFF@4.7.1 ... Building tiff version 4.7.1`)
- [x] Full Release build compiles and links cleanly
- [x] Loaded a TIFF file in the built app — loads correctly via the libtiff loader, no errors
- [x] Validated modified workflow YAML files parse correctly (Ruby `YAML.load_file`)
- [ ] CI: full matrix including `macOS 15 Intel CPM` — the jpeg-xl-only version of this fix was already confirmed to resolve the JXL error; this run additionally confirms spdlog/fmt and the rest of the overlap set