### PR TITLE
Fix PQ/HLG reference-white constant and a missed PNG buffer-sizing site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,17 @@ manual/CLI smoke check.
 `clang-format` before committing. `.cmake-format`/`.cmake-format.json` similarly govern `CMakeLists.txt`
 formatting.
 
+### Comments
+Keep comments concise and describe what the code currently does and why. A comment should read the same
+whether written with the file or years later — a reader should not be able to tell that a bug was just fixed
+here. Avoid changelog notes ("previously X", "this used to race"), justifying a line by contrasting it with a
+version that no longer exists, and restating an investigation that belongs in the commit message. Prefer a
+short note on a non-obvious constraint, invariant, or the reason a surprising approach is necessary.
+
+Comments accumulate cruft across multi-step edits, so at the end of a multi-iteration editing session re-read
+every touched file as a whole — not just the diffs — and revise for clean design and concise, logically
+ordered comments.
+
 ## Architecture
 
 ### Application core: the `HDRViewApp` god-object

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -588,7 +588,9 @@ TransferFunction transfer_function_from_CICP(int tc)
     case 2: return TransferFunction::Unspecified;
     case 1: [[fallthrough]];
     case 6: [[fallthrough]];
-    case 12: [[fallthrough]]; // FIXME: is this actually the same?
+    // 12 is BT.1361 extended colour gamut, which shares this curve for 1.33 > L >= -0.0045 and departs from it
+    // only for more negative values. Mapping it to ITU is therefore exact except deep into negative linear.
+    case 12: [[fallthrough]];
     case 14: [[fallthrough]];
     case 15: return TransferFunction::ITU;
     case 4: return {TransferFunction::Gamma, 2.2f};
@@ -1055,9 +1057,9 @@ void to_linear(float *r, float *g, float *b, int num_pixels, int num_channels, T
                          for (int i = start; i < end; ++i)
                          {
                              auto rgb      = EOTF_BT2100_HLG(float3{r[i * stride], g[i * stride], b[i * stride]});
-                             r[i * stride] = rgb[0] / 219.f;
-                             g[i * stride] = rgb[1] / 219.f;
-                             b[i * stride] = rgb[2] / 219.f;
+                             r[i * stride] = rgb[0] / HDR_REFERENCE_WHITE_NITS;
+                             g[i * stride] = rgb[1] / HDR_REFERENCE_WHITE_NITS;
+                             b[i * stride] = rgb[2] / HDR_REFERENCE_WHITE_NITS;
                          }
                      });
     }
@@ -1083,7 +1085,8 @@ void from_linear(float *pixels, int3 size, TransferFunction tf)
             parallel_for(blocked_range<int>(0, size.x * size.y, 1024 * 1024),
                          [rgb = reinterpret_cast<float3 *>(pixels)](int start, int end, int, int)
                          {
-                             for (int i = start; i < end; ++i) rgb[i] = inverse_EOTF_BT2100_HLG(rgb[i] * 219.f);
+                             for (int i = start; i < end; ++i)
+                                 rgb[i] = inverse_EOTF_BT2100_HLG(rgb[i] * HDR_REFERENCE_WHITE_NITS);
                          });
         else // size.z == 4
             // don't modify the alpha channel
@@ -1091,7 +1094,7 @@ void from_linear(float *pixels, int3 size, TransferFunction tf)
                          [rgba = reinterpret_cast<float4 *>(pixels)](int start, int end, int, int)
                          {
                              for (int i = start; i < end; ++i)
-                                 rgba[i].xyz() = inverse_EOTF_BT2100_HLG(rgba[i].xyz() * 219.f);
+                                 rgba[i].xyz() = inverse_EOTF_BT2100_HLG(rgba[i].xyz() * HDR_REFERENCE_WHITE_NITS);
                          });
     }
     else

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -396,6 +396,16 @@ Real OETF_ITU(Real linear)
         return alpha * std::pow(linear, Real(0.45)) - Real(alpha - 1.0);
 }
 
