### PR TITLE
Fix image-list crash, truncation perf, and scroll-to-selection stall

### DIFF
--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -237,7 +237,7 @@ void HDRViewApp::draw_image() const
 
         if (img)
         {
-            int                 group_idx = target == Target_Primary ? img->selected_group : img->reference_group;
+            int                 group_idx = img->active_group_index(target);
             const ChannelGroup &group     = img->groups[group_idx];
 
             // FIXME: tried to pass this as a 3x3 matrix, but the data was somehow not being passed properly to MSL.

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -69,7 +69,7 @@ void HDRViewApp::pixel_color_widget(const int2 &pixel, int &color_mode, int whic
         // false below, same mechanism as an out-of-bounds pixel.
         if (reference_image())
         {
-            auto &group = reference_image()->groups[reference_image()->reference_group];
+            auto &group = reference_image()->groups[reference_image()->active_group_index(Target_Secondary)];
             components  = group.num_channels;
             show_swatch = group.type == ChannelGroup::RGBA_Channels || group.type == ChannelGroup::RGB_Channels;
             inside      = reference_image()->contains(pixel);

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -676,6 +676,11 @@ void HDRViewApp::draw_file_window()
         int hidden_groups  = 0;
         int image_to_close = -1;
 
+        // The image rows' font depends only on the list mode, so it's pushed once around the whole list
+        // rather than per row. Pushed before the clipper is set up so that the row height it measures is
+        // the height rows are actually drawn at.
+        ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
+
         // currently we only support the clipper when each image is one row
         bool             use_clipper = m_file_list_mode == 0;
         ImGuiListClipper clipper;
@@ -712,8 +717,6 @@ void HDRViewApp::draw_file_window()
                 bool  is_reference = m_reference == i;
 
                 ImGuiTreeNodeFlags node_flags = base_node_flags;
-
-                ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
 
                 if (is_current || is_reference)
                     node_flags |= ImGuiTreeNodeFlags_Selected;
@@ -876,13 +879,11 @@ void HDRViewApp::draw_file_window()
 
                     ImGui::PopFont();
 
-                    if (open)
-                        ImGui::TreePop();
+                    ImGui::TreePop();
                 }
-
-                ImGui::PopFont();
             }
         }
+        ImGui::PopFont();
 
         int hidden_images = num_images() - num_visible_images();
         if (hidden_images || hidden_groups)

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -713,8 +713,8 @@ void HDRViewApp::draw_file_window()
                     ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
                 }
 
-                auto &selected_group =
-                    img->groups[(is_reference && !is_current) ? img->reference_group : img->selected_group];
+                auto  &selected_group = img->groups[img->active_group_index(
+                    is_reference && !is_current ? Target_Secondary : Target_Primary)];
                 string group_name =
                     selected_group.num_channels == 1 ? selected_group.name : "(" + selected_group.name + ")";
                 auto  &channel    = img->channels[selected_group.channels[0]];

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -698,20 +698,10 @@ void HDRViewApp::draw_file_window()
 
                 ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
 
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-                ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
-                ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", vi + 1).c_str());
-
-                ImGui::TableNextColumn();
-
                 if (is_current || is_reference)
                     node_flags |= ImGuiTreeNodeFlags_Selected;
                 if (m_file_list_mode == 0)
-                {
                     node_flags |= ImGuiTreeNodeFlags_Leaf;
-                    ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
-                }
 
                 auto  &selected_group = img->groups[img->active_group_index(
                     is_reference && !is_current ? Target_Secondary : Target_Primary)];
@@ -722,12 +712,19 @@ void HDRViewApp::draw_file_window()
                 string filename   = (m_short_names ? img->short_name : img->file_and_partname()) +
                                   (m_file_list_mode ? "" : img->delimiter() + layer_path + group_name);
 
-                bool open = ImGui::TreeNodeEx((void *)(intptr_t)i, node_flags, "%s", "");
+                // Drawn with an empty label -- SpanAllColumns still makes this the row's click target -- so
+                // the icon and front-truncated filename below can be laid out and drawn by hand afterward.
+                bool open = ImGui::TreeRow((void *)(intptr_t)i, node_flags, "", [&]
+                                           { ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", vi + 1).c_str()); },
+                                           [&]
+                                           {
+                                               if (m_file_list_mode == 0)
+                                                   ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
+                                               ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
+                                           });
                 auto icon = img->groups.size() > 1 ? ICON_MY_IMAGES : ICON_MY_IMAGE;
                 ImGui::SameLine(0.f, 0.f);
                 string the_text = ImGui::TruncatedText(filename, icon);
-
-                ImGui::PopStyleColor(3);
 
                 // Add right-click context menu
                 ImGui::PushFont(m_sans_regular, 0.f);

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -672,92 +672,32 @@ void HDRViewApp::draw_file_window()
         ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, icon_width);
         ImGui::PushStyleVarY(ImGuiStyleVar_CellPadding, 0.f);
 
-        // Flatten the whole visible row list -- every visible image, plus (in flat/tree mode) each
-        // visible image's currently-expanded channel rows -- before drawing anything, so a single
-        // ImGuiListClipper can span all three list modes uniformly instead of only "images only" mode
-        // getting clipped (the rest drew every row every frame regardless of scroll position). Pure
-        // bookkeeping over already-known visibility/tree-open state; no ImGui item calls happen here, so
-        // it's cheap even though it runs every frame.
-        ImGuiID              list_id = ImGui::GetID("ImageList");
-        vector<ImageListRow> flat_rows;
-        flat_rows.reserve(m_visible_images.size());
-        int hidden_groups = 0;
-        for (size_t vi = 0; vi < m_visible_images.size(); ++vi)
-        {
-            int   i   = (int)m_visible_images[vi];
-            auto &img = m_images[i];
-
-            // Independent of file_list_mode or the image row's own open/closed state below: how many of
-            // this image's groups the active filter is hiding, full stop.
-            hidden_groups += (int)img->groups.size() - img->root.visible_groups;
-
-            ImageListRow row;
-            row.kind           = ImageListRow::Kind_Image;
-            row.img_idx        = i;
-            row.shortcut_index = (int)vi; // 0-based position among visible images, for the row-number column
-            row.id             = ImGui::GetIDWithSeed(i, list_id);
-            flat_rows.push_back(row);
-
-            if (m_file_list_mode == 0)
-                continue; // leaf: no channel rows are ever shown
-
-            // Peeked, not drawn -- see flatten_layer_node()'s matching comment in image-gui.cpp.
-            if (!ImGui::GetStateStorage()->GetBool(row.id, true))
-                continue;
-
-            if (m_file_list_mode == 1)
-                img->flatten_channel_rows(i, row.id, flat_rows);
-            else
-                img->flatten_channel_tree(i, row.id, flat_rows);
-        }
-
-        // Locate the pending scroll-to-selection target's flat index, if any, so it can be forced into
-        // the clipper's visible range below even when it's currently scrolled out of view -- fixing the
-        // pre-existing bug where a target outside the clipper's natural [DisplayStart, DisplayEnd) window
-        // (e.g. right after a next/prev-image or next/prev-channel-group shortcut while scrolled away
-        // from it) never got its SetScrollHereY() call, since that call only ran inside the per-row loop
-        // body below, which the clipper -- by design -- only enters for rows it decided to draw.
-        int scroll_target = -1;
-        if (m_scroll_to_next_frame >= -0.5f && is_valid(m_current))
-        {
-            int wanted_group = m_file_list_mode == 0 ? -1 : m_images[m_current]->selected_group;
-            for (int r = 0; r < (int)flat_rows.size() && scroll_target < 0; ++r)
-            {
-                const ImageListRow &fr = flat_rows[r];
-                if (m_file_list_mode == 0 ? (fr.kind == ImageListRow::Kind_Image && fr.img_idx == m_current)
-                                          : (fr.kind == ImageListRow::Kind_Group && fr.img_idx == m_current &&
-                                             fr.group_idx == wanted_group))
-                    scroll_target = r;
-            }
-        }
-
+        int id             = 0;
+        int hidden_groups  = 0;
         int image_to_close = -1;
 
-        ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
-
+        // currently we only support the clipper when each image is one row
+        bool             use_clipper = m_file_list_mode == 0;
         ImGuiListClipper clipper;
