### PR TITLE
Fix Colorspace panel CIE diagram layout and auto-sizing

### DIFF
--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1138,9 +1138,13 @@ void Image::draw_colorspace()
 {
     auto bold_font = hdrview()->font("sans bold");
 
-    static const ImGuiTableFlags table_flags =
-        ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_ScrollY;
+    static const ImGuiTableFlags table_flags = ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize;
     ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32_BLACK_TRANS);
+    // Scroll this child rather than the table: a table's own ScrollY has no way to reserve scrollbar space
+    // unconditionally, so toggling it in and out changes the available width, which changes the height of the
+    // width-locked chromaticity diagram below, which can toggle the scrollbar again every frame.
+    ImGui::BeginChild("##ColorspaceScroll", ImVec2(0, 0), ImGuiChildFlags_None,
+                      ImGuiWindowFlags_AlwaysVerticalScrollbar);
     if (ImGui::PE::Begin("Colorspace", table_flags))
     {
         // The diagram gets its own full-width row when the value column alone is too narrow to render it legibly.
@@ -1358,6 +1362,7 @@ void Image::draw_colorspace()
         ImGui::Unindent(ImGui::GetStyle().CellPadding.x);
         ImGui::PE::End();
     }
+    ImGui::EndChild();
     ImGui::PopStyleColor();
 }
 

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -820,17 +820,14 @@ void Image::draw_info()
     }
 }
 
-void Image::draw_chromaticity_diagram()
+void Image::draw_chromaticity_diagram(float width)
 {
     static float2 vMin{-0.05f, -0.05f};
     static float2 vMax{0.75f, 0.9f};
     static float2 vSize  = vMax - vMin;
     static float  aspect = vSize.x / vSize.y;
 
-    // property_name("Diagram");
-    // ImGui::SameLine(label_size);
-    // ImGui::Indent();
-    float const size = ImMax(ImGui::GetContentRegionAvail().x, EmSize(8.f));
+    float const size = ImMax(width, EmSize(8.f));
 
     ImGui::PushFont(hdrview()->font("sans regular"), ImGui::GetStyle().FontSizeBase);
 
@@ -989,6 +986,9 @@ void Image::draw_chromaticity_diagram()
                             ImGui::GetStyle().FontSizeBase * label_font_scale * scale / 2.f);
 
             constexpr int temp_step = 1000;
