### PR TITLE
Fix Windows CI race: build version.cpp once as a shared object library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1461,7 +1461,6 @@ if(NOT HDRVIEW_PORTABLE_INSTALL)
 endif()
 
 set(HDRVIEW_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp
     src/imageio/image_loader.cpp
     src/imageio/dds.cpp
     src/imageio/exif.cpp
@@ -1507,6 +1506,15 @@ set(HDRVIEW_SOURCES
     ${EXTRA_SOURCES}
 )
 
+# Built once as its own object library and linked into HDRView and (if enabled) hdrview_tests below, rather than
+# listed directly in HDRVIEW_SOURCES: with the Visual Studio generator, a custom command's OUTPUT listed as a
+# source in two different targets gets its rule duplicated into both .vcxproj files, and parallel MSBuild can
+# then race to regenerate version.cpp, intermittently failing generate_version.cmake's configure_file with
+# "No such file or directory" (only ever observed on the windows-msvc preset, the only Windows preset that also
+# builds hdrview_tests alongside HDRView).
+add_library(hdrview_version OBJECT ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp)
+target_link_libraries(hdrview_version PRIVATE hello_imgui)
+
 hello_imgui_add_app(HDRView ${HDRVIEW_SOURCES} ASSETS_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/assets)
 if(HDRVIEW_SOKOL_SHDC_TARGETS)
   add_dependencies(HDRView ${HDRVIEW_SOKOL_SHDC_TARGETS})
@@ -1524,7 +1532,7 @@ endif()
 message(STATUS "HDRView build dependencies: ${HDRVIEW_DEPENDENCIES}")
 message(STATUS "HDRView build definitions: ${HDRVIEW_DEFINITIONS}")
 
-target_link_libraries(HDRView PRIVATE ${HDRVIEW_DEPENDENCIES})
+target_link_libraries(HDRView PRIVATE ${HDRVIEW_DEPENDENCIES} hdrview_version)
 target_compile_definitions(HDRView PRIVATE ${HDRVIEW_DEFINITIONS})
 
 if(NOT EMSCRIPTEN)
@@ -1559,7 +1567,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
   # Mirrors HDRView's own HDRVIEW_BUILD_TREE_ASSETS_DIR definition above, so tests/test_assets.cpp
   # can exercise the same asset lookup the app uses.
   target_compile_definitions(hdrview_tests PRIVATE HDRVIEW_BUILD_TREE_ASSETS_DIR="${CMAKE_CURRENT_BINARY_DIR}/assets")
-  target_link_libraries(hdrview_tests PRIVATE ${HDRVIEW_DEPENDENCIES} hello_imgui doctest::doctest)
+  target_link_libraries(hdrview_tests PRIVATE ${HDRVIEW_DEPENDENCIES} hello_imgui hdrview_version doctest::doctest)
 
   if(APPLE)
     target_compile_options(hdrview_tests PRIVATE "-fobjc-arc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,11 +141,9 @@ list(APPEND CMD "-D" "CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}")
 list(APPEND CMD "-D" "EMSCRIPTEN=${EMSCRIPTEN}")
 list(APPEND CMD "-D" "HDRVIEW_TARGET_ARCH=${HDRVIEW_TARGET_ARCH}")
 list(APPEND CMD "-P" "${CMAKE_SOURCE_DIR}/cmake/generate_version.cmake")
-# ALL + no DEPENDS makes this custom target unconditionally re-run every build (unlike an add_custom_command
-# OUTPUT rule, which Ninja/Make/MSBuild only re-run when a listed dependency is newer, and which never fires
-# again once version.cpp exists -- checking out a different commit/branch wouldn't be picked up without a clean
-# build). configure_file() inside generate_version.cmake only rewrites version.cpp when its content actually
-# changed, so this doesn't force a relink on every build, only when the git-derived info really changes.
+# ALL reruns this every build (an add_custom_command OUTPUT rule would only run once per build tree, missing
+# later commits/branch switches). configure_file() only rewrites version.cpp when content changes, so this
+# doesn't force a relink unless the git info actually did.
 add_custom_target(
   hdrview_check_version ALL
   COMMAND ${CMD}
@@ -1512,14 +1510,10 @@ set(HDRVIEW_SOURCES
     ${EXTRA_SOURCES}
 )
 
-# Built once as its own object library and linked into HDRView and (if enabled) hdrview_tests below, rather than
-# listed directly in HDRVIEW_SOURCES: with the Visual Studio generator, listing the same generated source (or
-# custom-command OUTPUT) in two different targets duplicates the generating rule into both .vcxproj files, and
-# parallel MSBuild can then race to (re)generate version.cpp, intermittently failing generate_version.cmake's
-# configure_file with "No such file or directory" (only ever observed on the windows-msvc preset, the only
-# Windows preset that also builds hdrview_tests alongside HDRView). Depending on hdrview_check_version here,
-# rather than each consumer depending on it independently, means only this one target's project reruns the
-# version check, and downstream targets just get an ordinary (race-free) build-order dependency on it.
+# Compiled once here and linked into HDRView and hdrview_tests below, rather than listing version.cpp directly
+# in both: the Visual Studio generator duplicates a shared generated source's build rule into every consuming
+# .vcxproj, and parallel MSBuild can then race to regenerate it (windows-msvc preset only, the one Windows job
+# that builds both targets).
 add_library(hdrview_version OBJECT ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp)
 add_dependencies(hdrview_version hdrview_check_version)
 target_link_libraries(hdrview_version PRIVATE hello_imgui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,16 @@ list(APPEND CMD "-D" "CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}")
 list(APPEND CMD "-D" "EMSCRIPTEN=${EMSCRIPTEN}")
 list(APPEND CMD "-D" "HDRVIEW_TARGET_ARCH=${HDRVIEW_TARGET_ARCH}")
 list(APPEND CMD "-P" "${CMAKE_SOURCE_DIR}/cmake/generate_version.cmake")
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp
+# ALL + no DEPENDS makes this custom target unconditionally re-run every build (unlike an add_custom_command
+# OUTPUT rule, which Ninja/Make/MSBuild only re-run when a listed dependency is newer, and which never fires
+# again once version.cpp exists -- checking out a different commit/branch wouldn't be picked up without a clean
+# build). configure_file() inside generate_version.cmake only rewrites version.cpp when its content actually
+# changed, so this doesn't force a relink on every build, only when the git-derived info really changes.
+add_custom_target(
+  hdrview_check_version ALL
   COMMAND ${CMD}
-  COMMENT "Generating git version file"
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp
+  COMMENT "Checking git version"
 )
 
 message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
@@ -1507,12 +1513,15 @@ set(HDRVIEW_SOURCES
 )
 
 # Built once as its own object library and linked into HDRView and (if enabled) hdrview_tests below, rather than
-# listed directly in HDRVIEW_SOURCES: with the Visual Studio generator, a custom command's OUTPUT listed as a
-# source in two different targets gets its rule duplicated into both .vcxproj files, and parallel MSBuild can
-# then race to regenerate version.cpp, intermittently failing generate_version.cmake's configure_file with
-# "No such file or directory" (only ever observed on the windows-msvc preset, the only Windows preset that also
-# builds hdrview_tests alongside HDRView).
+# listed directly in HDRVIEW_SOURCES: with the Visual Studio generator, listing the same generated source (or
+# custom-command OUTPUT) in two different targets duplicates the generating rule into both .vcxproj files, and
+# parallel MSBuild can then race to (re)generate version.cpp, intermittently failing generate_version.cmake's
+# configure_file with "No such file or directory" (only ever observed on the windows-msvc preset, the only
+# Windows preset that also builds hdrview_tests alongside HDRView). Depending on hdrview_check_version here,
+# rather than each consumer depending on it independently, means only this one target's project reruns the
+# version check, and downstream targets just get an ordinary (race-free) build-order dependency on it.
 add_library(hdrview_version OBJECT ${CMAKE_CURRENT_BINARY_DIR}/src/version.cpp)
+add_dependencies(hdrview_version hdrview_check_version)
 target_link_libraries(hdrview_version PRIVATE hello_imgui)
 
 hello_imgui_add_app(HDRView ${HDRVIEW_SOURCES} ASSETS_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/assets)


### PR DESCRIPTION
hdrview_tests reused HDRVIEW_SOURCES (including version.cpp, generated
by an add_custom_command) verbatim, so both HDRView and hdrview_tests
listed the same custom-command OUTPUT as a source. The Visual Studio
generator duplicates that command's build rule into each consuming
.vcxproj, and parallel MSBuild could then race to regenerate
version.cpp concurrently, intermittently failing generate_version.cmake's
configure_file() with "No such file or directory" -- only observed on
the windows-msvc preset, the only Windows CI job that builds
hdrview_tests alongside HDRView.

Compiling version.cpp once into its own hdrview_version OBJECT library
and linking it into both targets means the custom-build rule now lives
in exactly one project, eliminating the race. The object library links
hello_imgui PRIVATE to keep picking up the HELLOIMGUI_USE_GLFW3/SDL2
compile definitions that version.cpp's backend() needs, same as before.