-        clipper.Begin((int)flat_rows.size());
-        if (scroll_target >= 0)
-            clipper.IncludeItemsByIndex(scroll_target, scroll_target + 1);
-        while (clipper.Step())
+        if (use_clipper)
+            clipper.Begin((int)m_visible_images.size());
+        // the loop conditions here are to execute this outer loop once if we are not using the clipper, and execute it
+        // as long as clipper.Step() returns true otherwise
+        for (int iter = 0; (!use_clipper && iter < 1) || (use_clipper && clipper.Step()); ++iter)
         {
-            for (int r = clipper.DisplayStart; r < clipper.DisplayEnd; ++r)
+            int start = use_clipper ? clipper.DisplayStart : 0;
+            int end   = use_clipper ? clipper.DisplayEnd : (int)m_visible_images.size();
+            for (int vi = start; vi < end; ++vi)
             {
-                const ImageListRow &row          = flat_rows[r];
-                int                 i            = row.img_idx;
-                auto               &img          = m_images[i];
-                bool                is_current   = m_current == i;
-                bool                is_reference = m_reference == i;
-
-                if (row.kind != ImageListRow::Kind_Image)
-                {
-                    ImGui::PushFont(m_sans_regular, 0.f);
-                    img->draw_channel_list_row(row, is_current, is_reference, m_scroll_to_next_frame);
-                    ImGui::PopFont();
-                    continue;
-                }
+                int   i            = (int)m_visible_images[vi];
+                auto &img          = m_images[i];
+                bool  is_current   = m_current == i;
+                bool  is_reference = m_reference == i;
 
                 ImGuiTreeNodeFlags node_flags = base_node_flags;
+
+                ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
+
                 if (is_current || is_reference)
                     node_flags |= ImGuiTreeNodeFlags_Selected;
                 if (m_file_list_mode == 0)
@@ -774,15 +714,14 @@ void HDRViewApp::draw_file_window()
 
                 // Drawn with an empty label -- SpanAllColumns still makes this the row's click target -- so
                 // the icon and front-truncated filename below can be laid out and drawn by hand afterward.
-                bool open = ImGui::TreeRow(
-                    row.id, node_flags, "",
-                    [&] { ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", row.shortcut_index + 1).c_str()); },
-                    [&]
-                    {
-                        if (m_file_list_mode == 0)
-                            ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
-                        ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
-                    });
+                bool open = ImGui::TreeRow((void *)(intptr_t)i, node_flags, "", [&]
+                                           { ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", vi + 1).c_str()); },
+                                           [&]
+                                           {
+                                               if (m_file_list_mode == 0)
+                                                   ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
+                                               ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
+                                           });
                 auto icon = img->groups.size() > 1 ? ICON_MY_IMAGES : ICON_MY_IMAGE;
                 ImGui::SameLine(0.f, 0.f);
                 string the_text = ImGui::TruncatedText(filename, icon);
@@ -850,7 +789,7 @@ void HDRViewApp::draw_file_window()
 
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
-                        ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", row.shortcut_index + 1).c_str());
+                        ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", vi + 1).c_str());
                         ImGui::TableNextColumn();
                         ImGui::Text(the_text);
                         ImGui::EndTable();
@@ -885,18 +824,48 @@ void HDRViewApp::draw_file_window()
                 ImGui::SameLine(0.f, 0.f);
                 ImGui::TextAligned2(1.0f, -FLT_MIN, the_text.c_str());
 
-                if (m_file_list_mode == 0 && is_current && m_scroll_to_next_frame >= -0.5f)
+                if (open)
                 {
-                    if (!ImGui::IsItemVisible())
-                        ImGui::SetScrollHereY(m_scroll_to_next_frame);
-                    m_scroll_to_next_frame = -1.f;
+                    ImGui::PushFont(m_sans_regular, 0.f);
+                    int visible_groups = 1;
+                    if (m_file_list_mode == 0)
+                    {
+                        ImGui::Indent(ImGui::GetTreeNodeToLabelSpacing());
+                        if (is_current && m_scroll_to_next_frame >= -0.5f)
+                        {
+                            if (!ImGui::IsItemVisible())
+                                ImGui::SetScrollHereY(m_scroll_to_next_frame);
+                            m_scroll_to_next_frame = -1.f;
+                        }
+                    }
+                    else if (m_file_list_mode == 1)
+                    {
+                        visible_groups =
+                            img->draw_channel_rows(i, id, is_current, is_reference, m_scroll_to_next_frame);
+                        MY_ASSERT(visible_groups == img->root.visible_groups,
+                                  "Unexpected number of visible groups; {} != {}", visible_groups,
+                                  img->root.visible_groups);
+                    }
+                    else
+                    {
+                        visible_groups =
+                            img->draw_channel_tree(i, id, is_current, is_reference, m_scroll_to_next_frame);
+                        MY_ASSERT(visible_groups == img->root.visible_groups,
+                                  "Unexpected number of visible groups; {} != {}", visible_groups,
+                                  img->root.visible_groups);
+                    }
+
+                    hidden_groups += (int)img->groups.size() - visible_groups;
+
+                    ImGui::PopFont();
+
+                    if (open)
+                        ImGui::TreePop();
                 }
 
-                if (open)
-                    ImGui::TreePop();
+                ImGui::PopFont();
             }
         }
-        ImGui::PopFont();
 
         int hidden_images = num_images() - num_visible_images();
         if (hidden_images || hidden_groups)

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -680,7 +680,24 @@ void HDRViewApp::draw_file_window()
         bool             use_clipper = m_file_list_mode == 0;
         ImGuiListClipper clipper;
         if (use_clipper)
+        {
             clipper.Begin((int)m_visible_images.size());
+
+            // A pending scroll-to-selection request is consumed inside the per-row loop below, which the
+            // clipper only enters for rows it decided to draw. Without this, a request made while the
+            // target is scrolled out of view (e.g. a next/prev-image shortcut) would never reach its
+            // SetScrollHereY() call, and -- since the clipper computes the same range again next frame --
+            // would stay pending forever, until the user manually scrolled the target back into view.
+            if (m_scroll_to_next_frame >= -0.5f && is_valid(m_current))
+            {
+                auto it = find(m_visible_images.begin(), m_visible_images.end(), (size_t)m_current);
+                if (it != m_visible_images.end())
+                {
+                    int vi = int(it - m_visible_images.begin());
+                    clipper.IncludeItemsByIndex(vi, vi + 1);
+                }
+            }
+        }
         // the loop conditions here are to execute this outer loop once if we are not using the clipper, and execute it
         // as long as clipper.Step() returns true otherwise
         for (int iter = 0; (!use_clipper && iter < 1) || (use_clipper && clipper.Step()); ++iter)

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -672,32 +672,92 @@ void HDRViewApp::draw_file_window()
         ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, icon_width);
         ImGui::PushStyleVarY(ImGuiStyleVar_CellPadding, 0.f);
 
-        int id             = 0;
-        int hidden_groups  = 0;
+        // Flatten the whole visible row list -- every visible image, plus (in flat/tree mode) each
+        // visible image's currently-expanded channel rows -- before drawing anything, so a single
+        // ImGuiListClipper can span all three list modes uniformly instead of only "images only" mode
+        // getting clipped (the rest drew every row every frame regardless of scroll position). Pure
+        // bookkeeping over already-known visibility/tree-open state; no ImGui item calls happen here, so
+        // it's cheap even though it runs every frame.
+        ImGuiID              list_id = ImGui::GetID("ImageList");
+        vector<ImageListRow> flat_rows;
+        flat_rows.reserve(m_visible_images.size());
+        int hidden_groups = 0;
+        for (size_t vi = 0; vi < m_visible_images.size(); ++vi)
+        {
+            int   i   = (int)m_visible_images[vi];
+            auto &img = m_images[i];
+
+            // Independent of file_list_mode or the image row's own open/closed state below: how many of
+            // this image's groups the active filter is hiding, full stop.
+            hidden_groups += (int)img->groups.size() - img->root.visible_groups;
+
+            ImageListRow row;
+            row.kind           = ImageListRow::Kind_Image;
+            row.img_idx        = i;
+            row.shortcut_index = (int)vi; // 0-based position among visible images, for the row-number column
+            row.id             = ImGui::GetIDWithSeed(i, list_id);
+            flat_rows.push_back(row);
+
+            if (m_file_list_mode == 0)
+                continue; // leaf: no channel rows are ever shown
+
+            // Peeked, not drawn -- see flatten_layer_node()'s matching comment in image-gui.cpp.
+            if (!ImGui::GetStateStorage()->GetBool(row.id, true))
+                continue;
+
+            if (m_file_list_mode == 1)
+                img->flatten_channel_rows(i, row.id, flat_rows);
+            else
+                img->flatten_channel_tree(i, row.id, flat_rows);
+        }
+
+        // Locate the pending scroll-to-selection target's flat index, if any, so it can be forced into
+        // the clipper's visible range below even when it's currently scrolled out of view -- fixing the
+        // pre-existing bug where a target outside the clipper's natural [DisplayStart, DisplayEnd) window
+        // (e.g. right after a next/prev-image or next/prev-channel-group shortcut while scrolled away
+        // from it) never got its SetScrollHereY() call, since that call only ran inside the per-row loop
+        // body below, which the clipper -- by design -- only enters for rows it decided to draw.
+        int scroll_target = -1;
+        if (m_scroll_to_next_frame >= -0.5f && is_valid(m_current))
+        {
+            int wanted_group = m_file_list_mode == 0 ? -1 : m_images[m_current]->selected_group;
+            for (int r = 0; r < (int)flat_rows.size() && scroll_target < 0; ++r)
+            {
+                const ImageListRow &fr = flat_rows[r];
+                if (m_file_list_mode == 0 ? (fr.kind == ImageListRow::Kind_Image && fr.img_idx == m_current)
+                                          : (fr.kind == ImageListRow::Kind_Group && fr.img_idx == m_current &&
+                                             fr.group_idx == wanted_group))
+                    scroll_target = r;
+            }
+        }
+
         int image_to_close = -1;
 
-        // currently we only support the clipper when each image is one row
-        bool             use_clipper = m_file_list_mode == 0;
+        ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
+
         ImGuiListClipper clipper;
-        if (use_clipper)
-            clipper.Begin((int)m_visible_images.size());
-        // the loop conditions here are to execute this outer loop once if we are not using the clipper, and execute it
-        // as long as clipper.Step() returns true otherwise
-        for (int iter = 0; (!use_clipper && iter < 1) || (use_clipper && clipper.Step()); ++iter)
+        clipper.Begin((int)flat_rows.size());
+        if (scroll_target >= 0)
+            clipper.IncludeItemsByIndex(scroll_target, scroll_target + 1);
+        while (clipper.Step())
         {
-            int start = use_clipper ? clipper.DisplayStart : 0;
-            int end   = use_clipper ? clipper.DisplayEnd : (int)m_visible_images.size();
-            for (int vi = start; vi < end; ++vi)
+            for (int r = clipper.DisplayStart; r < clipper.DisplayEnd; ++r)
             {
-                int   i            = (int)m_visible_images[vi];
-                auto &img          = m_images[i];
-                bool  is_current   = m_current == i;
-                bool  is_reference = m_reference == i;
+                const ImageListRow &row          = flat_rows[r];
+                int                 i            = row.img_idx;
+                auto               &img          = m_images[i];
+                bool                is_current   = m_current == i;
+                bool                is_reference = m_reference == i;
+
+                if (row.kind != ImageListRow::Kind_Image)
+                {
+                    ImGui::PushFont(m_sans_regular, 0.f);
+                    img->draw_channel_list_row(row, is_current, is_reference, m_scroll_to_next_frame);
+                    ImGui::PopFont();
+                    continue;
+                }
 
                 ImGuiTreeNodeFlags node_flags = base_node_flags;
-
-                ImGui::PushFont(m_file_list_mode == 0 ? m_sans_regular : m_sans_bold, ImGui::GetStyle().FontSizeBase);
-
                 if (is_current || is_reference)
                     node_flags |= ImGuiTreeNodeFlags_Selected;
                 if (m_file_list_mode == 0)
@@ -714,14 +774,15 @@ void HDRViewApp::draw_file_window()
 
                 // Drawn with an empty label -- SpanAllColumns still makes this the row's click target -- so
                 // the icon and front-truncated filename below can be laid out and drawn by hand afterward.
-                bool open = ImGui::TreeRow((void *)(intptr_t)i, node_flags, "", [&]
-                                           { ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", vi + 1).c_str()); },
-                                           [&]
-                                           {
-                                               if (m_file_list_mode == 0)
-                                                   ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
-                                               ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
-                                           });
+                bool open = ImGui::TreeRow(
+                    row.id, node_flags, "",
+                    [&] { ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", row.shortcut_index + 1).c_str()); },
+                    [&]
+                    {
+                        if (m_file_list_mode == 0)
+                            ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
+                        ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
+                    });
                 auto icon = img->groups.size() > 1 ? ICON_MY_IMAGES : ICON_MY_IMAGE;
                 ImGui::SameLine(0.f, 0.f);
                 string the_text = ImGui::TruncatedText(filename, icon);
@@ -789,7 +850,7 @@ void HDRViewApp::draw_file_window()
 
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
-                        ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", vi + 1).c_str());
+                        ImGui::TextAligned2(1.0f, -FLT_MIN, fmt::format("{}", row.shortcut_index + 1).c_str());
                         ImGui::TableNextColumn();
                         ImGui::Text(the_text);
                         ImGui::EndTable();
@@ -824,48 +885,18 @@ void HDRViewApp::draw_file_window()
                 ImGui::SameLine(0.f, 0.f);
                 ImGui::TextAligned2(1.0f, -FLT_MIN, the_text.c_str());
 
-                if (open)
+                if (m_file_list_mode == 0 && is_current && m_scroll_to_next_frame >= -0.5f)
                 {
-                    ImGui::PushFont(m_sans_regular, 0.f);
-                    int visible_groups = 1;
-                    if (m_file_list_mode == 0)
-                    {
-                        ImGui::Indent(ImGui::GetTreeNodeToLabelSpacing());
-                        if (is_current && m_scroll_to_next_frame >= -0.5f)
-                        {
-                            if (!ImGui::IsItemVisible())
-                                ImGui::SetScrollHereY(m_scroll_to_next_frame);
-                            m_scroll_to_next_frame = -1.f;
-                        }
-                    }
-                    else if (m_file_list_mode == 1)
-                    {
-                        visible_groups =
-                            img->draw_channel_rows(i, id, is_current, is_reference, m_scroll_to_next_frame);
-                        MY_ASSERT(visible_groups == img->root.visible_groups,
-                                  "Unexpected number of visible groups; {} != {}", visible_groups,
-                                  img->root.visible_groups);
-                    }
-                    else
-                    {
-                        visible_groups =
-                            img->draw_channel_tree(i, id, is_current, is_reference, m_scroll_to_next_frame);
-                        MY_ASSERT(visible_groups == img->root.visible_groups,
-                                  "Unexpected number of visible groups; {} != {}", visible_groups,
-                                  img->root.visible_groups);
-                    }
-
-                    hidden_groups += (int)img->groups.size() - visible_groups;
-
-                    ImGui::PopFont();
-
-                    if (open)
-                        ImGui::TreePop();
+                    if (!ImGui::IsItemVisible())
+                        ImGui::SetScrollHereY(m_scroll_to_next_frame);
+                    m_scroll_to_next_frame = -1.f;
                 }
 
-                ImGui::PopFont();
+                if (open)
+                    ImGui::TreePop();
             }
         }
+        ImGui::PopFont();
 
         int hidden_images = num_images() - num_visible_images();
         if (hidden_images || hidden_groups)

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -311,127 +311,44 @@ void Image::draw_histogram()
     ImGui::PopFont();
 }
 
-void Image::flatten_channel_rows(int img_idx, unsigned int image_id, vector<ImageListRow> &out) const
+void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is_current, bool is_reference,
+                              bool short_names, int &visible_group, float &scroll_to)
 {
-    int shortcut_index = 0;
-    for (auto &layer : layers)
-        for (int g : layer.groups)
-        {
-            auto &group = groups[g];
-            if (!group.visible)
-                continue;
-
-            string group_name = group.num_channels == 1 ? group.name : "(" + group.name + ")";
-
-            ImageListRow row;
-            row.kind           = ImageListRow::Kind_Group;
-            row.img_idx        = img_idx;
-            row.name           = string(ICON_MY_CHANNEL_GROUP) + " " + layer.name + group_name;
-            row.group_idx      = g;
-            row.depth          = 1;
-            row.shortcut_index = shortcut_index++;
-            row.id             = ImGui::GetIDWithSeed(g, (ImGuiID)image_id);
-            out.push_back(std::move(row));
-        }
-}
-
-void Image::flatten_layer_node(int img_idx, const LayerTreeNode &node, unsigned int parent_id, int depth,
-                               int &shortcut_index, vector<ImageListRow> &out) const
-{
-    if (node.leaf_layer >= 0)
-        for (int g : layers[node.leaf_layer].groups)
-        {
-            auto &group = groups[g];
-            if (!group.visible)
-                continue;
-
-            string group_name = group.num_channels == 1 ? group.name : "(" + group.name + ")";
-
-            ImageListRow row;
-            row.kind           = ImageListRow::Kind_Group;
-            row.img_idx        = img_idx;
-            row.name           = string(ICON_MY_CHANNEL_GROUP) + " " + group_name;
-            row.group_idx      = g;
-            row.depth          = depth;
-            row.shortcut_index = shortcut_index++;
-            row.id             = ImGui::GetIDWithSeed(g, (ImGuiID)parent_id);
-            out.push_back(std::move(row));
-        }
-
-    for (auto &c : node.children)
-    {
-        const LayerTreeNode &child = c.second;
-        if (child.visible_groups == 0)
-            continue;
-
-        ImGuiID child_id =
-            ImGui::GetIDWithSeed(child.name.c_str(), child.name.c_str() + child.name.size(), (ImGuiID)parent_id);
-
-        ImageListRow row;
-        row.kind    = ImageListRow::Kind_Node;
-        row.img_idx = img_idx;
-        row.name    = fmt::format("{} {}", ICON_MY_OPEN_IMAGE, child.name);
-        row.node    = &child;
-        row.depth   = depth;
-        row.id      = child_id;
-        out.push_back(row);
-
-        // Peeked, not drawn: matches ImGuiTreeNodeFlags_DefaultOpen's own default for a node id ImGui
-        // hasn't seen yet, without needing to actually call TreeNodeBehavior for this (possibly clipped)
-        // row just to find out.
-        bool open = ImGui::GetStateStorage()->GetBool(child_id, true);
-        if (open)
-            flatten_layer_node(img_idx, child, child_id, depth + 1, shortcut_index, out);
-    }
-}
-
-void Image::flatten_channel_tree(int img_idx, unsigned int image_id, vector<ImageListRow> &out) const
-{
-    int shortcut_index = 0;
-    flatten_layer_node(img_idx, root, image_id, 1, shortcut_index, out);
-}
-
-bool Image::draw_channel_list_row(const ImageListRow &row, bool is_current, bool is_reference, float &scroll_to)
-{
-    static constexpr ImGuiTreeNodeFlags group_flags =
+    static constexpr ImGuiTreeNodeFlags tree_node_flags =
         ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf |
         ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_DrawLinesFull | ImGuiTreeNodeFlags_Bullet;
-    static constexpr ImGuiTreeNodeFlags node_flags =
-        ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_DrawLinesFull;
-
-    // Rows are drawn independently of one another (no recursive nesting), so indentation -- which would
-    // otherwise accumulate automatically from nested TreeNodeEx/TreePop calls -- is applied and undone
-    // entirely within this one row, self-contained, based on the depth flatten_channel_tree() recorded.
-    float spacing = ImGui::GetTreeNodeToLabelSpacing();
-    if (row.depth > 0)
-        ImGui::Indent(row.depth * spacing);
-
-    bool open = true;
-    if (row.kind == ImageListRow::Kind_Group)
+    for (size_t g = 0; g < layer.groups.size(); ++g)
     {
-        int  g                    = row.group_idx;
-        bool is_selected_channel  = is_current && selected_group == g;
-        bool is_reference_channel = is_reference && reference_group == g;
+        auto  &group      = groups[layer.groups[g]];
+        string group_name = group.num_channels == 1 ? group.name : "(" + group.name + ")";
+        string name       = string(ICON_MY_CHANNEL_GROUP) + " " + (short_names ? group_name : layer.name + group_name);
+
+        // check if any of the contained channels pass the channel filter
+        if (!group.visible)
+            continue;
+
+        bool is_selected_channel  = is_current && selected_group == layer.groups[g];
+        bool is_reference_channel = is_reference && reference_group == layer.groups[g];
 
         ImGuiTreeNodeFlags flags =
-            group_flags |
+            tree_node_flags |
             (is_selected_channel || is_reference_channel ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None);
-        ImGui::TreeRow(
-            row.id, flags, row.name.c_str(),
-            [&]
-            {
-                string shortcut = is_current && row.shortcut_index < 10
-                                      ? fmt::format(ICON_MY_KEY_CONTROL "{}", mod(row.shortcut_index + 1, 10))
-                                      : "";
-                ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
-            },
-            [&] { ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift); });
+        ImGui::TreeRow((void *)(intptr_t)id_++, flags, name.c_str(),
+                       [&]
+                       {
+                           string shortcut = is_current && visible_group < 10
+                                                 ? fmt::format(ICON_MY_KEY_CONTROL "{}", mod(visible_group + 1, 10))
+                                                 : "";
+                           ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
+                       },
+                       [&]
+                       { ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift); });
 
         if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
         {
             if (ImGui::GetIO().KeyShift)
             {
-                spdlog::trace("Shift-clicked on {}", row.name);
+                spdlog::trace("Shift-clicked on {}", name);
                 // check if we are already the reference channel group
                 if (is_reference_channel)
                 {
@@ -441,16 +358,16 @@ bool Image::draw_channel_list_row(const ImageListRow &row, bool is_current, bool
                 }
                 else
                 {
-                    spdlog::trace("Setting reference image to {}", row.img_idx);
-                    hdrview()->set_reference_image_index(row.img_idx);
-                    reference_group = g;
+                    spdlog::trace("Setting reference image to {}", img_idx);
+                    hdrview()->set_reference_image_index(img_idx);
+                    reference_group = layer.groups[g];
                 }
                 set_as_texture(Target_Secondary);
             }
             else
             {
-                hdrview()->set_current_image_index(row.img_idx);
-                selected_group = g;
+                hdrview()->set_current_image_index(img_idx);
+                selected_group = layer.groups[g];
                 set_as_texture(Target_Primary);
             }
         }
@@ -460,28 +377,60 @@ bool Image::draw_channel_list_row(const ImageListRow &row, bool is_current, bool
                 ImGui::SetScrollHereY(scroll_to);
             scroll_to = -1.f;
         }
+
+        ++visible_group;
     }
-    else // Kind_Node
+}
+
+/*!
+
+*/
+void Image::draw_layer_node(const LayerTreeNode &node, int img_idx, int &id_, bool is_current, bool is_reference,
+                            int &visible_group, float &scroll_to)
+{
+    static constexpr ImGuiTreeNodeFlags tree_node_flags =
+        ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_DrawLinesFull;
+
+    if (node.leaf_layer >= 0)
+        // draw this node's leaf channel groups
+        draw_layer_groups(layers[node.leaf_layer], img_idx, id_, is_current, is_reference, true, visible_group,
+                          scroll_to);
+
+    for (auto &c : node.children)
     {
-        open = ImGui::TreeRow(row.id, node_flags, row.name.c_str(), nullptr,
-                              [&]
-                              {
-                                  ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-                                  ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGuiCol_Header);
-                                  ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGuiCol_Header);
-                              });
-        // TreeNodeBehavior pushes `row.id` onto the window's ID stack whenever it reports open (matching
-        // ordinary TreeNodeEx semantics for a non-NoTreePushOnOpen node) -- unlike the recursive drawing
-        // this replaced, nothing here relies on that push (children are separate, independently-idâ€‘ed
-        // rows), but it still must be balanced or the next row's ID computations desync.
+        const LayerTreeNode &child_node = c.second;
+        if (child_node.visible_groups == 0)
+            continue;
+
+        bool open =
+            ImGui::TreeRow((void *)(intptr_t)id_++, tree_node_flags,
+                           fmt::format("{} {}", ICON_MY_OPEN_IMAGE, child_node.name).c_str(), nullptr,
+                           [&]
+                           {
+                               ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+                               ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGuiCol_Header);
+                               ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGuiCol_Header);
+                           });
         if (open)
