### PR TITLE
Add native Windows ARM64 build

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,6 +33,16 @@ jobs:
           # on both Windows presets would be redundant.
           - { name: "Windows MSVC", os: windows-latest, preset: "windows-msvc", run_tests: true }
           - { name: "Windows Ninja", os: windows-latest, preset: "windows-ninja" }
+          # Native ARM64 build on GitHub's hosted windows-11-arm runner (see issue #166). HEIC/AVCI are
+          # disabled to match the x64 release build (build_windows in release.yml) until libheif's
+          # AOM/dav1d dependencies are confirmed to build cleanly for Windows ARM64.
+          - {
+              name: "Windows ARM64 MSVC",
+              os: windows-11-arm,
+              preset: "windows-arm64-msvc",
+              msvc_arch: "arm64",
+              flags: "-DHDRVIEW_ENABLE_HEIC=OFF -DHDRVIEW_ENABLE_AVCI=OFF",
+            }
 
     steps:
       - name: Install dependencies
@@ -43,12 +53,17 @@ jobs:
           fetch-depth: 0
 
       - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.msvc_arch || 'x64' }}
 
       - name: Configure CMake
         run: |
           $extraFlags = @()
           if ("${{ matrix.config.run_tests }}" -eq "true" -and "${{ matrix.buildtype }}" -eq "Release") {
             $extraFlags += "-DHDRVIEW_BUILD_TESTS=ON"
+          }
+          if ("${{ matrix.config.flags }}") {
+            $extraFlags += "${{ matrix.config.flags }}" -split " "
           }
           cmake --preset ${{ matrix.config.preset }} @extraFlags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,8 @@ jobs:
       matrix:
         buildtype: [Release]
         config:
-          - { name: "Windows MSVC", os: windows-latest, preset: "windows-msvc" }
+          - { name: "Windows MSVC", os: windows-latest, preset: "windows-msvc", arch: "x86_64" }
+          - { name: "Windows ARM64 MSVC", os: windows-11-arm, preset: "windows-arm64-msvc", arch: "arm64", msvc_arch: "arm64" }
 
     steps:
       - name: Install dependencies
@@ -208,6 +209,8 @@ jobs:
           fetch-depth: 0
 
       - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.msvc_arch || 'x64' }}
 
       - name: Set version variables
         run: |
@@ -249,14 +252,14 @@ jobs:
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: "zip"
-          filename: "HDRView-${{ env.VERSION_NO_V }}-windows.zip"
+          filename: "HDRView-${{ env.VERSION_NO_V }}-windows-${{ matrix.config.arch }}.zip"
           directory: ${{github.workspace}}/build/${{ matrix.config.preset }}/deploy
 
       - name: Release
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            ${{github.workspace}}/build/${{ matrix.config.preset }}/deploy/HDRView-${{ env.VERSION_NO_V }}-windows.zip
+            ${{github.workspace}}/build/${{ matrix.config.preset }}/deploy/HDRView-${{ env.VERSION_NO_V }}-windows-${{ matrix.config.arch }}.zip
           prerelease: ${{ contains(github.ref_name, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,6 @@
       "hidden": true,
       "inherits": "base",
       "description": "Base for Visual Studio builds",
-      "architecture": "x64",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -179,6 +178,19 @@
       "displayName": "Windows (MSVC)",
       "description": "Windows build with Visual Studio",
       "inherits": "msvc-base",
+      "architecture": "x64",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-arm64-msvc",
+      "displayName": "Windows ARM64 (MSVC)",
+      "description": "Native Windows ARM64 build with Visual Studio",
+      "inherits": "msvc-base",
+      "architecture": "arm64",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -420,6 +432,30 @@
       "displayName": "RelWithDebInfo (MSVC)",
       "inherits": "build-base-relwithdebinfo",
       "configurePreset": "windows-msvc"
+    },
+    {
+      "name": "windows-arm64-msvc-debug",
+      "displayName": "Debug (ARM64 MSVC)",
+      "inherits": "build-base-debug",
+      "configurePreset": "windows-arm64-msvc"
+    },
+    {
+      "name": "windows-arm64-msvc-release",
+      "displayName": "Release (ARM64 MSVC)",
+      "inherits": "build-base-release",
+      "configurePreset": "windows-arm64-msvc"
+    },
+    {
+      "name": "windows-arm64-msvc-minsizerel",
+      "displayName": "MinSizeRel (ARM64 MSVC)",
+      "inherits": "build-base-minsizerel",
+      "configurePreset": "windows-arm64-msvc"
+    },
+    {
+      "name": "windows-arm64-msvc-relwithdebinfo",
+      "displayName": "RelWithDebInfo (ARM64 MSVC)",
+      "inherits": "build-base-relwithdebinfo",
+      "configurePreset": "windows-arm64-msvc"
     },
     {
       "name": "windows-ninja-debug",


### PR DESCRIPTION
## Summary
- Adds a `windows-arm64-msvc` CMake preset (native ARM64 MSVC toolchain), alongside the existing x64 `windows-msvc`/`windows-ninja` presets
- Wires it into `ci-windows.yml` on GitHub's hosted `windows-11-arm` runner as a build+smoke-test validation job
- Extends `release.yml`'s `build_windows` matrix with the ARM64 config, following the same per-arch pattern already used by `build_macos`/`build_linux`; Windows zip filenames now carry an explicit arch suffix (`-windows-x86_64.zip` / `-windows-arm64.zip`)
- HEIC/AVCI stay disabled on both Windows configs, matching prior behavior

Validated end-to-end via a throwaway prerelease tag: all 7 release jobs (macOS x2, Linux x2, Windows x2, Emscripten) built successfully, including the new Windows ARM64 job producing a working `HDRView.exe` + assets zip. That build has already been backfilled onto the `v2.8.3` release as `HDRView-2.8.3-windows-arm64.zip`.

Closes #166

## Test plan
- [x] `cmake --list-presets` parses cleanly with the new presets (validated locally)
- [x] `ci-windows.yml`'s new `windows-11-arm` job builds and passes the `HDRView.exe --help` smoke check
- [x] `release.yml`'s full pipeline validated via throwaway prerelease tag (since deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)