+            // Tracks the last tick actually drawn, so labels that would overlap it are skipped. Starts far
+            // off-plot so the first tick always draws.
+            float2 prev_tick_end = {-100000.f, -100000.f};
             for (int temp = 2000; temp <= 25000; temp += temp_step)
             {
                 float2 xy = Kelvin_to_xy((float)temp);
@@ -1004,8 +1004,7 @@ void Image::draw_chromaticity_diagram()
                 float2 tick[2] = {xy, xy + normal};
 
                 // Only draw this tick if it doesn't overlap with the previous tick
-                static float2 prev_tick_end = {-100000.f, -100000.f}; // large negative to ensure first tick is drawn
-                const float   min_dist      = 5.0f;                   // minimum pixel distance between ticks
+                const float min_dist = 5.0f; // minimum pixel distance between ticks
 
                 float2 tick_end_px      = ImPlot::PlotToPixels(ImPlotPoint(tick[1].x, tick[1].y));
                 float2 prev_tick_end_px = ImPlot::PlotToPixels(ImPlotPoint(prev_tick_end.x, prev_tick_end.y));
@@ -1067,7 +1066,7 @@ void Image::draw_chromaticity_diagram()
             // ImPlotScatterFlags_None,
             //                     0, sizeof(double2));
 
-            ImGui::PushFont(hdrview()->font("sans bold"), ImGui::GetStyle().FontSizeBase * scale_factor / 2.f);
+            ImGui::PushFont(hdrview()->font("sans bold"), ImGui::GetStyle().FontSizeBase);
             for (int i = 0; i < 4; ++i)
             {
                 if (ImPlot::DragPoint(i, &primaries[i].x, &primaries[i].y, colors[i], 1.5f * scale_factor,
@@ -1139,13 +1138,13 @@ void Image::draw_colorspace()
 {
     auto bold_font = hdrview()->font("sans bold");
 
-    float                        col2_w          = 0.f;
-    float                        col2_big_enough = HelloImGui::EmSize(12.f);
     static const ImGuiTableFlags table_flags =
         ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_ScrollY;
     ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32_BLACK_TRANS);
     if (ImGui::PE::Begin("Colorspace", table_flags))
     {
+        // The diagram gets its own full-width row when the value column alone is too narrow to render it legibly.
+        const bool diagram_fits_in_value_column = ImGui::PE::ColumnWidth(1) > HelloImGui::EmSize(12.f);
         ImGui::Indent(ImGui::GetStyle().CellPadding.x);
 
         ImGui::PE::WrappedText(
@@ -1161,7 +1160,6 @@ void Image::draw_colorspace()
         ImGui::PE::Entry("Color gamut",
                          [&]
                          {
-                             col2_w        = ImGui::GetContentRegionAvail().x;
                              bool modified = false;
                              auto csn      = color_gamut_names();
                              auto open_combo =
@@ -1342,21 +1340,25 @@ void Image::draw_colorspace()
                 return modified;
             });
 
-        if (col2_w > col2_big_enough)
+        if (diagram_fits_in_value_column)
             ImGui::PE::Entry("Diagram",
                              [this]()
                              {
-                                 draw_chromaticity_diagram();
+                                 draw_chromaticity_diagram(ImGui::GetContentRegionAvail().x);
                                  return false;
                              });
+        else
+            ImGui::PE::FullWidthEntry("Diagram",
+                                      [this](float width)
+                                      {
+                                          draw_chromaticity_diagram(width);
+                                          return false;
+                                      });
 
         ImGui::Unindent(ImGui::GetStyle().CellPadding.x);
         ImGui::PE::End();
     }
     ImGui::PopStyleColor();
-
-    if (col2_w <= col2_big_enough)
-        draw_chromaticity_diagram();
 }
 
 void Image::draw_channel_stats()

--- a/src/image.h
+++ b/src/image.h
@@ -389,7 +389,7 @@ public:
     */
     int  draw_channel_rows(int img_idx, int &id, bool is_current, bool is_reference, float &scroll_to);
     void draw_info();
-    void draw_chromaticity_diagram();
+    void draw_chromaticity_diagram(float width);
     void draw_colorspace();
     void draw_channel_stats();
 

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -735,8 +735,17 @@ bool PE::FullWidthEntry(const char *id, const std::function<bool(float)> &conten
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
 
+    // WidthGiven excludes each column's cell padding and inter-column spacing, so summing per-column widths
+    // falls short of the row's real span; read the bounds directly off the table instead. Also reset the cursor
+    // to column 0's true left edge, undoing any ambient Indent() a caller applied for ordinary column-0 rows
+    // (column 0 has ImGuiTableColumnFlags_IndentEnable on by default).
+    const ImGuiTable *table   = ImGui::GetCurrentTable();
+    const float       left_x  = table ? table->Columns[0].WorkMinX : ImGui::GetCursorScreenPos().x;
+    const float       right_x = table && table->ColumnsCount > 1 ? table->Columns[1].WorkMaxX : left_x;
+    ImGui::SetCursorScreenPos(ImVec2(left_x, ImGui::GetCursorScreenPos().y));
+
     // Tables clip each cell to its own column, so widen the clip rect to cover both before drawing across them.
-    const float  width = ColumnWidth(0) + ColumnWidth(1);
+    const float  width = right_x - left_x;
     const ImVec2 p0    = ImGui::GetCursorScreenPos();
     ImGui::PushClipRect(p0, ImVec2(p0.x + width, ImGui::GetCurrentWindow()->ClipRect.Max.y), false);
     bool result = content_fct(width);

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -734,6 +734,11 @@ bool PE::FullWidthEntry(const char *id, const std::function<bool(float)> &conten
     ImGui::PushID(id);
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
+    // Advance into column 1 before drawing. The content below visually spans both columns (via the cursor/clip
+    // rect override), but ImGui's per-column auto-fit width tracking has no notion of "spans columns" — it
+    // attributes whatever the cursor reaches to whichever column is current. Landing on column 1 keeps that
+    // tracking out of column 0, which is the column double-clicking the (only) resize border auto-fits.
+    ImGui::TableNextColumn();
 
     // WidthGiven excludes each column's cell padding and inter-column spacing, so summing per-column widths
     // falls short of the row's real span; read the bounds directly off the table instead. Also reset the cursor

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -723,6 +723,29 @@ void TextAligned2(float align_x, float size_x, const char *fmt, ...)
     va_end(args);
 }
 
+float PE::ColumnWidth(int column_n)
+{
+    const ImGuiTable *table = ImGui::GetCurrentTable();
+    return table && column_n < table->ColumnsCount ? table->Columns[column_n].WidthGiven : 0.f;
+}
+
+bool PE::FullWidthEntry(const char *id, const std::function<bool(float)> &content_fct)
+{
+    ImGui::PushID(id);
+    ImGui::TableNextRow();
+    ImGui::TableNextColumn();
+
+    // Tables clip each cell to its own column, so widen the clip rect to cover both before drawing across them.
+    const float  width = ColumnWidth(0) + ColumnWidth(1);
+    const ImVec2 p0    = ImGui::GetCursorScreenPos();
+    ImGui::PushClipRect(p0, ImVec2(p0.x + width, ImGui::GetCurrentWindow()->ClipRect.Max.y), false);
+    bool result = content_fct(width);
+    ImGui::PopClipRect();
+
+    ImGui::PopID();
+    return result;
+}
+
 // Generic entry, the lambda function should return true if the widget changed
 bool PE::Entry(const std::string &property_name, const std::function<bool()> &content_fct, const std::string &tooltip)
 {

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -223,6 +223,11 @@ bool Begin(const char     *label = "PE::Table",
            ImGuiTableFlags flag  = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_Resizable);
 void End();
 bool Entry(const std::string &property_name, const std::function<bool()> &content_fct, const std::string &tooltip = {});
+//! An unlabeled row whose content spans both columns. content_fct receives the available width, since a cell's
+//! content region only reports its own column.
+bool FullWidthEntry(const char *id, const std::function<bool(float)> &content_fct);
+//! Width in pixels of a column of the innermost table, or 0 outside one. Valid between Begin and End.
+float       ColumnWidth(int column_n);
 inline void Entry(const std::string &property_name, const std::string &value)
 {
     Entry(property_name,


### PR DESCRIPTION
## Summary
- Give the chromaticity diagram its own full-width row in the Colorspace panel when the panel is too narrow for the label + diagram to share the value column, via a new `PE::FullWidthEntry` helper.
- Fix double-click column auto-sizing in that table: the full-width row's content was being attributed to column 0's auto-fit width tracking (since it stayed the table's "current column" while visually spanning both columns), causing the label column to balloon when double-clicking the resize separator. Advancing into column 1 before drawing keeps that content out of column 0's tracking.
- Fix a scrollbar flicker in the Colorspace panel caused by the table's own ScrollY toggling the available width every frame.
- Harden image buffer size calculations.

## Test plan
- [x] Built `macos-arm64-cpm-release` preset, `HDRView --help` smoke check passes.
- [x] Manually verified in the running app: double-clicking the column separator on the Colorspace panel's chromaticity diagram row now auto-sizes correctly both when the panel is wide (label shown) and narrow (label omitted, full-width row).