+/*! HDR reference (diffuse) white luminance in cd/m^2, per Recommendation ITU-R BT.2408.
+
+    The PQ and HLG EOTFs produce absolute luminance in cd/m^2, whereas HDRView works in values relative to
+    diffuse white. Dividing EOTF output by this constant (and multiplying before the inverse EOTF) maps
+    reference white to 1.0.
+
+    see: https://www.itu.int/pub/R-REP-BT.2408
+*/
+inline constexpr float HDR_REFERENCE_WHITE_NITS = 203.f;
+
 /*! Defines Recommendation ITU-R BT.2100-2 Reference PQ electro-optical transfer function (EOTF).
 
     \param E_p Denotes a non-linear color value R', G', B' in PQ space.
@@ -526,12 +536,25 @@ inline Real inverse_OOTF_BT2100_HLG(Real E_D, Real Y_D, Real alpha = Real(1.0), 
     return (E_D / alpha) * std::pow(Y_D / alpha, Real(1.0) / gamma - Real(1.0));
 }
 
+/*! Recommendation ITU-R BT.2100-2 HLG reference system gamma for a given display peak luminance.
+
+    \param L_W Nominal peak luminance of the display in cd/m^2 for achromatic pixels.
+
+    \returns The system gamma, which is 1.2 at the nominal peak luminance of 1000 cd/m^2.
+
+    see: https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2100-2-201807-I!!PDF-E.pdf
+*/
+template <typename Real>
+inline Real HLG_system_gamma(Real L_W)
+{
+    return Real(1.2) + Real(0.42) * std::log10(L_W / Real(1000));
+}
+
 /*! Recommendation ITU-R BT.2100-2 Reference HLG electro-optical transfer function (EOTF).
 
     \param E_p Denotes a non-linear color value R', G', B' in HLG space.
     \param L_B Display luminance for black in cd/m^2.
     \param L_W Nominal peak luminance of the display in cd/m^2 for achromatic pixels.
-    \param gamma System gamma value. 1.2 at the nominal display peak luminance of 1000 cd/m^2.
 
     \returns Luminance of a displayed linear component {R_D, G_D, or B_D} in cd/m^2/.
 
@@ -540,8 +563,9 @@ inline Real inverse_OOTF_BT2100_HLG(Real E_D, Real Y_D, Real alpha = Real(1.0), 
     https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.inline.html#TRANSFER_HLG
 */
 template <typename Real>
