### PR TITLE
Scope CPM module cache key by buildtype to stop Debug/Release save races

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -66,10 +66,16 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
 
+      # Keyed per buildtype too (not just preset): the ccache key right below already varies by buildtype, but
+      # cpm_modules didn't, so the Debug and Release jobs for the same preset raced to save an identical cache
+      # under one shared key. actions/cache treats the loser as a soft failure, not a hard one, but it still burns
+      # several minutes archiving a large cpm_modules tree only to have the save rejected. restore-keys is left
+      # scoped to the preset only (no buildtype) so either buildtype's cache can still seed a warm start for the
+      # other, even though each buildtype now saves its own copy.
       - uses: actions/cache@v4
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -92,10 +92,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Keyed per buildtype too (not just preset): the ccache key right below already varies by buildtype, but
+      # cpm_modules didn't, so the Debug and Release jobs for the same preset raced to save an identical cache
+      # under one shared key. actions/cache treats the loser as a soft failure, not a hard one, but it still burns
+      # several minutes archiving a large cpm_modules tree only to have the save rejected. restore-keys is left
+      # scoped to the preset only (no buildtype) so either buildtype's cache can still seed a warm start for the
+      # other, even though each buildtype now saves its own copy.
       - uses: actions/cache@v4
         with:
           path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 


### PR DESCRIPTION
## Summary
#157 scoped the `cpm_modules` cache key by `matrix.config.preset`, fixing the collision across *different* presets. But `ci-mac.yml` and `ci-linux.yml` also have an orthogonal `buildtype: [Release, Debug]` matrix axis that isn't part of the preset name, so the Debug and Release jobs for the *same* preset still share one cache key and race to save the (buildtype-invariant) `cpm_modules` content at the end of the run.

Observed directly on #156's CI:
```
Failed to save: Unable to reserve cache with key macOS build-cpm-modules-macos-arm64-cpm-<hash>, another job may be creating this cache.
```
`actions/cache` treats the losing save as a soft failure rather than a build failure, but it still burns several minutes compressing a large `cpm_modules` tree first — likely why several macOS jobs on #156 took 15–54 minutes instead of the usual 2–3 once the cache was warm.

- Add `matrix.buildtype` to the primary cache key in `ci-mac.yml`/`ci-linux.yml` so each buildtype gets its own exclusively-owned cache entry (no more race).
- Leave `restore-keys` scoped to the preset only (no buildtype), so either buildtype's cache can still seed a warm start for the other rather than both needing a fully cold CPM fetch.
- `release.yml`'s `build_windows` job also has a `buildtype: [Release]` axis, but it's a single-value list with no sibling buildtype to race against, and that job doesn't use `actions/cache` at all — unaffected.

## Test plan
- [x] Validated both modified workflow YAML files parse correctly (Ruby `YAML.load_file`)
- [ ] CI: next matrix run should show no "Failed to save... another job may be creating this cache" warnings and consistent (fast, once warm) job times across Debug/Release pairs of the same preset