### PR TITLE
fix(macOS): use UDZO instead of UDBZ for release DMG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1647,7 +1647,7 @@ if(APPLE)
   
   # CPack DragNDrop settings
   set(CPACK_DMG_VOLUME_NAME "HDRView-Installer")
-  set(CPACK_DMG_FORMAT "UDBZ")
+  set(CPACK_DMG_FORMAT "UDZO")
   
   # Set custom DMG filename: e.g. HDRView-2.7.0-Universal.dmg
   set(CPACK_PACKAGE_FILE_NAME "HDRView-${VERSION_NO_V}-${HDRVIEW_TARGET_ARCH}")


### PR DESCRIPTION
The DMG generated with `CPACK_DMG_FORMAT UDBZ` (bzip2-compressed) starts with the bzip2 magic `BZh`. Homebrew's magic-based unpack detection misreads it as a Bzip2 archive and then fails to mount the extracted file with `Disk Image has no mountable file system`, so `brew install --cask hdrview` cannot work.

Switching to `UDZO` (zlib-compressed) produces a DMG that Homebrew correctly recognizes as a disk image (`koly` trailer present, no `BZh` header). Verified locally: the UDZO DMG installs cleanly via the Homebrew cask, while the UDBZ one fails at mount.

Related to #152 (Homebrew Cask distribution).