### PR TITLE
Switch from the hello_imgui fork to upstream v1.92.900

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,26 +463,6 @@ set(IMGUI_DISABLE_OBSOLETE_FUNCTIONS ON)
 # Prevent dependencies from installing their files
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
 
-# Fork of pthom/hello_imgui (v1.92.700 + two commits) carrying the two changes HDRView needs for HDR
-# display output. Both are written to be proposed upstream as independent PRs, and are kept on separate
-# branches in the fork -- rebased onto upstream master, which is where they will be submitted -- so they
-# can go up that way:
-#
-#   before-swap-callback       Adds RunnerCallbacks::BeforeSwap, the only point in the render loop where an
-#                              app can run a final full-screen pass over the whole frame (ImGui's UI
-#                              included) and still have it presented. No HDR-specific code.
-#   glfw-opengl-float-buffer   Makes the *existing* RendererBackendOptions::requestFloatBuffer work on the
-#                              GLFW3+OpenGL backend, not just Metal. Probes with a throwaway hidden window
-#                              and writes back what was actually obtained.
-#
-# The `hdr-display` branch pinned here carries the same two commits, but based on v1.92.700 rather than
-# upstream master: master has since removed DpiFontLoadingFactor() (upstream f5b94f3, "Scale fonts for
-# HighDPI via style.FontScaleDpi"), which HDRView still uses in fonts.cpp and app-zoom.cpp. Moving HDRView
-# to upstream master is a separate font-DPI migration, unrelated to HDR. Both changes are
-# guarded by `#if defined(GLFW_FLOATBUFFER)`, so built against a vanilla GLFW this fork is byte-identical to
-# upstream hello_imgui (verified: the probe is compiled out entirely).
-#
-# Re-point at pthom/hello_imgui directly if/when the PRs are merged there.
 set(HELLOIMGUI_CPM_OPTIONS "HELLOIMGUI_EMSCRIPTEN_PTHREAD OFF" "HELLOIMGUI_EMSCRIPTEN_PTHREAD_ALLOW_MEMORY_GROWTH OFF"
                            "IMGUI_DISABLE_OBSOLETE_FUNCTIONS ON"
 )
@@ -492,10 +472,15 @@ if(HDRVIEW_BUILD_GUI_TESTS AND NOT EMSCRIPTEN)
   list(APPEND HELLOIMGUI_CPM_OPTIONS "HELLOIMGUI_WITH_TEST_ENGINE ON")
 endif()
 
