### PR TITLE
Additive channel histogram fill

### DIFF
--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -154,7 +154,9 @@ void Image::draw_histogram()
             int         px1        = (int)std::ceil(plot_pos.x + plot_size.x);
             ImDrawList *draw_list  = ImPlot::GetPlotDrawList();
 
-            auto sample_height = [bin_type](const PixelStats *s, float x) -> float
+            // bin_type is a function-static local, so it has static (not automatic) storage duration and
+            // must not be captured -- it's directly accessible from the lambda body regardless.
+            auto sample_height = [](const PixelStats *s, float x) -> float
             {
                 const auto &xs = s->hist_xs;
                 const auto &ys = s->hist_ys;

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -36,7 +36,6 @@ static std::chrono::system_clock::time_point to_system_clock(std::filesystem::fi
 
 void Image::draw_histogram()
 {
-    static int        bin_type  = 1;
     static ImPlotCond plot_cond = ImPlotCond_Always;
     float combo_width = std::max(EmSize(5.f), 0.5f * (ImGui::GetContentRegionAvail().x - ImGui::IconButtonSize().x -
                                                       2.f * ImGui::GetStyle().ItemSpacing.x) -
@@ -154,21 +153,16 @@ void Image::draw_histogram()
             int         px1        = (int)std::ceil(plot_pos.x + plot_size.x);
             ImDrawList *draw_list  = ImPlot::GetPlotDrawList();
 
-            // bin_type is a function-static local, so it has static (not automatic) storage duration and
-            // must not be captured -- it's directly accessible from the lambda body regardless.
+            // The histogram is piecewise-constant (a count per bin), not piecewise-linear, so sample the
+            // step function directly: the height across bin i's range is simply hist_ys[i].
             auto sample_height = [](const PixelStats *s, float x) -> float
             {
-                const auto &xs = s->hist_xs;
                 const auto &ys = s->hist_ys;
-                if (x <= xs.front() || x >= xs.back())
+                float       x0 = (float)s->bin_to_value(0), x1 = (float)s->bin_to_value(PixelStats::NUM_BINS);
+                if (x < x0 || x >= x1)
                     return 0.f;
-                auto it = std::lower_bound(xs.begin(), xs.end(), x);
-                int  i1 = (int)(it - xs.begin());
-                int  i0 = std::max(0, i1 - 1);
-                if (bin_type == 0 || i0 == i1)
-                    return ys[i0]; // stairs: step function using the left bin's value
-                float t = (x - xs[i0]) / std::max(1e-20f, xs[i1] - xs[i0]);
-                return lerp(ys[i0], ys[i1], t);
+                int i = std::clamp((int)((x - x0) / (x1 - x0) * PixelStats::NUM_BINS), 0, PixelStats::NUM_BINS - 1);
+                return ys[i];
             };
 
             // Raw ImDrawList calls (unlike ImPlot's own PlotShaded/PlotLine/PlotStairs items) aren't
@@ -217,14 +211,15 @@ void Image::draw_histogram()
         }
         for (int c = 0; c < std::min(4, group.num_channels); ++c)
         {
+            // The histogram is piecewise-constant, so plot it as a step function using each bin's left
+            // edge (PlotStairs holds each x[i]'s y value constant across [x[i], x[i+1])), rather than
+            // linearly interpolating between bin centers.
+            std::array<float, PixelStats::NUM_BINS> left_edges;
+            for (int i = 0; i < PixelStats::NUM_BINS; ++i) left_edges[i] = (float)stats[c]->bin_to_value(i);
+
             ImPlot::PushStyleColor(ImPlotCol_Fill, float4{0.f});
             ImPlot::PushStyleColor(ImPlotCol_Line, float4{colors[c].xyz(), 1.0f});
-            if (bin_type != 0)
-                ImPlot::PlotLine(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
-                                 PixelStats::NUM_BINS);
-            else
-                ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
-                                   PixelStats::NUM_BINS);
+            ImPlot::PlotStairs(names[c].c_str(), left_edges.data(), stats[c]->hist_ys.data(), PixelStats::NUM_BINS);
             ImPlot::PopStyleColor(2);
         }
 

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -222,14 +222,12 @@ void Image::draw_histogram()
         }
         for (int c = 0; c < std::min(4, group.num_channels); ++c)
         {
-            // PlotStairs holds each x[i]'s y-value constant across [x[i], x[i+1)), so its x values must be
-            // bin left edges, not bin centers, to align the steps with the true bin boundaries.
-            std::array<float, PixelStats::NUM_BINS> left_edges;
-            for (int i = 0; i < PixelStats::NUM_BINS; ++i) left_edges[i] = (float)stats[c]->bin_to_value(i);
-
+            // PlotStairs holds each x[i]'s y-value constant across [x[i], x[i+1)), so hist_xs (each bin's
+            // left edge) rather than a bin center is what aligns the steps with the true bin boundaries.
             ImPlot::PushStyleColor(ImPlotCol_Fill, float4{0.f});
             ImPlot::PushStyleColor(ImPlotCol_Line, float4{colors[c].xyz(), 1.0f});
-            ImPlot::PlotStairs(names[c].c_str(), left_edges.data(), stats[c]->hist_ys.data(), PixelStats::NUM_BINS);
+            ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
+                               PixelStats::NUM_BINS);
             ImPlot::PopStyleColor(2);
         }
 

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -169,6 +169,11 @@ void Image::draw_histogram()
                 return lerp(ys[i0], ys[i1], t);
             };
 
