### PR TITLE
Fix incorrect channel statistics for non-origin rectangular selections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1394,55 +1394,54 @@ if(NOT HDRVIEW_PORTABLE_INSTALL)
   )
 endif()
 
-hello_imgui_add_app(
-  HDRView
-  ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp
-  src/imageio/image_loader.cpp
-  src/imageio/dds.cpp
-  src/imageio/exif.cpp
-  src/imageio/xmp.cpp
-  src/imageio/exr.cpp
-  src/imageio/heif.cpp
-  src/imageio/icc.cpp
-  src/imageio/jpg.cpp
-  src/imageio/jxl.cpp
-  src/imageio/pfm.cpp
-  src/imageio/png.cpp
-  src/imageio/psd.cpp
-  src/imageio/stb.cpp
-  src/imageio/qoi.cpp
-  src/imageio/raw.cpp
-  src/imageio/tiff.cpp
-  src/imageio/uhdr.cpp
-  src/imageio/webp.cpp
-  src/imageio/xmp.cpp
-  src/app-draw.cpp
-  src/app-file-io.cpp
-  src/app-gui.cpp
-  src/app-windows.cpp
-  src/app-zoom.cpp
-  src/app.cpp
-  src/colormap.cpp
-  src/colorspace.cpp
-  src/common.cpp
-  src/dithermatrix256.cpp
-  src/platform_utils.cpp
-  src/fonts.cpp
-  src/hdrview.cpp
-  src/image.cpp
-  src/imgui_ext.cpp
-  src/image-gui.cpp
-  src/opengl_check.cpp
-  src/shader.cpp
-  src/shader_gl.cpp
-  src/renderpass_gl.cpp
-  src/texture_gl.cpp
-  src/texture.cpp
-  src/theme.cpp
-  ${EXTRA_SOURCES}
-  ASSETS_LOCATION
-  ${CMAKE_CURRENT_BINARY_DIR}/assets
+set(HDRVIEW_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp
+    src/imageio/image_loader.cpp
+    src/imageio/dds.cpp
+    src/imageio/exif.cpp
+    src/imageio/xmp.cpp
+    src/imageio/exr.cpp
+    src/imageio/heif.cpp
+    src/imageio/icc.cpp
+    src/imageio/jpg.cpp
+    src/imageio/jxl.cpp
+    src/imageio/pfm.cpp
+    src/imageio/png.cpp
+    src/imageio/psd.cpp
+    src/imageio/stb.cpp
+    src/imageio/qoi.cpp
+    src/imageio/raw.cpp
+    src/imageio/tiff.cpp
+    src/imageio/uhdr.cpp
+    src/imageio/webp.cpp
+    src/imageio/xmp.cpp
+    src/app-draw.cpp
+    src/app-file-io.cpp
+    src/app-gui.cpp
+    src/app-windows.cpp
+    src/app-zoom.cpp
+    src/app.cpp
+    src/colormap.cpp
+    src/colorspace.cpp
+    src/common.cpp
+    src/dithermatrix256.cpp
+    src/platform_utils.cpp
+    src/fonts.cpp
+    src/hdrview.cpp
+    src/image.cpp
+    src/imgui_ext.cpp
+    src/image-gui.cpp
+    src/opengl_check.cpp
+    src/shader.cpp
+    src/shader_gl.cpp
+    src/renderpass_gl.cpp
+    src/texture_gl.cpp
+    src/texture.cpp
+    src/theme.cpp
+    ${EXTRA_SOURCES}
 )
+
+hello_imgui_add_app(HDRView ${HDRVIEW_SOURCES} ASSETS_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/assets)
 target_include_directories(HDRView PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set_target_properties(HDRView PROPERTIES OUTPUT_NAME ${output_name} CXX_STANDARD 17)
 target_compile_definitions(HDRView PRIVATE ${HDRVIEW_ICONSET})
@@ -1464,6 +1463,31 @@ if(APPLE)
   target_link_libraries(HDRView PRIVATE "-framework ApplicationServices")
   target_compile_definitions(HDRView PRIVATE IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
 endif(APPLE)
+
+# Unit tests. Off by default: reuses the same HDRVIEW_SOURCES/HDRVIEW_DEPENDENCIES/HDRVIEW_DEFINITIONS as the main
+# app (minus src/hdrview.cpp, which defines main() — doctest provides its own), since the sources under test
+# (e.g. image.cpp) aren't separated from the rest of the app's dependency graph.
+option(HDRVIEW_BUILD_TESTS "Build unit tests (requires doctest, fetched via CPM)" OFF)
+if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
+  CPMAddPackage("gh:doctest/doctest@2.4.11")
+
+  list(REMOVE_ITEM HDRVIEW_SOURCES src/hdrview.cpp)
+  add_executable(hdrview_tests ${HDRVIEW_SOURCES} tests/test_pixel_stats.cpp)
+  target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)
+  target_compile_definitions(hdrview_tests PRIVATE ${HDRVIEW_ICONSET} ${HDRVIEW_DEFINITIONS})
+  target_link_libraries(hdrview_tests PRIVATE ${HDRVIEW_DEPENDENCIES} hello_imgui doctest::doctest)
+
+  if(APPLE)
+    target_compile_options(hdrview_tests PRIVATE "-fobjc-arc")
+    target_link_libraries(hdrview_tests PRIVATE "-framework ApplicationServices")
+    target_compile_definitions(hdrview_tests PRIVATE IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
+  endif()
+
+  include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
+  enable_testing()
+  doctest_discover_tests(hdrview_tests)
+endif()
 
 if(EMSCRIPTEN)
   target_link_options(

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -333,7 +333,7 @@ void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Chann
         if (croi.size() != rroi.size())
             spdlog::error("Image and reference channel ROIs are not the same size!");
 
-        auto pixel_value = [&img, ref, &croi, &rroi, this](int i)
+        auto pixel_value = [&img, img_data_origin, ref, &croi, &rroi, this](int i)
         {
             int2 i2d(i % croi.size().x, i / croi.size().x); // convert to 2D coordinates
             if (i2d.y >= croi.size().y)
@@ -341,7 +341,7 @@ void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Chann
                 // spdlog::error("Pixel index {} ({}) out of bounds for ROI {}..{}", i, i2d, croi.min, croi.max);
                 return std::numeric_limits<float>::quiet_NaN(); // out of bounds
             }
-            float val = img(i2d);
+            float val = img(i2d + croi.min - img_data_origin);
             if (ref)
                 val = blend(val, (*ref)(i2d + croi.min - rroi.min), settings.blend_mode);
             return val;

--- a/tests/test_pixel_stats.cpp
+++ b/tests/test_pixel_stats.cpp
@@ -1,0 +1,84 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "image.h"
+
+namespace
+{
+
+// Fills a WxH channel with a value that uniquely identifies each pixel, so any mixup between which region of the
+// channel was actually sampled is immediately visible in the resulting statistics.
+Channel make_identifiable_channel(int w, int h)
+{
+    Channel c("test", int2{w, h});
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < w; ++x) c(x, y) = float(x + 10 * y);
+    return c;
+}
+
+} // namespace
+
+TEST_CASE("PixelStats::calculate uses the selected sub-region, not the image origin")
+{
+    // 10x10 channel; the selection below covers pixels (3,3),(4,3),(3,4),(4,4) -> values 33,34,43,44
+    auto img = make_identifiable_channel(10, 10);
+
+    PixelStats::Settings settings;
+    settings.roi = Box2i{int2{3, 3}, int2{5, 5}};
+
+    PixelStats        stats;
+    std::atomic<bool> canceled{false};
+    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+
+    CHECK(stats.summary.valid_pixels == 4);
+    CHECK(stats.summary.minimum == doctest::Approx(33.f));
+    CHECK(stats.summary.maximum == doctest::Approx(44.f));
+    CHECK(stats.summary.average == doctest::Approx(38.5));
+
+    // Before the fix, this would incorrectly report the image's own top-left corner (values 0,1,10,11:
+    // min=0, max=11, avg=5.5) regardless of where the selection actually was.
+    CHECK(stats.summary.minimum != doctest::Approx(0.f));
+    CHECK(stats.summary.maximum != doctest::Approx(11.f));
+}
+
+TEST_CASE("PixelStats::calculate covers the whole image when no selection is active")
+{
+    auto img = make_identifiable_channel(4, 4);
+
+    PixelStats::Settings settings; // default-constructed roi has no volume -> whole image
+
+    PixelStats        stats;
+    std::atomic<bool> canceled{false};
+    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+
+    // values range from 0 (0,0) to 33 (3,3) across all 16 pixels
+    CHECK(stats.summary.valid_pixels == 16);
+    CHECK(stats.summary.minimum == doctest::Approx(0.f));
+    CHECK(stats.summary.maximum == doctest::Approx(33.f));
+}
+
+TEST_CASE("PixelStats::calculate offsets a non-zero image data origin correctly")
+{
+    // Simulates an image (e.g. an EXR) whose data window doesn't start at (0,0): the channel's own local array is
+    // still 0-indexed, but img_data_origin records where that local origin sits in the shared/global coordinate
+    // space that the selection ROI is expressed in.
+    auto img = make_identifiable_channel(10, 10);
+
+    PixelStats::Settings settings;
+    // In global coordinates, with img_data_origin={5,5}, this selects local pixels (3,3)-(4,4) again: 33,34,43,44
+    settings.roi = Box2i{int2{8, 8}, int2{10, 10}};
+
+    PixelStats        stats;
+    std::atomic<bool> canceled{false};
+    stats.calculate(img, int2{5, 5}, nullptr, int2{0, 0}, settings, canceled);
+
+    CHECK(stats.summary.valid_pixels == 4);
+    CHECK(stats.summary.minimum == doctest::Approx(33.f));
+    CHECK(stats.summary.maximum == doctest::Approx(44.f));
+}

--- a/tests/test_pixel_stats.cpp
+++ b/tests/test_pixel_stats.cpp
@@ -82,3 +82,75 @@ TEST_CASE("PixelStats::calculate offsets a non-zero image data origin correctly"
     CHECK(stats.summary.minimum == doctest::Approx(33.f));
     CHECK(stats.summary.maximum == doctest::Approx(44.f));
 }
+
+TEST_CASE("PixelStats::calculate counts NaN/Inf pixels separately and excludes them from min/max/average")
+{
+    // 4x4 channel, values 0..15 (x + 4*y), except three pixels replaced with NaN/+Inf/-Inf. Pixels (0,0)=0 and
+    // (3,3)=15 are left untouched, so min/max staying exactly 0/15 confirms NaN/Inf didn't corrupt them.
+    Channel img("test", int2{4, 4});
+    for (int y = 0; y < 4; ++y)
+        for (int x = 0; x < 4; ++x) img(x, y) = float(x + 4 * y);
+    img(1, 1) = std::numeric_limits<float>::quiet_NaN();     // value 5
+    img(2, 2) = std::numeric_limits<float>::infinity();      // value 10
+    img(3, 0) = -std::numeric_limits<float>::infinity();     // value 3
+
+    PixelStats::Settings settings; // whole image
+
+    PixelStats        stats;
+    std::atomic<bool> canceled{false};
+    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+
+    CHECK(stats.summary.nan_pixels == 1);
+    CHECK(stats.summary.inf_pixels == 2);
+    CHECK(stats.summary.valid_pixels == 13); // 16 - 1 NaN - 2 Inf
+    CHECK(stats.summary.minimum == doctest::Approx(0.f));
+    CHECK(stats.summary.maximum == doctest::Approx(15.f));
+}
+
+TEST_CASE("PixelStats::calculate applies each blend mode against a reference image")
+{
+    // Both channels are constant-valued, so every pixel's blended result is identical and known exactly.
+    Channel img("img", int2{2, 2});
+    Channel ref("ref", int2{2, 2});
+    img.apply([](float, int, int) { return 10.f; });
+    ref.apply([](float, int, int) { return 4.f; });
+
+    auto blended_value = [&](BlendMode_ mode)
+    {
+        PixelStats::Settings settings;
+        settings.blend_mode = mode;
+
+        PixelStats        stats;
+        std::atomic<bool> canceled{false};
+        stats.calculate(img, int2{0, 0}, &ref, int2{0, 0}, settings, canceled);
+
+        CHECK(stats.summary.valid_pixels == 4);
+        // constant inputs -> every blended pixel is identical -> zero spread
+        CHECK(stats.summary.minimum == doctest::Approx(stats.summary.maximum));
+        CHECK(stats.summary.stddev == doctest::Approx(0.0));
+        return stats.summary.average;
+    };
+
+    CHECK(blended_value(BlendMode_Add) == doctest::Approx(14.0));
+    CHECK(blended_value(BlendMode_Multiply) == doctest::Approx(40.0));
+    CHECK(blended_value(BlendMode_Subtract) == doctest::Approx(6.0));
+    CHECK(blended_value(BlendMode_Divide) == doctest::Approx(2.5));
+    CHECK(blended_value(BlendMode_Average) == doctest::Approx(7.0));
+    CHECK(blended_value(BlendMode_Difference) == doctest::Approx(6.0));
+}
+
+TEST_CASE("PixelStats::calculate resets to the default, uncomputed state when canceled")
+{
+    auto img = make_identifiable_channel(4, 4);
+
+    PixelStats::Settings settings;
+
+    PixelStats        stats;
+    std::atomic<bool> canceled{true}; // already canceled before calculate() even starts
+    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+
+    CHECK_FALSE(stats.computed);
+    CHECK(stats.summary.valid_pixels == 0);
+    CHECK(stats.summary.minimum == std::numeric_limits<float>::infinity());
+    CHECK(stats.summary.maximum == -std::numeric_limits<float>::infinity());
+}


### PR DESCRIPTION
## Summary
Reported bug: after loading an image and pressing `m` to make a rectangular selection, the Channel Statistics window updates but shows near-degenerate values — mostly `1` for min/average/max and `0` for std. dev. Not consistent across all files.

Root cause, in `PixelStats::calculate` (`src/image.cpp`): the `pixel_value` lambda indexed the channel directly with `i2d` — coordinates local to the intersected ROI (`croi`), ranging over `[0, croi.size())` — without offsetting by `croi.min - img_data_origin` to convert to the channel's own local array index. This is the same offset already applied correctly one line below for the reference channel: `(*ref)(i2d + croi.min - rroi.min)`.

Whenever a selection's origin didn't coincide with the image's own data origin (i.e. almost any real rectangular selection — `img_data_origin` only equals `croi.min` when there's no selection, or the selection happens to start exactly at the image's own top-left corner), stats were computed from the wrong region entirely: always the image's own top-left corner, sized to match the selection, rather than the actual selected pixels. That region is often fairly uniform (e.g. near an edge, or a flat alpha channel), which explains the "mostly 1s, stddev near 0" symptom — and why it wasn't consistent across all files, since a selection starting at the image's own origin doesn't trigger the bug.

**Fix:** `img(i2d)` → `img(i2d + croi.min - img_data_origin)`, mirroring the pattern already used correctly for the reference channel.

### Verification
Since this project has no automated test suite, I compiled a standalone repro directly against `image.cpp`: a 10×10 channel filled with a distinct value per pixel (`x + 10*y`), stats computed over a 2×2 selection at `(3,3)-(5,5)` (expected pixels 33,34,43,44).
- **Before the fix:** `min=0, max=11, avg=5.5` — exactly the top-left corner's values, ignoring the selection entirely.
- **After the fix:** `min=33, max=44, avg=38.5` — matches the actual selected pixels exactly.

### Second commit: minimal unit test infrastructure
Since there was no automated test suite at all (`testPresets` in `CMakePresets.json` was empty, no `tests/` directory — CI only ran `HDRView --help` as a smoke check), added a lightweight setup so this bug (and future ones) can be guarded against with real regression tests instead of one-off manual repros:

- New `HDRVIEW_BUILD_TESTS` option (default `OFF`). When enabled, fetches [doctest](https://github.com/doctest/doctest) via CPM (single header, negligible build-time cost) and builds a separate `hdrview_tests` executable, registered with CTest via `doctest_discover_tests`.
- Extracted the main `HDRView` target's source list into an `HDRVIEW_SOURCES` variable so the test executable can reuse it (minus `hdrview.cpp`, which defines `main()` — doctest provides its own) without a second list to maintain. Since `image.cpp` isn't separated from the rest of the app's dependency graph, the test binary necessarily links against nearly the same dependency set as the main app (including `hello_imgui` itself, which `hello_imgui_add_app` links implicitly) — it just never exercises any GUI/rendering code paths at runtime.
- `tests/test_pixel_stats.cpp`: three doctest cases covering `PixelStats::calculate` — a selection not at the image's origin (this bug), the whole-image/no-selection baseline, and a selection combined with a non-zero image data origin (e.g. an EXR data window).

## Test plan
- [x] Standalone repro confirms the bug and the fix (see above)
- [x] `cmake -DHDRVIEW_BUILD_TESTS=ON` + build + `ctest` passes 3/3 from a clean configure, without disturbing the main `HDRView` target (built and ran `--help` successfully alongside it)
- [x] Confirmed the regression coverage is real: reverted the fix locally and re-ran — the two selection-based tests correctly fail (the no-selection baseline still passes, as expected since that path doesn't hit the bug)
- [ ] CI: full matrix