+# HDR display output relies on two things here: RunnerCallbacks::BeforeSwap, the one point in the render
+# loop where a full-screen pass over the whole frame (Dear ImGui's UI included) is still presented, and
+# RendererBackendOptions::requestFloatBuffer on the GLFW3+OpenGL backend, not just Metal. The latter needs
+# a GLFW defining GLFW_FLOATBUFFER (see the Tom94/glfw pin above); against stock GLFW, Hello ImGui reports
+# back that no float framebuffer was obtained.
 CPMAddPackage(
   NAME hello_imgui
-  GITHUB_REPOSITORY wkjarosz/hello_imgui
-  GIT_TAG 74ef58fc219476685624c9cca6847c9792dd83da
+  GITHUB_REPOSITORY pthom/hello_imgui
+  GIT_TAG v1.92.900
   OPTIONS ${HELLOIMGUI_CPM_OPTIONS}
   EXCLUDE_FROM_ALL YES
   SYSTEM YES
@@ -516,7 +501,9 @@ else()
   message(FATAL_ERROR "Could not find or download hello_imgui library.")
 endif()
 
-CPMAddPackage("gh:epezent/implot#3da8bd34299965d3b0ab124df743fe3e076fa222")
+# Must track the Dear ImGui that hello_imgui vendors: implot draws through ImDrawList directly, and
+# IMGUI_DISABLE_OBSOLETE_FUNCTIONS (set above) deletes superseded overloads rather than keeping shims.
+CPMAddPackage("gh:epezent/implot#7eeb9168d2e5e6b14e266d8782ecf7e649dfc3a4")
 if(NOT implot_ADDED)
   message(FATAL_ERROR "Could not download implot library.")
 endif()

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -142,9 +142,6 @@ void HDRViewApp::draw_developer_windows()
                     {
                         ImPlot::SetupAxes("input", "encoded", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
 
-                        ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, 2.f);
-                        ImPlot::PushStyleVar(ImPlotStyleVar_MarkerSize, 2.f);
-
                         auto f = [](float x) { return to_linear(x, tf); };
                         auto g = [](float y) { return from_linear(y, tf); };
 
@@ -162,12 +159,15 @@ void HDRViewApp::draw_developer_windows()
                             xs2[i] = g(ys2[i]);
                         }
 
-                        ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
-                        ImPlot::PlotLine("to_linear", xs1, ys1, N);
-                        ImPlot::SetNextMarkerStyle(ImPlotMarker_Square);
-                        ImPlot::PlotLine("from_linear", xs2, ys2, N);
+                        ImPlotSpec spec;
+                        spec.LineWeight = 2.f;
+                        spec.MarkerSize = 2.f;
 
-                        ImPlot::PopStyleVar(2);
+                        spec.Marker = ImPlotMarker_Circle;
+                        ImPlot::PlotLine("to_linear", xs1, ys1, N, spec);
+                        spec.Marker = ImPlotMarker_Square;
+                        ImPlot::PlotLine("from_linear", xs2, ys2, N, spec);
+
                         ImPlot::EndPlot();
                     }
                     ImGui::EndTabItem();
@@ -179,9 +179,10 @@ void HDRViewApp::draw_developer_windows()
                     {
                         ImPlot::SetupAxes("Wavelength", "Intensity", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
 
-                        ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, 2.f);
-                        ImPlot::PushStyleVar(ImPlotStyleVar_MarkerSize, 2.f);
-                        ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
+                        ImPlotSpec spec;
+                        spec.LineWeight = 2.f;
+                        spec.Marker     = ImPlotMarker_Circle;
+                        spec.MarkerSize = 2.f;
 
                         for (WhitePoint n = WhitePoint_FirstNamed; n <= WhitePoint_LastNamed; ++n)
                         {
@@ -193,9 +194,8 @@ void HDRViewApp::draw_developer_windows()
                             ImPlot::PlotLine(name.c_str(), spectrum.values.data(), (int)spectrum.values.size(),
                                              (spectrum.max_wavelength - spectrum.min_wavelength) /
                                                  (spectrum.values.size() - 1),
-                                             spectrum.min_wavelength);
+                                             spectrum.min_wavelength, spec);
                         }
-                        ImPlot::PopStyleVar(3);
                         ImPlot::EndPlot();
                     }
                     ImGui::EndTabItem();
@@ -207,20 +207,22 @@ void HDRViewApp::draw_developer_windows()
                     {
                         ImPlot::SetupAxes("Wavelength", "Intensity", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
 
-                        ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, 2.f);
-                        ImPlot::PushStyleVar(ImPlotStyleVar_MarkerSize, 2.f);
-                        ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
+                        ImPlotSpec spec;
+                        spec.LineWeight = 2.f;
+                        spec.Marker     = ImPlotMarker_Circle;
+                        spec.MarkerSize = 2.f;
+                        // the three curves are interleaved in one float3 array
+                        spec.Stride = sizeof(float3);
 
                         auto &xyz       = CIE_XYZ_spectra();
                         auto  increment = (xyz.max_wavelength - xyz.min_wavelength) / xyz.values.size();
                         ImPlot::PlotLine("X", (const float *)&xyz.values[0].x, (int)xyz.values.size(), increment,
-                                         xyz.min_wavelength, ImPlotLineFlags_None, 0, sizeof(float3));
+                                         xyz.min_wavelength, spec);
                         ImPlot::PlotLine("Y", (const float *)&xyz.values[0].y, (int)xyz.values.size(), increment,
-                                         xyz.min_wavelength, ImPlotLineFlags_None, 0, sizeof(float3));
+                                         xyz.min_wavelength, spec);
                         ImPlot::PlotLine("Z", (const float *)&xyz.values[0].z, (int)xyz.values.size(), increment,
-                                         xyz.min_wavelength, ImPlotLineFlags_None, 0, sizeof(float3));
+                                         xyz.min_wavelength, spec);
 