+            // Raw ImDrawList calls (unlike ImPlot's own PlotShaded/PlotLine/PlotStairs items) aren't
+            // automatically clipped to the plot's data rectangle, so scope them explicitly -- same as the
+            // CIE-diagram code further below in this file does around its own manual AddPolyline calls.
+            ImPlot::PushPlotClipRect();
+
             std::array<int, 4>   order;
             std::array<float, 4> heights;
             for (int px = px0; px < px1; ++px)
@@ -205,6 +210,8 @@ void Image::draw_histogram()
                     prev_h = h;
                 }
             }
+
+            ImPlot::PopPlotClipRect();
         }
         for (int c = 0; c < std::min(4, group.num_channels); ++c)
         {

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -146,29 +146,40 @@ void Image::draw_histogram()
             // band. That way only one ordinary alpha-over (against the plot background) is ever needed,
             // which is exact rather than an approximation.
             const int   n_channels = std::min(4, group.num_channels);
-            const float fill_alpha = 0.5f;
+            const float fill_alpha = 0.75f;
             ImVec2      plot_pos   = ImPlot::GetPlotPos();
             ImVec2      plot_size  = ImPlot::GetPlotSize();
             int         px0        = (int)std::floor(plot_pos.x);
             int         px1        = (int)std::ceil(plot_pos.x + plot_size.x);
             ImDrawList *draw_list  = ImPlot::GetPlotDrawList();
 
-            // The histogram is piecewise-constant (a count per bin), not piecewise-linear, so sample the
-            // step function directly: the height across bin i's range is simply hist_ys[i].
+            // The histogram is piecewise-constant (one count per bin): the height across bin i's range is
+            // simply hist_ys[i]. Bins are uniform in the (nonlinear) asinh-transformed value space, not in
+            // raw pixel-value space, so finding the containing bin needs value_to_bin()'s asinh transform
+            // rather than a linear fraction of x's position in the range.
             auto sample_height = [](const PixelStats *s, float x) -> float
             {
-                const auto &ys = s->hist_ys;
-                float       x0 = (float)s->bin_to_value(0), x1 = (float)s->bin_to_value(PixelStats::NUM_BINS);
-                if (x < x0 || x >= x1)
+                int i = s->value_to_bin((double)x);
+                if (i < 0 || i >= PixelStats::NUM_BINS)
                     return 0.f;
-                int i = std::clamp((int)((x - x0) / (x1 - x0) * PixelStats::NUM_BINS), 0, PixelStats::NUM_BINS - 1);
-                return ys[i];
+                return s->hist_ys[i];
             };
 
-            // Raw ImDrawList calls (unlike ImPlot's own PlotShaded/PlotLine/PlotStairs items) aren't
+            // Raw ImDrawList calls (unlike ImPlot's own Plot* items, e.g. PlotStairs below) aren't
             // automatically clipped to the plot's data rectangle, so scope them explicitly -- same as the
             // CIE-diagram code further below in this file does around its own manual AddPolyline calls.
             ImPlot::PushPlotClipRect();
+
+            // This fill isn't a real ImPlot item, so it doesn't participate in ImPlot's legend-driven
+            // show/hide on its own. Mirror each channel's outline item (registered under the same label by
+            // PlotStairs below) so a channel hidden via the legend also drops out of the fill; an item that
+            // hasn't been registered yet (e.g. the very first frame) defaults to shown.
+            std::array<bool, 4> shown{true, true, true, true};
+            for (int c = 0; c < n_channels; ++c)
+            {
+                auto *item = ImPlot::GetItem(names[c].c_str());
+                shown[c]   = !item || item->Show;
+            }
 
             std::array<int, 4>   order;
             std::array<float, 4> heights;
@@ -178,7 +189,7 @@ void Image::draw_histogram()
 
                 for (int c = 0; c < n_channels; ++c)
                 {
-                    heights[c] = std::max(0.f, sample_height(stats[c], (float)x));
+                    heights[c] = shown[c] ? std::max(0.f, sample_height(stats[c], (float)x)) : 0.f;
                     order[c]   = c;
                 }
                 std::sort(order.begin(), order.begin() + n_channels,
@@ -211,9 +222,8 @@ void Image::draw_histogram()
         }
         for (int c = 0; c < std::min(4, group.num_channels); ++c)
         {
-            // The histogram is piecewise-constant, so plot it as a step function using each bin's left
-            // edge (PlotStairs holds each x[i]'s y value constant across [x[i], x[i+1])), rather than
-            // linearly interpolating between bin centers.
+            // PlotStairs holds each x[i]'s y-value constant across [x[i], x[i+1)), so its x values must be
+            // bin left edges, not bin centers, to align the steps with the true bin boundaries.
             std::array<float, PixelStats::NUM_BINS> left_edges;
             for (int i = 0; i < PixelStats::NUM_BINS; ++i) left_edges[i] = (float)stats[c]->bin_to_value(i);
 

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -138,17 +138,73 @@ void Image::draw_histogram()
         // now do the actual plotting
         //
 
-        for (int c = 0; c < std::min(4, group.num_channels); ++c)
         {
-            ImPlot::PushStyleColor(ImPlotCol_Fill, colors[c]);
-            ImPlot::PushStyleColor(ImPlotCol_Line, float4{0.f});
-            if (bin_type != 0)
-                ImPlot::PlotShaded(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
-                                   PixelStats::NUM_BINS);
-            else
-                ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
-                                   PixelStats::NUM_BINS, ImPlotStairsFlags_Shaded);
-            ImPlot::PopStyleColor(2);
+            // ImPlot/Dear ImGui only ever composites with straight-alpha "over", so overlapping translucent
+            // fills can't reproduce true additive blending (e.g. red+green overlap should read as yellow,
+            // and red+green+blue as white). Instead, rasterize the fill ourselves one screen pixel column at
+            // a time: sample every channel's histogram height at that column, sum the colors of whichever
+            // channels reach into each height band, and hand ImGui a single already-blended rectangle per
+            // band. That way only one ordinary alpha-over (against the plot background) is ever needed,
+            // which is exact rather than an approximation.
+            const int   n_channels = std::min(4, group.num_channels);
+            const float fill_alpha = 0.5f;
+            ImVec2      plot_pos   = ImPlot::GetPlotPos();
+            ImVec2      plot_size  = ImPlot::GetPlotSize();
+            int         px0        = (int)std::floor(plot_pos.x);
+            int         px1        = (int)std::ceil(plot_pos.x + plot_size.x);
+            ImDrawList *draw_list  = ImPlot::GetPlotDrawList();
+
+            auto sample_height = [bin_type](const PixelStats *s, float x) -> float
+            {
+                const auto &xs = s->hist_xs;
+                const auto &ys = s->hist_ys;
+                if (x <= xs.front() || x >= xs.back())
+                    return 0.f;
+                auto it = std::lower_bound(xs.begin(), xs.end(), x);
+                int  i1 = (int)(it - xs.begin());
+                int  i0 = std::max(0, i1 - 1);
+                if (bin_type == 0 || i0 == i1)
+                    return ys[i0]; // stairs: step function using the left bin's value
+                float t = (x - xs[i0]) / std::max(1e-20f, xs[i1] - xs[i0]);
+                return lerp(ys[i0], ys[i1], t);
+            };
+
+            std::array<int, 4>   order;
+            std::array<float, 4> heights;
+            for (int px = px0; px < px1; ++px)
+            {
+                double x = ImPlot::PixelsToPlot(ImVec2((float)px + 0.5f, plot_pos.y)).x;
+
+                for (int c = 0; c < n_channels; ++c)
+                {
+                    heights[c] = std::max(0.f, sample_height(stats[c], (float)x));
+                    order[c]   = c;
+                }
+                std::sort(order.begin(), order.begin() + n_channels,
+                          [&](int a, int b) { return heights[a] < heights[b]; });
+
+                // Sweep bands from the baseline upward; the channels active in a band are exactly those
+                // whose height reaches into it, so their colors sum additively.
+                float prev_h = 0.f;
+                for (int k = 0; k < n_channels; ++k)
+                {
+                    float h = heights[order[k]];
+                    if (h <= prev_h)
+                        continue;
+
+                    float3 col{0.f};
+                    for (int j = k; j < n_channels; ++j) col += colors[order[j]].xyz();
+                    col = clamp(col, 0.f, 1.f);
+
+                    ImVec2 py0 = ImPlot::PlotToPixels(x, prev_h);
+                    ImVec2 py1 = ImPlot::PlotToPixels(x, h);
+                    draw_list->AddRectFilled(ImVec2((float)px, std::min(py0.y, py1.y)),
+                                             ImVec2((float)px + 1.f, std::max(py0.y, py1.y)),
+                                             ImGui::GetColorU32(float4{col, fill_alpha}));
+
+                    prev_h = h;
+                }
+            }
         }
         for (int c = 0; c < std::min(4, group.num_channels); ++c)
         {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -449,6 +449,8 @@ void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Chann
         hist_normalization[0]        = (float)axis_scale_fwd_xform(summary.minimum, (void *)&x_scale);
         hist_normalization[1] = (float)axis_scale_fwd_xform(summary.maximum, (void *)&x_scale) - hist_normalization[0];
 
+        for (int i = 0; i < NUM_BINS; ++i) hist_xs[i] = (float)bin_to_value(i);
+
         // accumulate bin counts
         for (int i = 0; i < croi.volume(); ++i)
         {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -449,9 +449,6 @@ void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Chann
         hist_normalization[0]        = (float)axis_scale_fwd_xform(summary.minimum, (void *)&x_scale);
         hist_normalization[1] = (float)axis_scale_fwd_xform(summary.maximum, (void *)&x_scale) - hist_normalization[0];
 
-        // compute bin center values
-        for (int i = 0; i < NUM_BINS; ++i) hist_xs[i] = (float)bin_to_value(i + 0.5);
-
         // accumulate bin counts
         for (int i = 0; i < croi.volume(); ++i)
         {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -519,12 +519,11 @@ float4x4 ChannelGroup::colors() const
     case RGBA_Channels:
     case RGB_Channels:
     case UVorXY_Channels:
-        // We'd ideally like to do additive blending, but dear imgui seemingly doesn't support it.
-        // Setting the alpha values to 1/(c+1) would ensure that where all three R,G,B histograms overlap we get a
-        // neutral gray, but then red is fully opaque, while blue is 2/3 transparent. We instead manually choose values
-        // where all three are 0.5 transparent while producing neutral gray when composited using the over operator.
-        return float4x4{
-            {1.f, 0.15f, 0.1f, 0.5f}, {.45f, 0.75f, 0.02f, 0.5f}, {.25f, 0.333f, 0.7f, 0.5f}, {1.f, 1.f, 1.f, 0.5f}};
+        // The histogram fill is composited additively in software (see Image::draw_histogram), so these are
+        // true emission colors: R+G+B sums to exactly white where all three channels overlap, R+G sums to
+        // yellow, etc. The alpha channel is unused by the fill (a single overall wash alpha is applied
+        // instead); it stays around only for the outline/hover-marker code paths that reuse this table.
+        return float4x4{{1.f, 0.f, 0.f, 0.5f}, {0.f, 1.f, 0.f, 0.5f}, {0.f, 0.f, 1.f, 0.5f}, {1.f, 1.f, 1.f, 0.5f}};
     case YCA_Channels:
     case YC_Channels:
         return float4x4{{1.f, 0.35133642f, 0.5f, 0.5f},

--- a/src/image.h
+++ b/src/image.h
@@ -109,7 +109,6 @@ struct PixelStats
     float2 hist_y_limits      = {0.f, 1.f};
     float2 hist_normalization = {0.f, 1.f};
 
-    std::array<float, NUM_BINS> hist_xs{}; // {}: value-initialized to zeros
     std::array<float, NUM_BINS> hist_ys{}; // {}: value-initialized to zeros
 
     PixelStats() = default;
@@ -119,7 +118,6 @@ struct PixelStats
                    const Settings &desired, std::atomic<bool> &canceled);
 
     int    clamp_idx(int i) const { return std::clamp(i, 0, NUM_BINS - 1); }
-    float &bin_x(int i) { return hist_xs[clamp_idx(i)]; }
     float &bin_y(int i) { return hist_ys[clamp_idx(i)]; }
 
     int value_to_bin(double value) const
@@ -129,7 +127,7 @@ struct PixelStats
                               hist_normalization[1] * NUM_BINS));
     }
 
-    double bin_to_value(double value)
+    double bin_to_value(double value) const
     {
         static constexpr int   x_scale  = AxisScale_Asinh;
         static constexpr float inv_bins = 1.f / NUM_BINS;

--- a/src/image.h
+++ b/src/image.h
@@ -109,6 +109,7 @@ struct PixelStats
     float2 hist_y_limits      = {0.f, 1.f};
     float2 hist_normalization = {0.f, 1.f};
 
+    std::array<float, NUM_BINS> hist_xs{}; // left edge of each bin's range; {}: value-initialized to zeros
     std::array<float, NUM_BINS> hist_ys{}; // {}: value-initialized to zeros
 
     PixelStats() = default;


### PR DESCRIPTION
## Summary
- Replace the per-channel alpha-over histogram fill with a manually-rasterized additive blend, so overlapping R/G/B histograms read as true composite colors (e.g. R+G+B = white) instead of muddy alpha-over overlap.
- Render the histogram as a proper piecewise-constant step function (matching how pixels are actually binned) rather than linearly interpolating between bin centers, for both the outline and the fill.
- Make the additive fill respect per-channel legend visibility toggles (clicking a legend entry hides both the outline and its contribution to the fill).

## Test plan
- [x] `cmake --build --preset macos-arm64-cpm-release` builds cleanly
- [x] `HDRView --help` smoke check
- [x] Manually verify in the GUI: open a multi-channel image, confirm the histogram fill and outline line up, overlapping channel colors composite additively, and toggling legend entries hides both the curve and the fill for that channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)