+        {
+            draw_layer_node(child_node, img_idx, id_, is_current, is_reference, visible_group, scroll_to);
             ImGui::TreePop();
+        }
+        else
+        {
+            // still account for visible groups within the closed tree node
+            visible_group += child_node.visible_groups;
+        }
     }
+}
 
-    if (row.depth > 0)
-        ImGui::Unindent(row.depth * spacing);
+int Image::draw_channel_rows(int img_idx, int &id_, bool is_current, bool is_reference, float &scroll_to)
+{
+    int visible_group = 0;
+    for (size_t l = 0; l < layers.size(); ++l)
+        draw_layer_groups(layers[l], img_idx, id_, is_current, is_reference, false, visible_group, scroll_to);
 
-    return open;
+    return visible_group;
 }
 
 void Image::draw_info()

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -311,44 +311,127 @@ void Image::draw_histogram()
     ImGui::PopFont();
 }
 
-void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is_current, bool is_reference,
-                              bool short_names, int &visible_group, float &scroll_to)
+void Image::flatten_channel_rows(int img_idx, unsigned int image_id, vector<ImageListRow> &out) const
 {
-    static constexpr ImGuiTreeNodeFlags tree_node_flags =
-        ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf |
-        ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_DrawLinesFull | ImGuiTreeNodeFlags_Bullet;
-    for (size_t g = 0; g < layer.groups.size(); ++g)
-    {
-        auto  &group      = groups[layer.groups[g]];
-        string group_name = group.num_channels == 1 ? group.name : "(" + group.name + ")";
-        string name       = string(ICON_MY_CHANNEL_GROUP) + " " + (short_names ? group_name : layer.name + group_name);
+    int shortcut_index = 0;
+    for (auto &layer : layers)
+        for (int g : layer.groups)
+        {
+            auto &group = groups[g];
+            if (!group.visible)
+                continue;
 
-        // check if any of the contained channels pass the channel filter
-        if (!group.visible)
+            string group_name = group.num_channels == 1 ? group.name : "(" + group.name + ")";
+
+            ImageListRow row;
+            row.kind           = ImageListRow::Kind_Group;
+            row.img_idx        = img_idx;
+            row.name           = string(ICON_MY_CHANNEL_GROUP) + " " + layer.name + group_name;
+            row.group_idx      = g;
+            row.depth          = 1;
+            row.shortcut_index = shortcut_index++;
+            row.id             = ImGui::GetIDWithSeed(g, (ImGuiID)image_id);
+            out.push_back(std::move(row));
+        }
+}
+
+void Image::flatten_layer_node(int img_idx, const LayerTreeNode &node, unsigned int parent_id, int depth,
+                               int &shortcut_index, vector<ImageListRow> &out) const
+{
+    if (node.leaf_layer >= 0)
+        for (int g : layers[node.leaf_layer].groups)
+        {
+            auto &group = groups[g];
+            if (!group.visible)
+                continue;
+
+            string group_name = group.num_channels == 1 ? group.name : "(" + group.name + ")";
+
+            ImageListRow row;
+            row.kind           = ImageListRow::Kind_Group;
+            row.img_idx        = img_idx;
+            row.name           = string(ICON_MY_CHANNEL_GROUP) + " " + group_name;
+            row.group_idx      = g;
+            row.depth          = depth;
+            row.shortcut_index = shortcut_index++;
+            row.id             = ImGui::GetIDWithSeed(g, (ImGuiID)parent_id);
+            out.push_back(std::move(row));
+        }
+
+    for (auto &c : node.children)
+    {
+        const LayerTreeNode &child = c.second;
+        if (child.visible_groups == 0)
             continue;
 
-        bool is_selected_channel  = is_current && selected_group == layer.groups[g];
-        bool is_reference_channel = is_reference && reference_group == layer.groups[g];
+        ImGuiID child_id =
+            ImGui::GetIDWithSeed(child.name.c_str(), child.name.c_str() + child.name.size(), (ImGuiID)parent_id);
+
+        ImageListRow row;
+        row.kind    = ImageListRow::Kind_Node;
+        row.img_idx = img_idx;
+        row.name    = fmt::format("{} {}", ICON_MY_OPEN_IMAGE, child.name);
+        row.node    = &child;
+        row.depth   = depth;
+        row.id      = child_id;
+        out.push_back(row);
+
+        // Peeked, not drawn: matches ImGuiTreeNodeFlags_DefaultOpen's own default for a node id ImGui
+        // hasn't seen yet, without needing to actually call TreeNodeBehavior for this (possibly clipped)
+        // row just to find out.
+        bool open = ImGui::GetStateStorage()->GetBool(child_id, true);
+        if (open)
+            flatten_layer_node(img_idx, child, child_id, depth + 1, shortcut_index, out);
+    }
+}
+
+void Image::flatten_channel_tree(int img_idx, unsigned int image_id, vector<ImageListRow> &out) const
+{
+    int shortcut_index = 0;
+    flatten_layer_node(img_idx, root, image_id, 1, shortcut_index, out);
+}
+
+bool Image::draw_channel_list_row(const ImageListRow &row, bool is_current, bool is_reference, float &scroll_to)
+{
+    static constexpr ImGuiTreeNodeFlags group_flags =
+        ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf |
+        ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_DrawLinesFull | ImGuiTreeNodeFlags_Bullet;
+    static constexpr ImGuiTreeNodeFlags node_flags =
+        ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_DrawLinesFull;
+
+    // Rows are drawn independently of one another (no recursive nesting), so indentation -- which would
+    // otherwise accumulate automatically from nested TreeNodeEx/TreePop calls -- is applied and undone
+    // entirely within this one row, self-contained, based on the depth flatten_channel_tree() recorded.
+    float spacing = ImGui::GetTreeNodeToLabelSpacing();
+    if (row.depth > 0)
+        ImGui::Indent(row.depth * spacing);
+
+    bool open = true;
+    if (row.kind == ImageListRow::Kind_Group)
+    {
+        int  g                    = row.group_idx;
+        bool is_selected_channel  = is_current && selected_group == g;
+        bool is_reference_channel = is_reference && reference_group == g;
 
         ImGuiTreeNodeFlags flags =
-            tree_node_flags |
+            group_flags |
             (is_selected_channel || is_reference_channel ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None);
-        ImGui::TreeRow((void *)(intptr_t)id_++, flags, name.c_str(),
-                       [&]
-                       {
-                           string shortcut = is_current && visible_group < 10
-                                                 ? fmt::format(ICON_MY_KEY_CONTROL "{}", mod(visible_group + 1, 10))
-                                                 : "";
-                           ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
-                       },
-                       [&]
-                       { ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift); });
+        ImGui::TreeRow(
+            row.id, flags, row.name.c_str(),
+            [&]
+            {
+                string shortcut = is_current && row.shortcut_index < 10
+                                      ? fmt::format(ICON_MY_KEY_CONTROL "{}", mod(row.shortcut_index + 1, 10))
+                                      : "";
+                ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
+            },
+            [&] { ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift); });
 
         if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
         {
             if (ImGui::GetIO().KeyShift)
             {
-                spdlog::trace("Shift-clicked on {}", name);
+                spdlog::trace("Shift-clicked on {}", row.name);
                 // check if we are already the reference channel group
                 if (is_reference_channel)
                 {
@@ -358,16 +441,16 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
                 }
                 else
                 {
-                    spdlog::trace("Setting reference image to {}", img_idx);
-                    hdrview()->set_reference_image_index(img_idx);
-                    reference_group = layer.groups[g];
+                    spdlog::trace("Setting reference image to {}", row.img_idx);
+                    hdrview()->set_reference_image_index(row.img_idx);
+                    reference_group = g;
                 }
                 set_as_texture(Target_Secondary);
             }
             else
             {
-                hdrview()->set_current_image_index(img_idx);
-                selected_group = layer.groups[g];
+                hdrview()->set_current_image_index(row.img_idx);
+                selected_group = g;
                 set_as_texture(Target_Primary);
             }
         }
@@ -377,60 +460,28 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
                 ImGui::SetScrollHereY(scroll_to);
             scroll_to = -1.f;
         }