-inline Real EOTF_BT2100_HLG(Real E_p, Real L_B = Real(0), Real L_W = Real(1000), Real gamma = Real(1.2))
+inline Real EOTF_BT2100_HLG(Real E_p, Real L_B = Real(0), Real L_W = Real(1000))
 {
+    const Real gamma = HLG_system_gamma(L_W);
     const Real alpha = L_W - L_B;
     const Real beta  = L_B != 0 ? std::sqrt(Real(3) * std::pow(L_B / L_W, Real(1) / gamma)) : Real(0);
     auto       E_s   = inverse_OETF_BT2100_HLG(std::max(Real(0), (Real(1) - beta) * E_p + beta));
@@ -553,7 +577,6 @@ inline Real EOTF_BT2100_HLG(Real E_p, Real L_B = Real(0), Real L_W = Real(1000),
     \param E_p A non-linear color value {R', G', B'} in HLG space.
     \param L_B Display luminance for black in cd/m^2.
     \param L_W Nominal peak luminance of the display in cd/m^2 for achromatic pixels.
-    \param gamma System gamma value. 1.2 at the nominal display peak luminance of 1000 cd/m^2.
 
     \returns Displayed linear color {R_D, G_D, B_D} in cd/m^2.
 
@@ -562,9 +585,9 @@ inline Real EOTF_BT2100_HLG(Real E_p, Real L_B = Real(0), Real L_W = Real(1000),
     https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.inline.html#TRANSFER_HLG
 */
 template <typename Real>
-inline la::vec<Real, 3> EOTF_BT2100_HLG(const la::vec<Real, 3> &E_p, Real L_B = Real(0), Real L_W = Real(1000),
-                                        Real gamma = Real(1.2))
+inline la::vec<Real, 3> EOTF_BT2100_HLG(const la::vec<Real, 3> &E_p, Real L_B = Real(0), Real L_W = Real(1000))
 {
+    const Real gamma = HLG_system_gamma(L_W);
     const Real alpha = L_W - L_B;
     const Real beta  = L_B != 0 ? std::sqrt(Real(3) * std::pow(L_B / L_W, Real(1) / gamma)) : Real(0);
 
@@ -585,7 +608,6 @@ inline la::vec<Real, 3> EOTF_BT2100_HLG(const la::vec<Real, 3> &E_p, Real L_B = 
     \param E_D Displayed linear value (R'_D, G'_D, B'_D) in cd/m^2
     \param L_B Display luminance for black in cd/m^2.
     \param L_W Nominal peak luminance of the display in cd/m^2 for achromatic pixels.
-    \param gamma System gamma value. 1.2 at the nominal display peak luminance of 1000 cd/m^2.
 
     \returns Non-linear HLG signal value {R'_S, G'_S, B'_S} in [0,1].
 
@@ -593,8 +615,9 @@ inline la::vec<Real, 3> EOTF_BT2100_HLG(const la::vec<Real, 3> &E_p, Real L_B = 
     https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2100-2-201807-I!!PDF-E.pdf
 */
 template <typename Real>
-inline Real inverse_EOTF_BT2100_HLG(Real E_D, Real L_B = Real(0), Real L_W = Real(1000), Real gamma = Real(1.2))
+inline Real inverse_EOTF_BT2100_HLG(Real E_D, Real L_B = Real(0), Real L_W = Real(1000))
 {
+    const Real gamma = HLG_system_gamma(L_W);
     const Real alpha = L_W - L_B;
     const Real beta  = L_B != 0 ? std::sqrt(Real(3) * std::pow(L_B / L_W, Real(1) / gamma)) : Real(0);
 
@@ -602,9 +625,9 @@ inline Real inverse_EOTF_BT2100_HLG(Real E_D, Real L_B = Real(0), Real L_W = Rea
 }
 
 template <typename Real>
-inline la::vec<Real, 3> inverse_EOTF_BT2100_HLG(const la::vec<Real, 3> &E_D, Real L_B = Real(0), Real L_W = Real(1000),
-                                                Real gamma = Real(1.2))
+inline la::vec<Real, 3> inverse_EOTF_BT2100_HLG(const la::vec<Real, 3> &E_D, Real L_B = Real(0), Real L_W = Real(1000))
 {
+    const Real gamma = HLG_system_gamma(L_W);
     const Real alpha = L_W - L_B;
     const Real beta  = L_B != 0 ? std::sqrt(Real(3) * std::pow(L_B / L_W, Real(1) / gamma)) : Real(0);
 
@@ -749,8 +772,8 @@ inline float from_linear(float linear, const TransferFunction tf)
     case TransferFunction::sRGB: return linear_to_sRGB(linear);
     case TransferFunction::Gamma: return linear_to_gamma(linear, 1.f / tf.gamma);
     case TransferFunction::ITU: return OETF_ITU(linear);
-    case TransferFunction::BT2100_PQ: return inverse_EOTF_BT2100_PQ(linear * 219.f);
-    case TransferFunction::BT2100_HLG: return inverse_EOTF_BT2100_HLG(linear * 219.f);
+    case TransferFunction::BT2100_PQ: return inverse_EOTF_BT2100_PQ(linear * HDR_REFERENCE_WHITE_NITS);
+    case TransferFunction::BT2100_HLG: return inverse_EOTF_BT2100_HLG(linear * HDR_REFERENCE_WHITE_NITS);
     case TransferFunction::ST240: return OETF_ST240(linear);
     case TransferFunction::Log100: return OETF_log100(linear);
     case TransferFunction::Log100_Sqrt10: return OETF_log100_sqrt10(linear);
@@ -769,8 +792,9 @@ inline float3 from_linear(float3 linear, const TransferFunction tf)
     case TransferFunction::sRGB: return linear_to_sRGB(linear);
     case TransferFunction::Gamma: return linear_to_gamma(linear, float3{1.f / tf.gamma});
     case TransferFunction::ITU: return la::apply(OETF_ITU<float>, linear);
-    case TransferFunction::BT2100_PQ: return la::apply(inverse_EOTF_BT2100_PQ<float>, linear * 219.f);
-    case TransferFunction::BT2100_HLG: return inverse_EOTF_BT2100_HLG(linear * 219.f);
+    case TransferFunction::BT2100_PQ:
+        return la::apply(inverse_EOTF_BT2100_PQ<float>, linear * HDR_REFERENCE_WHITE_NITS);
+    case TransferFunction::BT2100_HLG: return inverse_EOTF_BT2100_HLG(linear * HDR_REFERENCE_WHITE_NITS);
     case TransferFunction::ST240: return la::apply(OETF_ST240<float>, linear);
     case TransferFunction::Log100: return la::apply(OETF_log100<float>, linear);
     case TransferFunction::Log100_Sqrt10: return la::apply(OETF_log100_sqrt10<float>, linear);
@@ -789,8 +813,8 @@ inline float to_linear(float encoded, const TransferFunction tf)
     case TransferFunction::sRGB: return sRGB_to_linear(encoded);
     case TransferFunction::Gamma: return linear_to_gamma(encoded, tf.gamma);
     case TransferFunction::ITU: return inverse_OETF_ITU(encoded);
-    case TransferFunction::BT2100_PQ: return EOTF_BT2100_PQ(encoded) / 219.f;
-    case TransferFunction::BT2100_HLG: return EOTF_BT2100_HLG(encoded) / 219.f;
+    case TransferFunction::BT2100_PQ: return EOTF_BT2100_PQ(encoded) / HDR_REFERENCE_WHITE_NITS;
+    case TransferFunction::BT2100_HLG: return EOTF_BT2100_HLG(encoded) / HDR_REFERENCE_WHITE_NITS;
     case TransferFunction::ST240: return EOTF_ST240(encoded);
     case TransferFunction::Log100: return EOTF_log100(encoded);
     case TransferFunction::Log100_Sqrt10: return EOTF_log100_sqrt10(encoded);
@@ -809,8 +833,8 @@ inline float3 to_linear(const float3 &encoded, const TransferFunction tf)
     case TransferFunction::sRGB: return sRGB_to_linear(encoded);
     case TransferFunction::Gamma: return linear_to_gamma(encoded, float3{tf.gamma});
     case TransferFunction::ITU: return la::apply(inverse_OETF_ITU<float>, encoded);
-    case TransferFunction::BT2100_PQ: return la::apply(EOTF_BT2100_PQ<float>, encoded) / 219.f;
-    case TransferFunction::BT2100_HLG: return EOTF_BT2100_HLG(encoded) / 219.f;
+    case TransferFunction::BT2100_PQ: return la::apply(EOTF_BT2100_PQ<float>, encoded) / HDR_REFERENCE_WHITE_NITS;
+    case TransferFunction::BT2100_HLG: return EOTF_BT2100_HLG(encoded) / HDR_REFERENCE_WHITE_NITS;
     case TransferFunction::ST240: return la::apply(EOTF_ST240<float>, encoded);
     case TransferFunction::Log100: return la::apply(EOTF_log100<float>, encoded);
     case TransferFunction::Log100_Sqrt10: return la::apply(EOTF_log100_sqrt10<float>, encoded);

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -717,7 +717,7 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         png_read_image(png_ptr, row_pointers.data());
 
         // process and copy over the pixel data
-        std::vector<float> float_pixels(size.x * size.y * size.z);
+        std::vector<float> float_pixels((size_t)size.x * size.y * size.z);
         if (video_full_range_flag)
             for (size_t i = 0; i < float_pixels.size(); ++i)
                 float_pixels[i] = bit_depth == 16

--- a/tests/test_colorspace.cpp
+++ b/tests/test_colorspace.cpp
@@ -42,6 +42,47 @@ TEST_CASE("to_linear/from_linear round-trip for every TransferFunction")
     }
 }
 
+// The round-trip test above passes for any choice of normalization constant, since to_linear and from_linear
+// scale by it symmetrically. These cases pin the absolute mapping against the values BT.2100/BT.2408 specify.
+TEST_CASE("PQ maps absolute luminance relative to BT.2408 reference white")
+{
+    // The PQ EOTF is defined over 0 to 10000 cd/m^2.
+    CHECK(EOTF_BT2100_PQ(1.0f) == doctest::Approx(10000.f));
+    CHECK(EOTF_BT2100_PQ(0.0f) == doctest::Approx(0.f));
+
+    // to_linear additionally normalizes so that reference white lands at 1.0. These expectations spell out 203
+    // rather than referring to HDR_REFERENCE_WHITE_NITS, so that they pin the constant instead of tracking it.
+    CHECK(to_linear(1.0f, TransferFunction::BT2100_PQ) == doctest::Approx(10000.f / 203.f));
+
+    const float reference_white_signal = inverse_EOTF_BT2100_PQ(203.f);
+    CHECK(to_linear(reference_white_signal, TransferFunction::BT2100_PQ) == doctest::Approx(1.f));
+}
+
+TEST_CASE("HLG maps its 75% reference level to BT.2408 reference white")
+{
+    // BT.2408 places HLG reference white at 75% signal, which the 1000 cd/m^2 reference display renders at
+    // approximately 203 cd/m^2.
+    CHECK(EOTF_BT2100_HLG(0.75f) == doctest::Approx(203.f).epsilon(0.002));
+    CHECK(to_linear(0.75f, TransferFunction::BT2100_HLG) == doctest::Approx(1.f).epsilon(0.002));
+}
+
+TEST_CASE("HLG system gamma follows display peak luminance")
+{
+    CHECK(HLG_system_gamma(1000.f) == doctest::Approx(1.2f));
+    CHECK(HLG_system_gamma(2000.f) == doctest::Approx(1.2f + 0.42f * std::log10(2.f)));
+    CHECK(HLG_system_gamma(500.f) == doctest::Approx(1.2f - 0.42f * std::log10(2.f)));
+}
+
+// Narrow (studio) range packs luma into 16..235, a span of 219. This 219 is unrelated to the HDR reference
+// white above; the two must not be conflated.
+TEST_CASE("narrow-range dequantization maps the studio range to [0,1]")
+{
+    CHECK(dequantize_narrow<uint8_t>(16) == doctest::Approx(0.f));
+    CHECK(dequantize_narrow<uint8_t>(235) == doctest::Approx(1.f));
+    CHECK(dequantize_narrow<uint16_t>(16 * 256) == doctest::Approx(0.f));
+    CHECK(dequantize_narrow<uint16_t>(235 * 256) == doctest::Approx(1.f));
+}
+
 TEST_CASE("quantize_full/dequantize_full round-trip within quantization error, undithered")
 {
     for (float x : {0.0f, 0.1f, 0.25f, 0.5f, 0.75f, 0.9f, 1.0f})


### PR DESCRIPTION
## Summary

- Normalizes PQ/HLG against the BT.2408 reference white of 203 cd/m², replacing a `219` constant that was actually the narrow/studio-range luma span (235−16), unrelated to HDR reference white. PQ and HLG content was rendering ~7.3% (0.11 stops) too dark. Adds a named `HDR_REFERENCE_WHITE_NITS` constant so the two 219s (studio-range quantization vs. this) can't be conflated again.
- Also derives HLG system gamma from display peak luminance (`L_W`) per BT.2100, rather than taking it as an independent parameter defaulting to 1.2 (the two only agreed at the default `L_W = 1000`). No caller overrode it.
- Sharpens the CICP transfer-characteristic-12 comment: it's BT.1361 extended gamut, which shares the ITU curve for `1.33 > L >= -0.0045` and departs from it only for more negative values, so mapping it to `TransferFunction::ITU` is exact except deep into negative linear.
- Fixes one PNG loader site (`png.cpp:720`) that still multiplied `int`s to size a pixel buffer, missed by a broader buffer-sizing sweep already on `master` (`a52079b`) that fixed the neighboring sites in the same function.
- Documents comment conventions in `CLAUDE.md`: describe current behavior/invariants rather than changelog-style "this used to..." comments.

## Why round-trip tests didn't catch the 219/203 bug

`from_linear`/`to_linear` scale by the constant symmetrically, so the existing round-trip test in `test_colorspace.cpp` passes for *any* choice of constant. The new tests instead pin absolute values (e.g. PQ signal `1.0` → `10000/203` cd/m², HLG reference-white signal `0.75` → `≈1.0`), spelling out `203`/`10000` literally rather than referencing the new constant, so they can't pass by tracking a wrong value. Verified these fail against a deliberately reintroduced `219` before finalizing.

## Test plan

- [x] `cmake --preset linux-local -DHDRVIEW_BUILD_TESTS=ON && cmake --build ... && ctest` — 25/27 pass. The 2 failures (PNG cICP round-trip cases) are pre-existing on `master` too (confirmed by rebuilding clean `master`), caused by Ubuntu's libpng lacking cICP chunk support in this environment.
- [x] `HDRView --help` smoke check passes.
- [x] Manual: open an HDR10 PQ HEIC/AVIF and compare brightness against Apple Preview / tev — the ~7% difference should disappear. (Not yet checked on a real display in this session.)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYAw2sJCgx2wX7Xug24w7X)_