### PR TITLE
Scope cpm_modules cache path/hashFiles to avoid symlink-walk hangs

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -45,7 +45,7 @@ jobs:
       # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
       # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
       # (CPM_SOURCE_CACHE above), so path needs no "**" either.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -42,10 +42,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
+      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
+      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
+      # cpm_modules to the workspace root, so no "**" is needed for path.
       - uses: actions/cache@v4
         with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          path: "cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-
 

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -42,10 +42,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
-      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
-      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
-      # cpm_modules to the workspace root, so no "**" is needed for path.
+      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
+      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
+      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
       - uses: actions/cache@v4
         with:
           path: "cpm_modules"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -66,19 +66,13 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
 
-      # Keyed per buildtype too (not just preset): the ccache key right below already varies by buildtype, but
-      # cpm_modules didn't, so the Debug and Release jobs for the same preset raced to save an identical cache
-      # under one shared key. actions/cache treats the loser as a soft failure, not a hard one, but it still burns
-      # several minutes archiving a large cpm_modules tree only to have the save rejected. restore-keys is left
-      # scoped to the preset only (no buildtype) so either buildtype's cache can still seed a warm start for the
-      # other, even though each buildtype now saves its own copy.
+      # Buildtype is part of the key (ccache below already varies by buildtype) so Debug and Release don't race
+      # to overwrite one shared cache entry; restore-keys stays preset-only so either buildtype can seed the other.
       #
-      # Both path and hashFiles patterns are deliberately scoped (not "**"-prefixed from the workspace root):
-      # a leading "**" walks the whole workspace, including build/. On macOS this has walked into CPack's
-      # DragNDrop staging tree's "Applications -> /Applications" symlink and from there into every Xcode
-      # install's SDK frameworks, causing multi-hour hangs (confirmed via debug logs); scoping the same way
-      # here too for consistency across workflows and to avoid the same class of bug if this job ever grows a
-      # similar symlink. CPM_SOURCE_CACHE above pins cpm_modules to the workspace root, so no "**" is needed.
+      # path and hashFiles avoid a workspace-root "**": on macOS that walks into build/'s CPack staging symlink
+      # and every installed Xcode SDK - prohibitively expensive to glob. Scoped the same way here for consistency
+      # and to stay safe if this job ever grows a similar symlink. cpm_modules is always at the workspace root
+      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
       - uses: actions/cache@v4
         with:
           path: "cpm_modules"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -73,7 +73,7 @@ jobs:
       # and every installed Xcode SDK - prohibitively expensive to glob. Scoped the same way here for consistency
       # and to stay safe if this job ever grows a similar symlink. cpm_modules is always at the workspace root
       # (CPM_SOURCE_CACHE above), so path needs no "**" either.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -72,10 +72,17 @@ jobs:
       # several minutes archiving a large cpm_modules tree only to have the save rejected. restore-keys is left
       # scoped to the preset only (no buildtype) so either buildtype's cache can still seed a warm start for the
       # other, even though each buildtype now saves its own copy.
+      #
+      # Both path and hashFiles patterns are deliberately scoped (not "**"-prefixed from the workspace root):
+      # a leading "**" walks the whole workspace, including build/. On macOS this has walked into CPack's
+      # DragNDrop staging tree's "Applications -> /Applications" symlink and from there into every Xcode
+      # install's SDK frameworks, causing multi-hour hangs (confirmed via debug logs); scoping the same way
+      # here too for consistency across workflows and to avoid the same class of bug if this job ever grows a
+      # similar symlink. CPM_SOURCE_CACHE above pins cpm_modules to the workspace root, so no "**" is needed.
       - uses: actions/cache@v4
         with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          path: "cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -98,10 +98,19 @@ jobs:
       # several minutes archiving a large cpm_modules tree only to have the save rejected. restore-keys is left
       # scoped to the preset only (no buildtype) so either buildtype's cache can still seed a warm start for the
       # other, even though each buildtype now saves its own copy.
+      #
+      # Both path and hashFiles patterns are deliberately scoped (not "**"-prefixed from the workspace root):
+      # a leading "**" walks the whole workspace, including build/, which by this point in the job contains
+      # CPack's DragNDrop staging tree with its conventional "Applications -> /Applications" symlink. Following
+      # that lands on the runner's real /Applications, which has multiple full Xcode installs, each with SDK
+      # frameworks (e.g. Ruby.framework) that alias themselves via versioned symlinks - a combinatorial glob
+      # walk that has caused multi-hour hangs in this step (confirmed via ACTIONS_STEP_DEBUG logs showing
+      # "Symlink cycle detected" across several Xcode_15.*.app SDK trees during this exact evaluation).
+      # CPM_SOURCE_CACHE above pins cpm_modules to the workspace root, so no "**" is needed for path either.
       - uses: actions/cache@v4
         with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          path: "cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -92,21 +92,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Keyed per buildtype too (not just preset): the ccache key right below already varies by buildtype, but
-      # cpm_modules didn't, so the Debug and Release jobs for the same preset raced to save an identical cache
-      # under one shared key. actions/cache treats the loser as a soft failure, not a hard one, but it still burns
-      # several minutes archiving a large cpm_modules tree only to have the save rejected. restore-keys is left
-      # scoped to the preset only (no buildtype) so either buildtype's cache can still seed a warm start for the
-      # other, even though each buildtype now saves its own copy.
+      # Buildtype is part of the key (ccache below already varies by buildtype) so Debug and Release don't race
+      # to overwrite one shared cache entry; restore-keys stays preset-only so either buildtype can seed the other.
       #