-
-        ++visible_group;
     }
-}
-
-/*!
-
-*/
-void Image::draw_layer_node(const LayerTreeNode &node, int img_idx, int &id_, bool is_current, bool is_reference,
-                            int &visible_group, float &scroll_to)
-{
-    static constexpr ImGuiTreeNodeFlags tree_node_flags =
-        ImGuiTreeNodeFlags_SpanAllColumns | ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_DrawLinesFull;
-
-    if (node.leaf_layer >= 0)
-        // draw this node's leaf channel groups
-        draw_layer_groups(layers[node.leaf_layer], img_idx, id_, is_current, is_reference, true, visible_group,
-                          scroll_to);
-
-    for (auto &c : node.children)
+    else // Kind_Node
     {
-        const LayerTreeNode &child_node = c.second;
-        if (child_node.visible_groups == 0)
-            continue;
-
-        bool open =
-            ImGui::TreeRow((void *)(intptr_t)id_++, tree_node_flags,
-                           fmt::format("{} {}", ICON_MY_OPEN_IMAGE, child_node.name).c_str(), nullptr,
-                           [&]
-                           {
-                               ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-                               ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGuiCol_Header);
-                               ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGuiCol_Header);
-                           });
+        open = ImGui::TreeRow(row.id, node_flags, row.name.c_str(), nullptr,
+                              [&]
+                              {
+                                  ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+                                  ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGuiCol_Header);
+                                  ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGuiCol_Header);
+                              });
+        // TreeNodeBehavior pushes `row.id` onto the window's ID stack whenever it reports open (matching
+        // ordinary TreeNodeEx semantics for a non-NoTreePushOnOpen node) -- unlike the recursive drawing
+        // this replaced, nothing here relies on that push (children are separate, independently-idâ€‘ed
+        // rows), but it still must be balanced or the next row's ID computations desync.
         if (open)