-                        ImPlot::PopStyleVar(3);
                         ImPlot::EndPlot();
                     }
 

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -242,13 +242,10 @@ float4 HDRViewApp::tonemap_value(float4 value) const
 void HDRViewApp::calculate_viewport()
 {
     auto &io = ImGui::GetIO();
-    //
-    // calculate the viewport sizes
-    // fbsize is the size of the window in physical pixels while accounting for dpi factor on retina
-    // screens. For retina displays, io.DisplaySize is the size of the window in logical pixels so we it by
-    // io.DisplayFramebufferScale to get the physical pixel size for the framebuffer.
-    spdlog::trace("DisplayFramebufferScale: {}, DpiWindowSizeFactor: {}, DpiFontLoadingFactor: {}",
-                  float2{io.DisplayFramebufferScale}, DpiWindowSizeFactor(), DpiFontLoadingFactor());
+    // The viewport is the central dockspace node, falling back to the whole window before the dockspace
+    // exists. Both are in logical pixels, the same space as io.DisplaySize and ImGui's MousePos.
+    spdlog::trace("DisplayFramebufferScale: {}, DpiWindowSizeFactor: {}, FontScaleDpi: {}",
+                  float2{io.DisplayFramebufferScale}, DpiWindowSizeFactor(), ImGui::GetStyle().FontScaleDpi);
     m_viewport_min  = {0.f, 0.f};
     m_viewport_size = io.DisplaySize;
     if (auto id = m_params.dockingParams.dockSpaceIdFromName("MainDockSpace"))

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -322,21 +322,10 @@ void HDRViewApp::setup_platform_backend_callbacks(vector<string> in_files)
                                 hdrview()->load_images(arg);
                             });
 
-        // Our patched Hello ImGui clears requestFloatBuffer when the request could not be satisfied, so by
-        // now this is the *achieved* framebuffer, not the one we asked for. It drives the HDR-related UI
-        // below; the display's actual color space is queried separately, and per frame, by
-        // update_colorpass().
+        // Hello ImGui clears requestFloatBuffer when the request could not be satisfied, so by now this is
+        // the *achieved* framebuffer, not the one we asked for. It drives the HDR-related UI below; the
+        // display's actual color space is queried separately, and per frame, by update_colorpass().
         m_float_buffer = m_params.rendererBackendOptions.requestFloatBuffer;
-#if !defined(__APPLE__) && !defined(GLFW_FLOATBUFFER)
-        // ...but only our patched version does that. Stock Hello ImGui ignores requestFloatBuffer entirely
-        // on this backend and leaves it set, so trusting the read-back above would claim a float buffer we
-        // never got (this is the Emscripten build, and any desktop build with HDRVIEW_ENABLE_HDR_DISPLAY
-        // off). Without GLFW_FLOATBUFFER no float framebuffer is obtainable here in the first place.
-        //
-        // Once the upstream PR (see the hello_imgui pin in CMakeLists.txt) is merged, delete this block and
-        // just rely on the documented contract: Hello ImGui resets the field when it cannot satisfy it.
-        m_float_buffer = false;
-#endif
         spdlog::info("Got a {} framebuffer.", m_float_buffer ? "floating-point precision" : "standard precision");
 
         // Seed the display color space before the first frame so startup logs and the UI are right from the