-      # Both path and hashFiles patterns are deliberately scoped (not "**"-prefixed from the workspace root):
-      # a leading "**" walks the whole workspace, including build/, which by this point in the job contains
-      # CPack's DragNDrop staging tree with its conventional "Applications -> /Applications" symlink. Following
-      # that lands on the runner's real /Applications, which has multiple full Xcode installs, each with SDK
-      # frameworks (e.g. Ruby.framework) that alias themselves via versioned symlinks - a combinatorial glob
-      # walk that has caused multi-hour hangs in this step (confirmed via ACTIONS_STEP_DEBUG logs showing
-      # "Symlink cycle detected" across several Xcode_15.*.app SDK trees during this exact evaluation).
-      # CPM_SOURCE_CACHE above pins cpm_modules to the workspace root, so no "**" is needed for path either.
+      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
+      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
+      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
       - uses: actions/cache@v4
         with:
           path: "cpm_modules"

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -98,7 +98,7 @@ jobs:
       # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
       # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
       # (CPM_SOURCE_CACHE above), so path needs no "**" either.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ matrix.buildtype }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,14 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
 
+      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
+      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
+      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
+      # cpm_modules to the workspace root, so no "**" is needed for path.
       - uses: actions/cache@v5
         with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          path: "cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
@@ -139,10 +143,14 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
 
+      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
+      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
+      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
+      # cpm_modules to the workspace root, so no "**" is needed for path.
       - uses: actions/cache@v5
         with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          path: "cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
@@ -264,10 +272,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
+      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
+      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
+      # cpm_modules to the workspace root, so no "**" is needed for path.
       - uses: actions/cache@v5
         with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          path: "cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-${{ matrix.config.preset }}-
 
+      # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
 
-      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
-      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
-      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
-      # cpm_modules to the workspace root, so no "**" is needed for path.
+      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
+      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
+      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
       - uses: actions/cache@v5
         with:
           path: "cpm_modules"
@@ -143,10 +142,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_NO_V=$VERSION_NO_V" >> $GITHUB_ENV
 
-      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
-      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
-      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
-      # cpm_modules to the workspace root, so no "**" is needed for path.
+      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
+      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
+      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
       - uses: actions/cache@v5
         with:
           path: "cpm_modules"
@@ -272,10 +270,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # path/hashFiles are scoped (not "**"-prefixed from the workspace root) to avoid walking into build/ - on
-      # macOS this glob has walked through CPack's DragNDrop staging symlink into every Xcode install's SDK
-      # frameworks, causing multi-hour cache-save hangs (confirmed via debug logs). CPM_SOURCE_CACHE above pins
-      # cpm_modules to the workspace root, so no "**" is needed for path.
+      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
+      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
+      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
       - uses: actions/cache@v5
         with:
           path: "cpm_modules"


### PR DESCRIPTION
## Summary
- The macOS CI cache-save step (`Post Run actions/cache@v4`) has intermittently hung for hours across `ci-mac.yml` (and, structurally, `ci-linux.yml`/`ci-emscripten.yml`/`release.yml`).
- `ACTIONS_STEP_DEBUG` logs from a real hung run show the hang happening while the Post step re-evaluates the cache `key`'s `hashFiles('**/CMakeLists.txt', '**/*.cmake')` expression. A leading `**` walks the whole workspace from `github.workspace`, including `build/`, which by that point in the job contains CPack's DragNDrop staging tree with its conventional `Applications -> /Applications` symlink. Following that symlink lands on the runner's real `/Applications`, which has several full Xcode installs side by side; walking into each one's SDK frameworks (e.g. `Ruby.framework`, which self-aliases via versioned symlinks) triggers repeated symlink-cycle detection across a combinatorially large path space.
- `actions/cache`'s save-phase `path:` glob uses the same underlying glob library, evaluated live at save time, so `path: "**/cpm_modules"` is exposed to the identical mechanism even though it happens not to match anything under `Applications`.
- Fix: narrow both patterns so neither ever has a path into `build/`. `CMakeLists.txt` only exists at the repo root, and all `*.cmake` files live under `cmake/`, so `hashFiles('CMakeLists.txt', 'cmake/**/*.cmake')` covers the real inputs without a workspace-root `**`. `CPM_SOURCE_CACHE` is already pinned to the workspace root, so `path: "cpm_modules"` (no `**`) is equally sufficient.
- Applied identically across all six cache blocks in `ci-mac.yml`, `ci-linux.yml`, `ci-emscripten.yml`, and `release.yml` (3 blocks).

## Test plan
- [x] All four workflow YAML files parse cleanly (`YAML.load_file` via Ruby)
- [x] Verified `CMakeLists.txt` exists only at the repo root and all `*.cmake` files live under `cmake/` (including `cmake/modules/`), so the narrowed patterns cover every real input
- [ ] This PR's own CI run (same-repo branch, so it uses this PR's workflow files, not master's) should confirm the `Post Run actions/cache@v4` step no longer stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)