-        {
-            draw_layer_node(child_node, img_idx, id_, is_current, is_reference, visible_group, scroll_to);
             ImGui::TreePop();
-        }
-        else
-        {
-            // still account for visible groups within the closed tree node
-            visible_group += child_node.visible_groups;
-        }
     }
-}
 
-int Image::draw_channel_rows(int img_idx, int &id_, bool is_current, bool is_reference, float &scroll_to)
-{
-    int visible_group = 0;
-    for (size_t l = 0; l < layers.size(); ++l)
-        draw_layer_groups(layers[l], img_idx, id_, is_current, is_reference, false, visible_group, scroll_to);
+    if (row.depth > 0)
+        ImGui::Unindent(row.depth * spacing);
 
-    return visible_group;
+    return open;
 }
 
 void Image::draw_info()

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -330,60 +330,54 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
         bool is_selected_channel  = is_current && selected_group == layer.groups[g];
         bool is_reference_channel = is_reference && reference_group == layer.groups[g];
 
-        ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift);
+        ImGuiTreeNodeFlags flags =
+            tree_node_flags |
+            (is_selected_channel || is_reference_channel ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None);
+        ImGui::TreeRow((void *)(intptr_t)id_++, flags, name.c_str(),
+                       [&]
+                       {
+                           string shortcut = is_current && visible_group < 10
+                                                 ? fmt::format(ICON_MY_KEY_CONTROL "{}", mod(visible_group + 1, 10))
+                                                 : "";
+                           ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
+                       },
+                       [&]
+                       { ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift); });
+
+        if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
         {
-            ImGui::TableNextRow();
-
-            ImGui::TableNextColumn();
-            string shortcut = is_current && visible_group < 10
-                                  ? fmt::format(ICON_MY_KEY_CONTROL "{}", mod(visible_group + 1, 10))
-                                  : "";
-            ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
-
-            // ImGui::TableNextColumn();
-            // ImGui::TextAligned2(0.0f, -FLT_MIN, is_selected_channel ? ICON_MY_VISIBILITY : "");
-
-            ImGui::TableNextColumn();
-            ImGui::TreeNodeEx((void *)(intptr_t)id_++,
-                              tree_node_flags |
-                                  (is_selected_channel || is_reference_channel ? ImGuiTreeNodeFlags_Selected
-                                                                               : ImGuiTreeNodeFlags_None),
-                              "%s", name.c_str());
-            if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
+            if (ImGui::GetIO().KeyShift)
             {
-                if (ImGui::GetIO().KeyShift)
+                spdlog::trace("Shift-clicked on {}", name);
+                // check if we are already the reference channel group
+                if (is_reference_channel)
                 {
-                    spdlog::trace("Shift-clicked on {}", name);
-                    // check if we are already the reference channel group
-                    if (is_reference_channel)
-                    {
-                        spdlog::trace("Clearing reference image");
-                        hdrview()->set_reference_image_index(-1, true);
-                        reference_group = 0;
-                    }
-                    else
-                    {
-                        spdlog::trace("Setting reference image to {}", img_idx);
-                        hdrview()->set_reference_image_index(img_idx);
-                        reference_group = layer.groups[g];
-                    }
-                    set_as_texture(Target_Secondary);
+                    spdlog::trace("Clearing reference image");
+                    hdrview()->set_reference_image_index(-1, true);
+                    reference_group = 0;
                 }
                 else
                 {
-                    hdrview()->set_current_image_index(img_idx);
-                    selected_group = layer.groups[g];
-                    set_as_texture(Target_Primary);
+                    spdlog::trace("Setting reference image to {}", img_idx);
+                    hdrview()->set_reference_image_index(img_idx);
+                    reference_group = layer.groups[g];
                 }
+                set_as_texture(Target_Secondary);
             }
-            else if (is_selected_channel && scroll_to >= -0.5f)
+            else
             {
-                if (!ImGui::IsItemVisible())
-                    ImGui::SetScrollHereY(scroll_to);
-                scroll_to = -1.f;
+                hdrview()->set_current_image_index(img_idx);
+                selected_group = layer.groups[g];
+                set_as_texture(Target_Primary);
             }
         }
-        ImGui::PopStyleColor(3);
+        else if (is_selected_channel && scroll_to >= -0.5f)
+        {
+            if (!ImGui::IsItemVisible())
+                ImGui::SetScrollHereY(scroll_to);
+            scroll_to = -1.f;
+        }
+
         ++visible_group;
     }
 }
@@ -408,14 +402,15 @@ void Image::draw_layer_node(const LayerTreeNode &node, int img_idx, int &id_, bo
         if (child_node.visible_groups == 0)
             continue;
 
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(1);
-        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGuiCol_Header);
-        ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGuiCol_Header);
-        bool open = ImGui::TreeNodeEx((void *)(intptr_t)id_++, tree_node_flags, "%s %s", ICON_MY_OPEN_IMAGE,
-                                      child_node.name.c_str());
-        ImGui::PopStyleColor(3);
+        bool open =
+            ImGui::TreeRow((void *)(intptr_t)id_++, tree_node_flags,
+                           fmt::format("{} {}", ICON_MY_OPEN_IMAGE, child_node.name).c_str(), nullptr,
+                           [&]
+                           {
+                               ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+                               ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGuiCol_Header);
+                               ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGuiCol_Header);
+                           });
         if (open)
         {
             draw_layer_node(child_node, img_idx, id_, is_current, is_reference, visible_group, scroll_to);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -599,10 +599,11 @@ void Channel::update_stats(int c, ConstImagePtr img1, ConstImagePtr img2)
         hdrview()->exposure(),   hdrview()->histogram_x_scale(), hdrview()->histogram_y_scale(),   hdrview()->roi(),
         hdrview()->blend_mode(), img2 ? img2->id : -1,           img2 ? img2->reference_group : -1};
 