--- a/src/fonts.cpp
+++ b/src/fonts.cpp
@@ -51,27 +51,29 @@ void HDRViewApp::load_fonts()
         iconFontParams.mergeToLastFont       = true;
         iconFontParams.fontConfig.PixelSnapH = true;
 
+        // Fonts load at their nominal size; ImGui bakes them on demand at nominal * style.FontScaleDpi,
+        // which Hello ImGui sets from the display's DPI factor. The glyph metrics below are nominal for
+        // the same reason: ImGui rescales them by the baked size over the merged-into font's own size.
 #if defined(HDRVIEW_ICONSET_FA6)
         auto icon_font_size                        = 0.85f * size;
         iconFontParams.fontConfig.GlyphMinAdvanceX = iconFontParams.fontConfig.GlyphMaxAdvanceX =
-            icon_font_size * DpiFontLoadingFactor() * 1.25f;
-        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * DpiFontLoadingFactor() * 0.05f;
+            icon_font_size * 1.25f;
+        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * 0.05f;
 #elif defined(HDRVIEW_ICONSET_LC)
         auto icon_font_size                     = size;
-        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * DpiFontLoadingFactor() * 0.03f;
-        iconFontParams.fontConfig.GlyphOffset.y = icon_font_size * DpiFontLoadingFactor() * 0.20f;
+        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * 0.03f;
+        iconFontParams.fontConfig.GlyphOffset.y = icon_font_size * 0.20f;
 #elif defined(HDRVIEW_ICONSET_MS)
         auto icon_font_size                     = 1.28571429f * size;
-        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * DpiFontLoadingFactor() * 0.01f;
-        iconFontParams.fontConfig.GlyphOffset.y = icon_font_size * DpiFontLoadingFactor() * 0.2f;
+        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * 0.01f;
+        iconFontParams.fontConfig.GlyphOffset.y = icon_font_size * 0.2f;
 #elif defined(HDRVIEW_ICONSET_MD)
         auto icon_font_size                     = size;
-        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * DpiFontLoadingFactor() * 0.01f;
-        iconFontParams.fontConfig.GlyphOffset.y = icon_font_size * DpiFontLoadingFactor() * 0.2f;
+        iconFontParams.fontConfig.GlyphOffset.x = icon_font_size * 0.01f;
+        iconFontParams.fontConfig.GlyphOffset.y = icon_font_size * 0.2f;
 #elif defined(HDRVIEW_ICONSET_MDI)
         auto icon_font_size                   = size;
-        iconFontParams.fontConfig.GlyphOffset = icon_font_size * DpiFontLoadingFactor() * float2{0.02f, 0.1f};
-
+        iconFontParams.fontConfig.GlyphOffset = icon_font_size * float2{0.02f, 0.1f};
 #endif
         return LoadFont(FONT_ICON_FILE_NAME_MY, icon_font_size, iconFontParams);
     };

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -229,27 +229,26 @@ void Image::draw_histogram()
         {
             // PlotStairs holds each x[i]'s y-value constant across [x[i], x[i+1)), so hist_xs (each bin's
             // left edge) rather than a bin center is what aligns the steps with the true bin boundaries.
-            ImPlot::PushStyleColor(ImPlotCol_Fill, float4{0.f});
-            ImPlot::PushStyleColor(ImPlotCol_Line, float4{colors[c].xyz(), 1.0f});
+            ImPlotSpec spec;
+            spec.LineColor = float4{colors[c].xyz(), 1.0f};
+            spec.FillColor = float4{0.f};
             ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
-                               PixelStats::NUM_BINS);
-            ImPlot::PopStyleColor(2);
+                               PixelStats::NUM_BINS, spec);
         }
 
         if (contains(hovered_pixel) && hdrview()->mouse_over_viewport())
         {
             for (int c = 0; c < std::min(4, group.num_channels); ++c)
             {
-                ImPlot::PushStyleColor(ImPlotCol_Fill, float4{0.f});
-                ImPlot::PushStyleColor(ImPlotCol_Line, float4{colors[c].xyz(), 1.0f});
-
-                ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle, 2.f);
+                ImPlotSpec spec;
+                spec.LineColor  = float4{colors[c].xyz(), 1.0f};
+                spec.FillColor  = float4{0.f};
+                spec.Marker     = ImPlotMarker_Circle;
+                spec.MarkerSize = 2.f;
                 ImPlot::PlotStems(fmt::format("##hover_{}", c).c_str(), &color32[c],
-                                  &stats[c]->bin_y(stats[c]->value_to_bin(color32[c])), 1, 0);
+                                  &stats[c]->bin_y(stats[c]->value_to_bin(color32[c])), 1, 0, spec);
 
                 ImPlot::TagX(color32[c], float4{colors[c].xyz(), 1.0f}, "%s", "");
