### PR TITLE
Scope CPM module cache keys per matrix preset to fix cache contention

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: |
+            ${{ github.workflow }}-cpm-modules-
 
       # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
       - name: ccache

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -69,7 +69,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: |
+            ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
       # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
       - name: ccache

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -83,7 +83,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: |
+            ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
       # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
       - name: ccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: |
+            ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
       # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
       - name: ccache
@@ -135,7 +137,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: |
+            ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -259,6 +263,8 @@ jobs:
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: |
+            ${{ github.workflow }}-cpm-modules-
 
       # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
       - name: ccache


### PR DESCRIPTION
## Summary
The `actions/cache` key used to save/restore CPM's `cpm_modules` directory was identical across every job in a workflow's matrix:

```yaml
key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
```

`github.workflow` is just a literal string (e.g. `"macOS build"`), so this key doesn't vary by `matrix.config.os`, `matrix.config.preset`, or `matrix.buildtype` — every job in the matrix, including `-local`/`-universal` presets that don't even use CPM, was racing to save an identical cache key at the end of the run. This showed up as multi-minute stalls on the "Post Run actions/cache" step (observed as 10+ minutes on macOS jobs), because with ~16-18 jobs in a matrix finishing around the same time, most of them lose the race and spend time contending for the same cache entry (retries/backoff against the cache backend). It's more visible on macOS specifically because cache save/restore I/O is already known to be much slower there than on Linux for an equivalent payload, widening the race window.

- `ci-mac.yml`, `ci-linux.yml`, and both matrix jobs in `release.yml` (`build_macos`, `build_linux`): added `matrix.config.preset` into the cache key, and a matching `restore-keys` fallback, mirroring the pattern already used for the adjacent `ccache` key.
- `ci-emscripten.yml` and `release.yml`'s `build_emscripten` job: no matrix, so no collision risk — added a `restore-keys` fallback only, for consistency.

`ci-windows.yml` doesn't use `actions/cache` at all, so it's untouched.

## Test plan
- [x] Validated all four modified workflow YAML files parse correctly (`Ruby YAML.load_file`)
- [ ] CI: next matrix run on this branch should show scoped cache keys per preset and no `Post Run actions/cache` stalls — will confirm once CI runs on this PR