-    auto recompute_async_stats =
-        [this, desired_settings, img1, img_data_origin = img1->data_window.min,
-         ref             = img2 ? &img2->channels[img2->groups[img2->reference_group].channels[c]] : nullptr,
-         ref_data_origin = img2 ? img2->data_window.min : int2{}]()
+    auto recompute_async_stats = [this, desired_settings, img1, img_data_origin = img1->data_window.min,
+                                  ref             = (img2 && img2->is_valid_group(img2->reference_group))
+                                                        ? &img2->channels[img2->groups[img2->reference_group].channels[c]]
+                                                        : nullptr,
+                                  ref_data_origin = img2 ? img2->data_window.min : int2{}]()
     {
         spdlog::debug("id: {}", img1->id);
         // First cancel the potential previous async task
@@ -663,7 +664,7 @@ void Image::set_as_texture(Target_ target)
 {
     auto                s         = hdrview()->shader();
     auto                t         = target_name(target);
-    int                 group_idx = target == Target_Primary ? selected_group : reference_group;
+    int                 group_idx = active_group_index(target);
     const ChannelGroup &group     = groups[group_idx];
 
     for (int c = 0; c < group.num_channels; ++c)
@@ -1271,7 +1272,7 @@ float4 Image::raw_pixel(int2 p, Target_ target) const
     if (!contains(p))
         return float4{0.f};
 
-    int                 group_idx = target == Target_Primary ? selected_group : reference_group;
+    int                 group_idx = active_group_index(target);
     const ChannelGroup &group     = groups[group_idx];
 
     float4 value{0.f};
@@ -1286,7 +1287,7 @@ float4 Image::rgba_pixel(int2 p, Target_ target) const
     if (!contains(p))
         return float4{0.f};
 
-    int                 group_idx = target == Target_Primary ? selected_group : reference_group;
+    int                 group_idx = active_group_index(target);
     const ChannelGroup &group     = groups[group_idx];
 
     float4 value{float3{0.f}, 1.f};

--- a/src/image.h
+++ b/src/image.h
@@ -267,34 +267,6 @@ struct LayerTreeNode
     void calculate_visibility(const Image *img);
 };
 
-//! One flattened row of the image-list window (any of its three list modes: images-only, flat, tree),
-//! built without drawing anything by Image::flatten_channel_rows()/flatten_channel_tree() below -- so
-//! the total row count and each row's kind/identity are known up front, before an ImGuiListClipper
-//! decides which of them to actually draw this frame. `id` (an ImGuiID, typed as unsigned int here to
-//! avoid pulling imgui.h into this header) is stable and order-independent -- chained via
-//! ImGui::GetIDWithSeed() from the owning image's own id -- rather than the sequential counter the
-//! row-drawing code used before the clipper existed: since the clipper can skip a row's ancestor (its
-//! enclosing image or layer-tree node) while still drawing the row itself, an id can't depend on
-//! whether ancestors happened to be drawn this frame.
-struct ImageListRow
-{
-    enum Kind_ : int
-    {
-        Kind_Image, //!< A top-level image row; drawn directly by HDRViewApp::draw_file_window(), not by
-                    //!< Image::draw_channel_list_row() below (which only ever sees Kind_Group/Kind_Node).
-        Kind_Group, //!< A leaf channel-group row; `group_idx` indexes `Image::groups`.
-        Kind_Node   //!< A tree-mode intermediate layer-path row; `node` points into `Image::root`.
-    } kind;
-    int                  img_idx = -1;             //!< Index into HDRViewApp's image list.
-    std::string          name;                     //!< Pre-formatted icon + label (unused for Kind_Image).
-    int                  group_idx      = -1;      //!< Kind_Group only.
-    const LayerTreeNode *node           = nullptr; //!< Kind_Node only.
-    int                  depth          = 0;       //!< Indent level, relative to the image row.
-    int                  shortcut_index = 0;       //!< Kind_Group only: this group's 0-based order
-                                                   //!< among the image's currently-drawn groups.
-    unsigned int id = 0;                           //!< ImGuiID.
-};
-
 struct Image
 {
 public:
@@ -404,22 +376,28 @@ public:
                                         bool unpremultiply = true, bool convert_to_sRGB = true) const;
 
     void draw_histogram();
+    void draw_layer_groups(const Layer &layer, int img_idx, int &id, bool is_current, bool is_reference,
+                           bool short_names, int &visible_group, float &scroll_to);
+    void draw_layer_node(const LayerTreeNode &node, int img_idx, int &id, bool is_current, bool is_reference,
+                         int &visible_group, float &scroll_to);
+    int  draw_channel_tree(int img_idx, int &_id, bool is_current, bool is_reference, float &scroll_to)
+    {
+        int visible_group = 0;
+        draw_layer_node(root, img_idx, _id, is_current, is_reference, visible_group, scroll_to);
+        return visible_group;
+    }
 
-    //! Appends flat-mode rows (every visible channel group, no tree nesting) for this image to `out`, in
-    //! the same order they'd be drawn in. Pure bookkeeping over already-known data (Layer::groups,
-    //! ChannelGroup::visible) -- no ImGui widget calls.
-    void flatten_channel_rows(int img_idx, unsigned int image_id, std::vector<ImageListRow> &out) const;
-    //! Appends tree-mode rows (layer-path nodes and their leaf channel groups) for this image to `out`,
-    //! recursing into a child node only if it's currently open, per ImGui's own persisted tree-node state
-    //! at that node's id (queried via ImGui::GetStateStorage(), not drawn) -- so a collapsed branch simply
-    //! doesn't contribute rows, exactly as if it had been drawn and skipped.
-    void flatten_channel_tree(int img_idx, unsigned int image_id, std::vector<ImageListRow> &out) const;
+    /*!
+        For each visible channel in the image, draw a row into an imgui table.
 
-    //! Draws one row previously produced by flatten_channel_rows()/flatten_channel_tree() (always
-    //! Kind_Group or Kind_Node -- Kind_Image rows are drawn directly by draw_file_window()). Returns
-    //! whether a Kind_Node row is open (always true for Kind_Group, which has no children of its own).
-    bool draw_channel_list_row(const ImageListRow &row, bool is_current, bool is_reference, float &scroll_to);
-
+        \param img_idx The index of the image in HDRViewApp's list of images (or -1). If non-negative, will be used to
+                       set HDRViewApp's current image upon clicking on the row.
+        \param id A unique integer id for imgui purposes. Is incremented for each added clickable row.
+        \param is_current Is this the current image in HDRViewApp?
+        \param is_reference Is this the reference image in HDRViewApp?
+        \returns The number of displayed channel groups.
+    */
+    int  draw_channel_rows(int img_idx, int &id, bool is_current, bool is_reference, float &scroll_to);
     void draw_info();
     void draw_chromaticity_diagram(float width);
     void draw_colorspace();
@@ -433,16 +411,6 @@ private:
     std::map<std::string, int> channels_in_layer(const std::string &layer) const;
     void traverse_tree(const LayerTreeNode *node, std::function<void(const LayerTreeNode *, int)> callback,
                        int level = 0) const;
-
-    // Recursive helper behind flatten_channel_tree(): walks `node`'s children (skipping any whose
-    // precomputed visible_groups is 0), appending a Kind_Node row for each -- and, if it's currently
-    // open, recursing into it -- plus a Kind_Group row for each visible channel group in `node`'s own
-    // leaf layer, if any. `parent_id` seeds each child's id (ImGui::GetIDWithSeed(name, parent_id)) so
-    // sibling subtrees with same-named branches (e.g. "diffuse" under both "beauty" and "specular") don't
-    // collide. `shortcut_index` is threaded through by reference: it's this image's single running count
-    // of Kind_Group rows appended so far, across the whole tree, for the Ctrl+N hint.
-    void flatten_layer_node(int img_idx, const LayerTreeNode &node, unsigned int parent_id, int depth,
-                            int &shortcut_index, std::vector<ImageListRow> &out) const;
 };
 
 template <typename T>

--- a/src/image.h
+++ b/src/image.h
@@ -267,6 +267,34 @@ struct LayerTreeNode
     void calculate_visibility(const Image *img);
 };
 
+//! One flattened row of the image-list window (any of its three list modes: images-only, flat, tree),
+//! built without drawing anything by Image::flatten_channel_rows()/flatten_channel_tree() below -- so
+//! the total row count and each row's kind/identity are known up front, before an ImGuiListClipper
+//! decides which of them to actually draw this frame. `id` (an ImGuiID, typed as unsigned int here to
+//! avoid pulling imgui.h into this header) is stable and order-independent -- chained via
+//! ImGui::GetIDWithSeed() from the owning image's own id -- rather than the sequential counter the
+//! row-drawing code used before the clipper existed: since the clipper can skip a row's ancestor (its
+//! enclosing image or layer-tree node) while still drawing the row itself, an id can't depend on
+//! whether ancestors happened to be drawn this frame.
+struct ImageListRow
+{
+    enum Kind_ : int
+    {
+        Kind_Image, //!< A top-level image row; drawn directly by HDRViewApp::draw_file_window(), not by
+                    //!< Image::draw_channel_list_row() below (which only ever sees Kind_Group/Kind_Node).
+        Kind_Group, //!< A leaf channel-group row; `group_idx` indexes `Image::groups`.
+        Kind_Node   //!< A tree-mode intermediate layer-path row; `node` points into `Image::root`.
+    } kind;
+    int                  img_idx = -1;             //!< Index into HDRViewApp's image list.
+    std::string          name;                     //!< Pre-formatted icon + label (unused for Kind_Image).
+    int                  group_idx      = -1;      //!< Kind_Group only.
+    const LayerTreeNode *node           = nullptr; //!< Kind_Node only.
+    int                  depth          = 0;       //!< Indent level, relative to the image row.
+    int                  shortcut_index = 0;       //!< Kind_Group only: this group's 0-based order
+                                                   //!< among the image's currently-drawn groups.
+    unsigned int id = 0;                           //!< ImGuiID.
+};
+
 struct Image
 {
 public:
@@ -376,28 +404,22 @@ public:
                                         bool unpremultiply = true, bool convert_to_sRGB = true) const;
 
     void draw_histogram();
-    void draw_layer_groups(const Layer &layer, int img_idx, int &id, bool is_current, bool is_reference,
-                           bool short_names, int &visible_group, float &scroll_to);
-    void draw_layer_node(const LayerTreeNode &node, int img_idx, int &id, bool is_current, bool is_reference,
-                         int &visible_group, float &scroll_to);
-    int  draw_channel_tree(int img_idx, int &_id, bool is_current, bool is_reference, float &scroll_to)
-    {
-        int visible_group = 0;
-        draw_layer_node(root, img_idx, _id, is_current, is_reference, visible_group, scroll_to);
-        return visible_group;
-    }
 
-    /*!
-        For each visible channel in the image, draw a row into an imgui table.
+    //! Appends flat-mode rows (every visible channel group, no tree nesting) for this image to `out`, in
+    //! the same order they'd be drawn in. Pure bookkeeping over already-known data (Layer::groups,
+    //! ChannelGroup::visible) -- no ImGui widget calls.
+    void flatten_channel_rows(int img_idx, unsigned int image_id, std::vector<ImageListRow> &out) const;
+    //! Appends tree-mode rows (layer-path nodes and their leaf channel groups) for this image to `out`,
+    //! recursing into a child node only if it's currently open, per ImGui's own persisted tree-node state
+    //! at that node's id (queried via ImGui::GetStateStorage(), not drawn) -- so a collapsed branch simply
+    //! doesn't contribute rows, exactly as if it had been drawn and skipped.
+    void flatten_channel_tree(int img_idx, unsigned int image_id, std::vector<ImageListRow> &out) const;
 
-        \param img_idx The index of the image in HDRViewApp's list of images (or -1). If non-negative, will be used to
-                       set HDRViewApp's current image upon clicking on the row.
-        \param id A unique integer id for imgui purposes. Is incremented for each added clickable row.
-        \param is_current Is this the current image in HDRViewApp?
-        \param is_reference Is this the reference image in HDRViewApp?
-        \returns The number of displayed channel groups.
-    */
-    int  draw_channel_rows(int img_idx, int &id, bool is_current, bool is_reference, float &scroll_to);
+    //! Draws one row previously produced by flatten_channel_rows()/flatten_channel_tree() (always
+    //! Kind_Group or Kind_Node -- Kind_Image rows are drawn directly by draw_file_window()). Returns
+    //! whether a Kind_Node row is open (always true for Kind_Group, which has no children of its own).
+    bool draw_channel_list_row(const ImageListRow &row, bool is_current, bool is_reference, float &scroll_to);
+
     void draw_info();
     void draw_chromaticity_diagram(float width);
     void draw_colorspace();
@@ -411,6 +433,16 @@ private:
     std::map<std::string, int> channels_in_layer(const std::string &layer) const;
     void traverse_tree(const LayerTreeNode *node, std::function<void(const LayerTreeNode *, int)> callback,
                        int level = 0) const;