-
-                ImPlot::PopStyleColor(2);
             }
         }
 
@@ -969,7 +968,7 @@ void Image::draw_chromaticity_diagram(float width)
             }
 
             ImPlot::GetPlotDrawList()->AddPolyline((ImVec2 *)&poly[0], poly.Size, ImGui::GetColorU32(text_color_f),
-                                                   ImDrawFlags_Closed, std::max(1.f, 1.2f * pixels_per_texel));
+                                                   std::max(1.f, 1.2f * pixels_per_texel), ImDrawFlags_Closed);
         }
 
         //
@@ -1001,9 +1000,11 @@ void Image::draw_chromaticity_diagram(float width)
                 // Tick mark parameters
                 float2 tick[2] = {pos, pos + normal};
 
-                ImPlot::SetNextMarkerStyle(ImPlotMarker_None);
-                ImPlot::SetNextLineStyle({0.f, 0.f, 0.f, 1.f}, 0.5f * scale_factor);
-                ImPlot::PlotLine("##CCT_tick", &tick[0].x, &tick[0].y, 2, 0, 0, sizeof(float2));
+                ImPlotSpec tick_spec;
+                tick_spec.LineColor  = ImVec4{0.f, 0.f, 0.f, 1.f};
+                tick_spec.LineWeight = 0.5f * scale_factor;
+                tick_spec.Stride     = sizeof(float2);
+                ImPlot::PlotLine("##CCT_tick", &tick[0].x, &tick[0].y, 2, tick_spec);
 
                 // Add text label for major ticks (100 nm multiples)
                 if (is_major)
@@ -1046,7 +1047,7 @@ void Image::draw_chromaticity_diagram(float width)
             for (int i = 0; i < poly.Size; ++i) poly[i] = ImPlot::PlotToPixels({poly[i].x, poly[i].y});
 
             ImPlot::GetPlotDrawList()->AddPolyline((ImVec2 *)&poly[0], poly.Size, ImGui::GetColorU32(text_color_f),
-                                                   ImDrawFlags_None, scale_factor);
+                                                   scale_factor, ImDrawFlags_None);
 
             const float label_font_scale = 1.0f;
             const float scale            = 1.f;