+
+    // Recursive helper behind flatten_channel_tree(): walks `node`'s children (skipping any whose
+    // precomputed visible_groups is 0), appending a Kind_Node row for each -- and, if it's currently
+    // open, recursing into it -- plus a Kind_Group row for each visible channel group in `node`'s own
+    // leaf layer, if any. `parent_id` seeds each child's id (ImGui::GetIDWithSeed(name, parent_id)) so
+    // sibling subtrees with same-named branches (e.g. "diffuse" under both "beauty" and "specular") don't
+    // collide. `shortcut_index` is threaded through by reference: it's this image's single running count
+    // of Kind_Group rows appended so far, across the whole tree, for the Ctrl+N hint.
+    void flatten_layer_node(int img_idx, const LayerTreeNode &node, unsigned int parent_id, int depth,
+                            int &shortcut_index, std::vector<ImageListRow> &out) const;
 };
 
 template <typename T>

--- a/src/image.h
+++ b/src/image.h
@@ -347,8 +347,19 @@ public:
     int2 size() const { return data_window.size(); }
 
     bool is_valid_group(int index) const { return index >= 0 && index < (int)groups.size(); }
-    int  next_visible_group_index(int index, Direction_ direction) const;
-    int  nth_visible_group_index(int n) const;
+
+    //! The group index to use for `target`: `selected_group` for Target_Primary, `reference_group` for
+    //! Target_Secondary -- except reference_group can be left at -1 by update_visibility() (a channel
+    //! filter can hide the group an image was set as *reference* for without deselecting it as the
+    //! reference), so Target_Secondary falls back to `selected_group` whenever `reference_group` is
+    //! currently invalid, rather than indexing `groups` out of bounds.
+    int active_group_index(Target_ target) const
+    {
+        return (target == Target_Secondary && is_valid_group(reference_group)) ? reference_group : selected_group;
+    }
+
+    int next_visible_group_index(int index, Direction_ direction) const;
+    int nth_visible_group_index(int n) const;
 
     static void set_null_texture(Target_ target = Target_Primary);
     void        set_as_texture(Target_ target = Target_Primary);

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -416,20 +416,28 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
     float4 header  = GetStyleColorVec4(ImGuiCol_Header);
     float4 hovered = GetStyleColorVec4(ImGuiCol_HeaderHovered);
 
-    // "complementary" color (for reference image/channel group) is shifted by 2/3 in hue
-    constexpr float3 hsv_adjust = float3{0.67f, 0.f, -0.2f};
-    float4           hovered_c{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(hovered.xyz()) + hsv_adjust), hovered.w};
-    float4           header_c{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(header.xyz()) + hsv_adjust), header.w};
-    float4           active_c{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(active.xyz()) + hsv_adjust), active.w};
+    // The derived colors below depend only on those three theme colors, but this is called once per
+    // visible row per frame, so they're cached and rederived only when the theme actually changes --
+    // comparing three colors is much cheaper than six HSV<->RGB conversions.
+    static float4 cached_hovered{-1.f}, cached_header{-1.f}, cached_active{-1.f};
+    static float4 hovered_c, header_c, active_c, hovered_avg, header_avg, active_avg;
+    if (hovered != cached_hovered || header != cached_header || active != cached_active)
+    {
+        cached_hovered = hovered;
+        cached_header  = header;
+        cached_active  = active;
 
-    // the average between the two is used when a row is both current and reference
-    float4 hovered_avg = 0.5f * (hovered_c + hovered);
-    float4 header_avg  = 0.5f * (header_c + header);
-    float4 active_avg  = 0.5f * (active_c + active);
-    // constexpr float3 hsv_adjust2 = float3{0.33f, 0.f, -0.2f};
-    // float4           hovered_avg{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(hovered.xyz()) + hsv_adjust2), hovered.w};
-    // float4           header_avg{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(header.xyz()) + hsv_adjust2), header.w};
-    // float4           active_avg{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(active.xyz()) + hsv_adjust2), active.w};
+        // "complementary" color (for reference image/channel group) is shifted by 2/3 in hue
+        constexpr float3 hsv_adjust = float3{0.67f, 0.f, -0.2f};
+        hovered_c = float4{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(hovered.xyz()) + hsv_adjust), hovered.w};
+        header_c  = float4{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(header.xyz()) + hsv_adjust), header.w};
+        active_c  = float4{ColorConvertHSVtoRGB(ColorConvertRGBtoHSV(active.xyz()) + hsv_adjust), active.w};
+
+        // the average between the two is used when a row is both current and reference
+        hovered_avg = 0.5f * (hovered_c + hovered);
+        header_avg  = 0.5f * (header_c + header);
+        active_avg  = 0.5f * (active_c + active);
+    }
 
     ImGui::PushStyleColor(ImGuiCol_HeaderHovered, reference_mod ? (is_current ? hovered_avg : hovered_c)
                                                                 : (is_reference ? hovered_avg : hovered));

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -282,12 +282,10 @@ string TruncatedText(const string &filename, const string &icon)
     if (CalcTextSize((icon + filename).c_str()).x <= avail_width)
         return filename;
 
-    // Unlike RenderTextEllipsis (imgui.cpp), which keeps the prefix and elides the tail, filenames
-    // here are `file:part.layer.channel` paths whose meaningful part is the *end* -- so this keeps
-    // the tail and elides the front instead. Mirrors RenderTextEllipsis's technique (a single
-    // width-accumulating pass over per-glyph advances, O(n)) rather than the old approach of
-    // re-measuring the whole (icon + ellipsis + text) string with CalcTextSize on every character
-    // dropped, which was O(n^2).
+    // Filenames here are `file:part.layer.channel` paths whose meaningful part is the *end*, so this
+    // keeps the tail and elides the front -- the opposite of ImGui's RenderTextEllipsis(), which
+    // keeps the prefix. Same technique as that function though: accumulate per-glyph advances in a
+    // single pass (here walking backwards from the end) rather than re-measuring a growing substring.
     static const string ellipsis = " ...";
     const float         budget   = avail_width - CalcTextSize((icon + ellipsis).c_str()).x;
 
@@ -308,8 +306,8 @@ string TruncatedText(const string &filename, const string &icon)
         ImTextCharFromUtf8(&codepoint, prev, cut);
         float advance = baked->GetCharAdvance((ImWchar)codepoint);
 
-        // Always keep at least the very last character, even if it alone exceeds the budget --
-        // matches the old loop's `text.length() > 1` guard.
+        // Always keep at least the final character, even if it alone exceeds the budget, so the
+        // result is never a bare ellipsis.
         if (cut != end && width + advance > budget)
             break;
 

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -437,7 +437,7 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
     ImGui::PushStyleColor(ImGuiCol_HeaderActive, reference_mod ? (is_current ? active_avg : active_c) : active);
 }
 
-bool TreeRow(ImGuiID id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
+bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
              const std::function<void()> &before_node)
 {
     ImGui::TableNextRow();
@@ -447,7 +447,7 @@ bool TreeRow(ImGuiID id, ImGuiTreeNodeFlags flags, const char *label, const std:
 
     ImGui::TableNextColumn();
     before_node();
-    bool open = ImGui::TreeNodeBehavior(id, flags, label);
+    bool open = ImGui::TreeNodeEx(id, flags, "%s", label);
     ImGui::PopStyleColor(3);
     return open;
 }

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -437,6 +437,21 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
     ImGui::PushStyleColor(ImGuiCol_HeaderActive, reference_mod ? (is_current ? active_avg : active_c) : active);
 }
 
+bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
+             const std::function<void()> &before_node)
+{
+    ImGui::TableNextRow();
+    ImGui::TableNextColumn();
+    if (leading_column)
+        leading_column();
+
+    ImGui::TableNextColumn();
+    before_node();
+    bool open = ImGui::TreeNodeEx(id, flags, "%s", label);
+    ImGui::PopStyleColor(3);
+    return open;
+}
+
 // Splits `total_width` (already reduced by inter-item spacing) into `num_components` columns using the same
 // truncated allocation Dear ImGui's ColorEdit4 uses internally (remainder folded into the last column), so
 // a header row computed independently still lines up with the value boxes drawn below it.

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -276,17 +276,48 @@ ImU32 SpdLogWindow::get_level_color(spdlog::level::level_enum level)
 
 string TruncatedText(const string &filename, const string &icon)
 {
-    string ellipsis = "";
-    string text     = filename;
-
     const float avail_width = GetContentRegionAvail().x;
-    while (CalcTextSize((icon + ellipsis + text).c_str()).x > avail_width && text.length() > 1)
+
+    // Common case: the whole thing already fits, nothing to truncate.
+    if (CalcTextSize((icon + filename).c_str()).x <= avail_width)
+        return filename;
+
+    // Unlike RenderTextEllipsis (imgui.cpp), which keeps the prefix and elides the tail, filenames
+    // here are `file:part.layer.channel` paths whose meaningful part is the *end* -- so this keeps
+    // the tail and elides the front instead. Mirrors RenderTextEllipsis's technique (a single
+    // width-accumulating pass over per-glyph advances, O(n)) rather than the old approach of
+    // re-measuring the whole (icon + ellipsis + text) string with CalcTextSize on every character
+    // dropped, which was O(n^2).
+    static const string ellipsis = " ...";
+    const float         budget   = avail_width - CalcTextSize((icon + ellipsis).c_str()).x;
+
+    ImFont      *font  = GetFont();
+    ImFontBaked *baked = font->GetFontBaked(GetFontSize());
+
+    const char *begin = filename.c_str();
+    const char *end   = begin + filename.size();
+    const char *cut   = end;
+    float       width = 0.f;
+    while (cut > begin)
     {
-        text     = text.substr(1);
-        ellipsis = " ...";
+        // Step back to the start (lead byte) of the codepoint immediately before `cut`.
+        const char *prev = cut - 1;
+        while (prev > begin && (static_cast<unsigned char>(*prev) & 0xC0) == 0x80) --prev;
+
+        unsigned int codepoint = 0;
+        ImTextCharFromUtf8(&codepoint, prev, cut);
+        float advance = baked->GetCharAdvance((ImWchar)codepoint);
+
+        // Always keep at least the very last character, even if it alone exceeds the budget --
+        // matches the old loop's `text.length() > 1` guard.
+        if (cut != end && width + advance > budget)
+            break;
+
+        width += advance;
+        cut = prev;
     }
 
-    return ellipsis + text;
+    return cut == begin ? filename : ellipsis + string(cut, end);
 };
 
 ImVec2 IconSize() { return CalcTextSize(ICON_MY_WIDEST); }

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -437,7 +437,7 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
     ImGui::PushStyleColor(ImGuiCol_HeaderActive, reference_mod ? (is_current ? active_avg : active_c) : active);
 }
 
-bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
+bool TreeRow(ImGuiID id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
              const std::function<void()> &before_node)
 {
     ImGui::TableNextRow();
@@ -447,7 +447,7 @@ bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const 
 
     ImGui::TableNextColumn();
     before_node();
-    bool open = ImGui::TreeNodeEx(id, flags, "%s", label);
+    bool open = ImGui::TreeNodeBehavior(id, flags, label);
     ImGui::PopStyleColor(3);
     return open;
 }

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -240,15 +240,19 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod = fals
 //! Draws one row of a table-as-tree/outliner view -- the shared skeleton behind the image list's three
 //! row kinds (top-level image rows, flat/tree channel-group rows, tree-mode layer-path rows): TableNextRow(),
 //! an optional leading-column callback (drawn in column 0; pass nullptr to leave it empty), then
-//! TreeNodeEx(id, flags, "%s", label) in column 1. `before_node` runs immediately before the TreeNodeEx
-//! call (after the row has moved into the label column) and must push exactly 3 style colors -- e.g. via
-//! PushRowColors() above, or a plain dim/hover-neutralizing 3x PushStyleColor() for a non-selectable row --
-//! which TreeRow() pops again before returning; it's also the right place for any one-off Indent()/
-//! Unindent() that needs to apply specifically to this row's label column. `label` may be "" for callers
-//! that render their own content after TreeRow() returns instead (e.g. a row needing custom text
-//! truncation) -- SpanAllColumns keeps that row the click target either way. Returns TreeNodeEx's own
-//! open/closed result.
-bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
+//! TreeNodeBehavior(id, flags, label) in column 1. `id` is taken as an already-resolved ImGuiID (typically
+//! via GetIDWithSeed(), see e.g. Image::flatten_channel_rows()) rather than the usual ptr/str id that gets
+//! hashed against the current ID stack -- this row's ancestors (its enclosing image or layer-tree node)
+//! may not have been drawn this frame (e.g. when skipped by an ImGuiListClipper), so the id can't depend
+//! on whatever happens to be on the ID stack right now. `before_node` runs immediately before the
+//! TreeNodeBehavior call (after the row has moved into the label column) and must push exactly 3 style
+//! colors -- e.g. via PushRowColors() above, or a plain dim/hover-neutralizing 3x PushStyleColor() for a
+//! non-selectable row -- which TreeRow() pops again before returning; it's also the right place for any
+//! one-off Indent()/Unindent() that needs to apply specifically to this row's label column. `label` may
+//! be "" for callers that render their own content after TreeRow() returns instead (e.g. a row needing
+//! custom text truncation) -- SpanAllColumns keeps that row the click target either way. Returns
+//! TreeNodeBehavior's own open/closed result.
+bool TreeRow(ImGuiID id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
              const std::function<void()> &before_node);
 
 void TextAlignedV2(float align_x, float size_x, const char *fmt, va_list args);

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -240,19 +240,15 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod = fals
 //! Draws one row of a table-as-tree/outliner view -- the shared skeleton behind the image list's three
 //! row kinds (top-level image rows, flat/tree channel-group rows, tree-mode layer-path rows): TableNextRow(),
 //! an optional leading-column callback (drawn in column 0; pass nullptr to leave it empty), then
-//! TreeNodeBehavior(id, flags, label) in column 1. `id` is taken as an already-resolved ImGuiID (typically
-//! via GetIDWithSeed(), see e.g. Image::flatten_channel_rows()) rather than the usual ptr/str id that gets
-//! hashed against the current ID stack -- this row's ancestors (its enclosing image or layer-tree node)
-//! may not have been drawn this frame (e.g. when skipped by an ImGuiListClipper), so the id can't depend
-//! on whatever happens to be on the ID stack right now. `before_node` runs immediately before the
-//! TreeNodeBehavior call (after the row has moved into the label column) and must push exactly 3 style
-//! colors -- e.g. via PushRowColors() above, or a plain dim/hover-neutralizing 3x PushStyleColor() for a
-//! non-selectable row -- which TreeRow() pops again before returning; it's also the right place for any
-//! one-off Indent()/Unindent() that needs to apply specifically to this row's label column. `label` may
-//! be "" for callers that render their own content after TreeRow() returns instead (e.g. a row needing
-//! custom text truncation) -- SpanAllColumns keeps that row the click target either way. Returns
-//! TreeNodeBehavior's own open/closed result.
-bool TreeRow(ImGuiID id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
+//! TreeNodeEx(id, flags, "%s", label) in column 1. `before_node` runs immediately before the TreeNodeEx
+//! call (after the row has moved into the label column) and must push exactly 3 style colors -- e.g. via
+//! PushRowColors() above, or a plain dim/hover-neutralizing 3x PushStyleColor() for a non-selectable row --
+//! which TreeRow() pops again before returning; it's also the right place for any one-off Indent()/
+//! Unindent() that needs to apply specifically to this row's label column. `label` may be "" for callers
+//! that render their own content after TreeRow() returns instead (e.g. a row needing custom text
+//! truncation) -- SpanAllColumns keeps that row the click target either way. Returns TreeNodeEx's own
+//! open/closed result.
+bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
              const std::function<void()> &before_node);
 
 void TextAlignedV2(float align_x, float size_x, const char *fmt, va_list args);

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -237,6 +237,20 @@ std::string TruncatedText(const std::string &filename, const std::string &icon);
 
 void PushRowColors(bool is_current, bool is_reference, bool reference_mod = false);
 
+//! Draws one row of a table-as-tree/outliner view -- the shared skeleton behind the image list's three
+//! row kinds (top-level image rows, flat/tree channel-group rows, tree-mode layer-path rows): TableNextRow(),
+//! an optional leading-column callback (drawn in column 0; pass nullptr to leave it empty), then
+//! TreeNodeEx(id, flags, "%s", label) in column 1. `before_node` runs immediately before the TreeNodeEx
+//! call (after the row has moved into the label column) and must push exactly 3 style colors -- e.g. via
+//! PushRowColors() above, or a plain dim/hover-neutralizing 3x PushStyleColor() for a non-selectable row --
+//! which TreeRow() pops again before returning; it's also the right place for any one-off Indent()/
+//! Unindent() that needs to apply specifically to this row's label column. `label` may be "" for callers
+//! that render their own content after TreeRow() returns instead (e.g. a row needing custom text
+//! truncation) -- SpanAllColumns keeps that row the click target either way. Returns TreeNodeEx's own
+//! open/closed result.
+bool TreeRow(const void *id, ImGuiTreeNodeFlags flags, const char *label, const std::function<void()> &leading_column,
+             const std::function<void()> &before_node);
+
 void TextAlignedV2(float align_x, float size_x, const char *fmt, va_list args);
 void TextAligned2(float align_x, float size_x, const char *fmt, ...);
 


### PR DESCRIPTION
## Summary

Fixes for the image/channel-list window (`draw_file_window()` and its helpers), found via a Dear ImGui
best-practices review:

- **Crash fix**: `Image::active_group_index()` guards against `reference_group == -1` being used to
  index `Image::groups` — reachable when a channel filter hides the active reference channel group
  without clearing the reference itself. Fixed at all 7 call sites.
- **Perf fix**: `TruncatedText()`'s O(n²) filename-truncation loop replaced with an O(n) backward
  glyph-advance walk (front-truncating, unlike `ImGui::RenderTextEllipsis`, since these rows show
  `file:part.layer.channel` paths where the meaningful part is the end). ~295x faster on a 500-char
  name, verified byte-identical output across 324 cases.
- **Refactor**: the three per-row drawers (image rows, flat channel-group rows, tree-mode layer-path
  rows) unified behind a shared `ImGui::TreeRow()` helper.
- **Bug fix**: scroll-to-selection (next/prev-image and next/prev-channel-group shortcuts) could get
  stuck indefinitely if the target row was scrolled outside the "images only" mode's `ImGuiListClipper`
  range — fixed via `clipper.IncludeItemsByIndex()`.
- **Cleanup**: a dead redundant `if (open)` guard, an image-row font push hoisted out of the per-row
  loop, and `PushRowColors()`'s per-row HSV-conversion caching.

### Not included: clipping flat/tree list modes

An attempt to extend `ImGuiListClipper` to flat/tree mode (currently only "images only" mode is
clipped; flat/tree mode draws every row every frame) was implemented and reverted after visual testing
showed it broke tree connector lines (`ImGuiTreeNodeFlags_DrawLinesFull`). Root cause: Dear ImGui draws
those lines from a node's `TreeNodeBehavior()` call down to its matching `TreePop()`'s cursor position,
which requires real nested draw calls across parent/child rows — incompatible with drawing rows
independently from a flattened, clipped list. This is a documented ImGui limitation
(`imgui_demo.cpp:8600`: *"Tree lines may not work in all situations (e.g. using a clipper)"*), not
specific to this implementation.

The underlying perf concern (many-channel EXRs drawing hundreds of rows every frame regardless of
scroll position) was never actually measured, so trading a visible feature for an unmeasured
optimization wasn't the right call. If revisited, it should follow Dear ImGui's own
`ExampleAppPropertyEditor::DrawClippedTree()` pattern (`imgui_demo.cpp`) — traverse-and-clip in place
rather than materializing a row list — and start with a real measurement.

## Test plan

- [x] `cmake --preset macos-arm64-cpm -DHDRVIEW_BUILD_TESTS=ON && cmake --build --preset macos-arm64-cpm-release`
- [x] `ctest --test-dir build/macos-arm64-cpm -C Release` — 34/34 passing
- [x] `HDRView --help` CLI smoke check
- [x] `clang-format` clean
- [x] Manually verified: reference-group crash repro (filtered reference channel, no crash), filename
      truncation (long paths still show their tail), tree connector lines intact, scroll-to-selection
      via next/prev shortcuts while scrolled away, row highlight colors including a theme switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