@@ -1082,9 +1083,11 @@ void Image::draw_chromaticity_diagram(float width)
 
                 if (draw)
                 {
-                    ImPlot::SetNextMarkerStyle(ImPlotMarker_None);
-                    ImPlot::SetNextLineStyle(text_color_f, 0.5f * scale_factor);
-                    ImPlot::PlotLine("##CCT_tick", &tick[0].x, &tick[0].y, 2, 0, 0, sizeof(float2));
+                    ImPlotSpec tick_spec;
+                    tick_spec.LineColor  = text_color_f;
+                    tick_spec.LineWeight = 0.5f * scale_factor;
+                    tick_spec.Stride     = sizeof(float2);
+                    ImPlot::PlotLine("##CCT_tick", &tick[0].x, &tick[0].y, 2, tick_spec);
                     prev_tick_end = tick[1];
 
                     ImPlot::Annotation(tick[1].x, tick[1].y, ImVec4(1, 1, 1, 0.5), ImVec2(1, 1), false, "%s", label);
@@ -1110,10 +1113,11 @@ void Image::draw_chromaticity_diagram(float width)
 
             primaries[3] = double2(gamut_chr.red);
 
-            ImPlot::SetNextMarkerStyle(ImPlotMarker_None);
-            ImPlot::SetNextLineStyle(text_color_fc, scale_factor);
-            ImPlot::PlotLine("##gamut_triangle", &primaries[0].x, &primaries[0].y, 4, ImPlotLineFlags_None, 0,
-                             sizeof(double2));
+            ImPlotSpec triangle_spec;
+            triangle_spec.LineColor  = text_color_fc;
+            triangle_spec.LineWeight = scale_factor;
+            triangle_spec.Stride     = sizeof(double2);
+            ImPlot::PlotLine("##gamut_triangle", &primaries[0].x, &primaries[0].y, 4, triangle_spec);
 
             primaries[3] = double2(gamut_chr.white);
 
@@ -1127,12 +1131,6 @@ void Image::draw_chromaticity_diagram(float width)
                 ImPlot::GetPlotDrawList()->AddCircleFilled(
                     poly[i], 2.5f * scale_factor,
                     ImGui::GetColorU32(clicked[i] || hovered[i] || held[i] ? text_color_f : text_color_fc), 0);
-
-            // ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle, 5.f);
-            // ImPlot::SetNextLineStyle(ImVec4{0.f, 0.f, 0.f, 1.0f});
-            // ImPlot::PlotScatter("##white_point", &primaries[3].x, &primaries[3].y, 1,
-            // ImPlotScatterFlags_None,
-            //                     0, sizeof(double2));
 
             ImGui::PushFont(hdrview()->font("sans bold"), ImGui::GetStyle().FontSizeBase);
             for (int i = 0; i < 4; ++i)
@@ -1175,8 +1173,6 @@ void Image::draw_chromaticity_diagram(float width)
         {
             auto &io      = ImGui::GetIO();
             auto  rgb2xyz = mul(M_RGB_to_XYZ, inverse(M_to_sRGB));
-            ImPlot::PushStyleColor(ImPlotCol_Line, ImVec4{0.f, 0.f, 0.f, 1.0f});
-            ImPlot::PushStyleVar(ImPlotStyleVar_MarkerSize, 2.f);
             if (hdrview()->mouse_over_viewport())
             {
                 auto   hovered_pixel = int2{hdrview()->pixel_at_app_pos(io.MousePos)};
@@ -1185,10 +1181,11 @@ void Image::draw_chromaticity_diagram(float width)
                 float3 XYZ = mul(rgb2xyz, color32.xyz());
                 float2 xy  = XYZ.xy() / (XYZ.x + XYZ.y + XYZ.z);
 
-                ImPlot::PlotScatter("##HoveredPixel", &xy.x, &xy.y, 1);
+                ImPlotSpec spec;
+                spec.LineColor  = ImVec4{0.f, 0.f, 0.f, 1.0f};
+                spec.MarkerSize = 2.f;
+                ImPlot::PlotScatter("##HoveredPixel", &xy.x, &xy.y, 1, spec);
             }
-            ImPlot::PopStyleColor();
-            ImPlot::PopStyleVar();
         }
         ImPlot::PopPlotClipRect();
 

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -837,7 +837,7 @@ void DrawLabeledRect(ImDrawList *draw_list, const Box2f &rect, ImU32 col, const 
     constexpr float2 fudge     = float2{thickness * 0.5f - 0.5f, -(thickness * 0.5f - 0.5f)};
     const float2     pad       = float2{0.25, 0.125} * ImGui::GetFontSize();
 
-    draw_list->AddRect(rect.min, rect.max, col, 0.f, ImDrawFlags_None, thickness);
+    draw_list->AddRect(rect.min, rect.max, col, 0.f, thickness, ImDrawFlags_None);
 
     if (!draw_label)
         return;
@@ -1053,9 +1053,8 @@ DialogResult DialogButtons(const char *confirm_label, const char *cancel_label, 
     ImGui::SameLine();
 
     ImGui::BeginDisabled(!confirm_enabled);
-    if (ImGui::Button(confirm_label) ||
-        (confirm_enabled && use_shortcuts && !ImGui::GetIO().NavVisible &&
-         ImGui::Shortcut(ImGuiMod_Ctrl | ImGuiKey_Enter)))
+    if (ImGui::Button(confirm_label) || (confirm_enabled && use_shortcuts && !ImGui::GetIO().NavVisible &&
+                                         ImGui::Shortcut(ImGuiMod_Ctrl | ImGuiKey_Enter)))
         result = DialogResult::Confirm;
     ImGui::EndDisabled();
 

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -330,7 +330,11 @@ void Theme::load(json j)
             read_float1("DockingSeparatorSize", style.DockingSeparatorSize);
             read_float1("FontSizeBase", style.FontSizeBase);
             read_float1("FontScaleMain", style.FontScaleMain);
-            read_float1("FontScaleDpi", style.FontScaleDpi);
+            // FontScaleDpi belongs to Hello ImGui, which sets it from the current display, so a value
+            // saved against a different monitor must not be restored over it. Files still carrying the key
+            // have the DPI factor baked into FontSizeBase instead; divide it back out. Saving drops the key.
+            if (j_style.contains("FontScaleDpi") && style.FontScaleDpi > 0.f)
+                style.FontSizeBase /= style.FontScaleDpi;
             read_float1("CircleTessellationMaxError", style.CircleTessellationMaxError);
             if (j_style.contains("WindowMenuButtonPosition"))
                 style.WindowMenuButtonPosition = (ImGuiDir)j_style["WindowMenuButtonPosition"].get<int>();
@@ -417,7 +421,6 @@ void Theme::save(json &j, float dpiWindowSizeFactor) const
     j_style["DockingSeparatorSize"]        = style.DockingSeparatorSize;
     j_style["FontSizeBase"]                = style.FontSizeBase;
     j_style["FontScaleMain"]               = style.FontScaleMain;
-    j_style["FontScaleDpi"]                = style.FontScaleDpi;
     j_style["CircleTessellationMaxError"]  = style.CircleTessellationMaxError;
     j_style["WindowMenuButtonPosition"]    = (int)style.WindowMenuButtonPosition;
 

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -205,8 +205,17 @@ const char *Theme::name(int t)
 
 static void apply(int theme)
 {
+    // Applying a theme replaces the whole ImGuiStyle. FontScaleDpi belongs to Hello ImGui, which sets it
+    // from the display's DPI, so carry it across.
+    float dpi_scale = ImGui::GetStyle().FontScaleDpi;
+
     if (theme >= 0)
     {
+        // A built-in theme's style function starts from the live style and sets only the fields it
+        // defines, so reset first: otherwise it inherits the previous theme's geometry, DPI scaling
+        // included.
+        ImGui::GetStyle() = ImGuiStyle();
+
         ImGuiTheme::ImGuiTheme_ t                               = (ImGuiTheme::ImGuiTheme_)theme;
         GetRunnerParams()->imGuiWindowParams.tweakedTheme.Theme = t;
         ImGuiTheme::ApplyTheme(t);
@@ -217,6 +226,9 @@ static void apply(int theme)
         apply_hdrview_light_theme();
 
     // otherwise, its a custom theme, and we keep the parameters that were read from the config file
+
+    if (theme != Theme::CUSTOM_THEME)
+        ImGui::GetStyle().FontScaleDpi = dpi_scale;
 }
 
 void Theme::set(int t)
@@ -231,6 +243,16 @@ void Theme::set(int t)
     theme = t;
 
     apply(theme);
+
+    // apply() leaves non-custom themes at nominal, DPI-unscaled geometry. Hello ImGui scales geometry for
+    // DPI only on the second frame after startup (HandleDpiOnSecondFrame()), so a theme set after that
+    // needs it reapplied here.
+    if (theme != CUSTOM_THEME)
+    {
+        float dpi_scale = GetRunnerParams()->dpiAwareParams.dpiWindowSizeFactor;
+        if (dpi_scale > 1.f)
+            ImGui::GetStyle().ScaleAllSizes(dpi_scale);
+    }
 }
 
 void Theme::load(json j)


### PR DESCRIPTION
Both changes HDRView carried in `wkjarosz/hello_imgui` are now upstream, so the pin moves back to `pthom/hello_imgui` at [v1.92.900](https://github.com/pthom/hello_imgui/releases/tag/v1.92.900): `RunnerCallbacks::BeforeSwap`, and a `requestFloatBuffer` that works on the GLFW3+OpenGL backend rather than Metal only.

## Font DPI migration

v1.92.900 removes `FontLoadingParams::adjustSizeToDpi` and `DpiFontLoadingFactor()`. Fonts now load at their nominal size and are scaled at display time via `ImGui::GetStyle().FontScaleDpi`, which the runner sets from the display's DPI factor.

`ImFontConfig`'s glyph offsets/advances are rescaled by the ratio of the baked size to the merged-into font's `SizePixels`, so they become nominal too. Dropping the `DpiFontLoadingFactor()` multiplications in `fonts.cpp` is the entire migration — the ratios are preserved exactly.

## Persisted custom theme

This flips which style field carries the DPI factor, and `theme.cpp` persists both:

- `FontSizeBase` is now DPI-free and safe to save. It previously was not, which was a latent cross-monitor bug.
- `FontScaleDpi` belongs to Hello ImGui, and is restored *after* the runner sets it — persisting it would overwrite a correct value with a stale one. It is no longer saved or restored.

An existing settings file still carrying `FontScaleDpi` has the factor baked into `FontSizeBase`, so it is divided back out once on load. Without that, an existing Custom theme on a HiDPI display would come up at double text size.

## Dropped workaround

Upstream now clears `requestFloatBuffer` itself when no float framebuffer is obtainable, on both the GLFW3 and Emscripten paths, so the block in `app.cpp` compensating for stock Hello ImGui is gone — as its own comment said to do once merged.

## implot

v1.92.900 vendors Dear ImGui 1.92.9b, which deletes the pre-1.92.8 `ImDrawList::AddRect`/`AddPolyline` argument orders under `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`. HDRView's own three call sites are swapped to the current order, and implot needs bumping for the same reason.

Every implot commit carrying that fix postdates implot v1.0, which replaced `SetNextLineStyle`/`SetNextMarkerStyle` and the per-item `ImPlotStyleVar_`/`ImPlotCol_` push/pop pairs with an `ImPlotSpec` passed to each `Plot*` call. The plotting code in `app-windows.cpp` and `image-gui.cpp` moves to that API.

## Testing

Clean build and 39/39 `ctest` pass on `macos-arm64-cpm` Release, including `hdrview_gui_tests`, plus the `--help` smoke check.

Two caveats for review:

- **The migrated plots are unverified visually.** The GUI suite proves they render without asserting, not that they look right. Affected surfaces: the histogram, the chromaticity diagram (gamut triangle, CCT ticks, hovered-pixel marker), and the three developer-window plots.
- **macOS only so far.** Linux/Windows/Emscripten are untested locally; the dropped float-buffer block is on the non-Apple path specifically, so CI on those platforms is the real check.

One unrelated cleanup rode along: `calculate_viewport()` carried a stale comment describing an `fbsize` variable and a `DisplayFramebufferScale` division that the function does not do. Happy to drop that hunk if you'd rather keep this strictly to the dependency swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)