### PR TITLE
Histogram legend, resizing, and split clip warnings; status bar and Colorspace layout

### DIFF
--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -95,7 +95,7 @@ layout(binding=1) uniform fs_params {
     int   secondary_channels_type;
     mat4  secondary_M_to_sRGB;
     float time;
-    int   draw_clip_warnings;
+    ivec2 clip_warnings;
     vec2  clip_range;
 } fsp;
 
@@ -272,11 +272,13 @@ void main()
     vec4  blended    = linearToSRGB(tonemapped);
     vec4  dithered   = dither(blended);
     dithered         = clamp(dithered, fsp.clamp_to_LDR != 0 ? 0.0 : -64.0, fsp.clamp_to_LDR != 0 ? 1.0 : 64.0);
-    if (fsp.draw_clip_warnings != 0)
-    {
+    // Stripe only where the value came from real image data: sample_channel() returns 0 outside a data
+    // window, which the shadow test would otherwise read as crushed black across the whole background.
+    bool in_data = in_img || (fsp.has_reference != 0 && in_ref);
+    if (in_data && fsp.clip_warnings.y != 0)
         dithered.rgb = mix(dithered.rgb, vec3(zebra1), clipped);
+    if (in_data && fsp.clip_warnings.x != 0)
         dithered.rgb = mix(dithered.rgb, vec3(zebra2), crushed);
-    }
     frag_color = vec4(dithered.rgb, 1.0);
 }
 @end

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -273,7 +273,7 @@ void HDRViewApp::draw_image() const
         // fs_params/vs_params are GLSL uniform blocks (see image-shader.sglsl); booleans are `int` there
         // since GLSL uniform blocks cannot contain `bool` members.
         m_shader->set_uniform_block("fsp", {{"time", (float)ImGui::GetTime()},
-                                            {"draw_clip_warnings", (int)m_draw_clip_warnings},
+                                            {"clip_warnings", int2{m_clip_warnings}},
                                             {"clip_range", m_clip_range},
                                             {"randomness", randomness},
                                             {"gain", powf(2.0f, m_exposure_live)},

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -796,7 +796,7 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
     view["auto_fit_selection"] = m_auto_fit_selection;
     view["draw_grid"]          = m_draw_grid;
     view["draw_pixel_info"]    = m_draw_pixel_info;
-    view["draw_clip_warnings"] = m_draw_clip_warnings;
+    view["clip_warnings"]      = m_clip_warnings;
     view["clip_range"]         = m_clip_range;
     view["roi"]                = json::array();
     view["roi"].push_back(m_roi.min);
@@ -1176,8 +1176,11 @@ void HDRViewApp::finish_pending_session()
     m_auto_fit_selection = view.value<bool>("auto_fit_selection", m_auto_fit_selection);
     m_draw_grid          = view.value<bool>("draw_grid", m_draw_grid);
     m_draw_pixel_info    = view.value<bool>("draw_pixel_info", m_draw_pixel_info);
-    m_draw_clip_warnings = view.value<bool>("draw_clip_warnings", m_draw_clip_warnings);
-    m_clip_range         = view.value<float2>("clip_range", m_clip_range);
+    // "draw_clip_warnings" is the older key, a single toggle covering both ends; fall back to it so sessions
+    // written by an earlier version still restore their clip warnings
+    bool both       = view.value<bool>("draw_clip_warnings", false);
+    m_clip_warnings = view.value<bool2>("clip_warnings", bool2{both, both});
+    m_clip_range    = view.value<float2>("clip_range", m_clip_range);
     if (view.contains("roi") && view["roi"].is_array() && view["roi"].size() == 2)
     {
         view["roi"][0].get_to(m_roi.min);

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -436,12 +436,29 @@ void HDRViewApp::draw_menus()
         ImGui::SameLine();
         ImGui::TextUnformatted("Clip warnings");
         ImGui::SameLine();
-        ImGui::Checkbox("##Draw clip warnings", &m_draw_clip_warnings);
-        ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
-        ImGui::BeginDisabled(!m_draw_clip_warnings);
-        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemInnerSpacing.x);
-        ImGui::DragFloatRange2("##Clip warnings", &m_clip_range.x, &m_clip_range.y, 0.01f, 0.f, 0.f, "min: %.01f",
-                               "max: %.01f");
+        // Each end's checkbox is followed by its own bound, so enabling one end never hands the user the
+        // other's draggable. The two bounds still can't cross, as a DragFloatRange2 would have enforced.
+        const float inner_sp = ImGui::GetStyle().ItemInnerSpacing.x;
+        const float drag_w   = ImMax(
+            0.5f * (ImGui::GetContentRegionAvail().x - 2.f * ImGui::GetFrameHeight() - 4.f * inner_sp), EmSize(4.f));
+
+        ImGui::Checkbox("##Shadow clipping", &m_clip_warnings.x);
+        ImGui::SetItemTooltip("Zebra-stripe values below the low clip bound.");
+        ImGui::SameLine(0.f, inner_sp);
+        ImGui::BeginDisabled(!m_clip_warnings.x);
+        ImGui::SetNextItemWidth(drag_w);
+        if (ImGui::DragFloat("##Low clip bound", &m_clip_range.x, 0.01f, 0.f, 0.f, "min: %.3f"))
+            m_clip_range.x = std::min(m_clip_range.x, m_clip_range.y);
+        ImGui::EndDisabled();
+
+        ImGui::SameLine(0.f, inner_sp);
+        ImGui::Checkbox("##Highlight clipping", &m_clip_warnings.y);
+        ImGui::SetItemTooltip("Zebra-stripe values above the high clip bound.");
+        ImGui::SameLine(0.f, inner_sp);
+        ImGui::BeginDisabled(!m_clip_warnings.y);
+        ImGui::SetNextItemWidth(drag_w);
+        if (ImGui::DragFloat("##High clip bound", &m_clip_range.y, 0.01f, 0.f, 0.f, "max: %.3f"))
+            m_clip_range.y = std::max(m_clip_range.y, m_clip_range.x);
         ImGui::EndDisabled();
         ImGui::PopStyleVar();
         ImGui::EndMenu();

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -98,11 +98,13 @@ void HDRViewApp::draw_status_bar()
     // this callback runs; override the starting cursor position with a smaller explicit top margin
     // instead of accepting that default. Tune this constant directly to adjust the bar's top margin.
     const float top_margin = HelloImGui::EmSize(0.25f);
-    ImGui::SetCursorPosY(top_margin);
 
     const float item_spacing = ImGui::GetStyle().ItemSpacing.x;
     float       badge_x, reserved_w; // set inside the badge block below, used by the zones that follow it
 
+    auto fpy = ImGui::GetStyle().FramePadding.y;
+    ImGui::PushStyleVarY(ImGuiStyleVar_FramePadding, 1.f);
+    ImGui::SetCursorPosY(top_margin + fpy);
     {
         // drawn first so it always sits at a fixed position at the far left, regardless of whatever
         // transient content (progress bars, etc.) follows
@@ -190,6 +192,7 @@ void HDRViewApp::draw_status_bar()
     // whatever follows never has to move depending on it
     const float progress_w = EmSize(15.f);
     const float progress_x = badge_x + reserved_w + item_spacing;
+
     if (auto num = m_image_loader.num_pending_images())
     {
         ImGui::SetCursorPosX(progress_x);
@@ -236,7 +239,10 @@ void HDRViewApp::draw_status_bar()
 
         const float drag_size = EmSize(5.f);
         const float inner_sp  = ImGui::GetStyle().ItemInnerSpacing.x;
-        const float hover_w   = 2.f * drag_size + 2.f * inner_sp + EmSize(0.5f) + inner_sp + EmSize(25.f);
+        // width the color row is given below; also part of the fit test, so the zone is only drawn when the
+        // whole thing -- coordinates, "=", color row -- clears the right-aligned zoom text
+        const float color_w = EmSize(18.f);
+        const float hover_w = 2.f * drag_size + 2.f * inner_sp + EmSize(0.5f) + inner_sp + color_w;
 
         // last_hovered_pixel() freezes at the last real hover instead of clearing when the mouse leaves
         // the viewport, so the color widget below stays reachable (e.g. to click its dropdown) instead
@@ -258,35 +264,25 @@ void HDRViewApp::draw_status_bar()
                 }
 
                 ImGui::SameLine(hover_x);
-                auto fpy = ImGui::GetStyle().FramePadding.y;
-                ImGui::PushStyleVarY(ImGuiStyleVar_FramePadding, 0.f);
-                auto y = ImGui::GetCursorPosY();
                 // ReadOnly alone doesn't block DragInt's drag gesture, only keyboard entry -- these
                 // coordinates track the live hover position and were never meant to be draggable at all.
                 ImGui::BeginDisabled();
-                ImGui::SetCursorPosY(y + fpy);
                 ImGui::SetNextItemWidth(drag_size);
                 ImGui::DragInt("##pixel x coordinates", &hovered_pixel.x, 1.f, 0, 0, "X: %d",
                                ImGuiInputTextFlags_ReadOnly);
                 ImGui::SameLine(0.f, inner_sp);
-                ImGui::SetCursorPosY(y + fpy);
                 ImGui::SetNextItemWidth(drag_size);
                 ImGui::DragInt("##pixel y coordinates", &hovered_pixel.y, 1.f, 0, 0, "Y: %d",
                                ImGuiInputTextFlags_ReadOnly);
                 ImGui::EndDisabled();
-                ImGui::PopStyleVar();
 
                 float x = hover_x + 2.f * drag_size + 2.f * inner_sp;
                 sized_text(x, 0.5f, "=", 0.5f);
 
                 ImGui::PushID("Current");
                 ImGui::SameLine(x);
-                // pixel_color_widget no longer bakes in compact styling itself, so opt in here to match the
-                // X/Y drag boxes above, and nudge down by the same backed-up fpy to stay on "="'s baseline
-                ImGui::PushStyleVarY(ImGuiStyleVar_FramePadding, 0.f);
-                ImGui::SetCursorPosY(y + fpy);
-                pixel_color_widget(hovered_pixel, m_status_color_mode, 2, false, EmSize(25.f));
-                ImGui::PopStyleVar();
+                pixel_color_widget(hovered_pixel, m_status_color_mode, 2, false, color_w);
+
                 ImGui::PopID();
             }
         }
@@ -303,6 +299,7 @@ void HDRViewApp::draw_status_bar()
         ImGui::AlignTextToFramePadding();
         ImGui::Text("FPS: %.1f%s", FrameRate(), m_params.fpsIdling.isIdling ? " (Idling)" : "");
     }
+    ImGui::PopStyleVar();
 }
 
 void HDRViewApp::draw_menus()

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -416,12 +416,16 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
                 m_dither               = j.value<bool>("dither", m_dither);
                 m_file_list_mode       = j.value<int>("file list mode", m_file_list_mode);
                 m_short_names          = j.value<bool>("short names", m_short_names);
-                m_draw_clip_warnings   = j.value<bool>("draw clip warnings", m_draw_clip_warnings);
-                m_show_FPS             = j.value<bool>("show FPS", m_show_FPS);
-                m_clip_range           = j.value<float2>("clip range", m_clip_range);
-                m_playback_speed       = j.value<float>("playback speed", m_playback_speed);
-                m_colormap_index       = clamp<int>(j.value<int>("colormap index", 0), 0, std::size(m_colormaps));
-                m_show_developer_menu  = j.value<bool>("show developer menu", m_show_developer_menu);
+                // "draw clip warnings" is the older key, a single toggle covering both ends; fall back to it
+                // so settings written by an earlier version still take effect
+                bool both             = j.value<bool>("draw clip warnings", false);
+                m_clip_warnings       = j.value<bool2>("clip warnings", bool2{both, both});
+                m_show_FPS            = j.value<bool>("show FPS", m_show_FPS);
+                m_clip_range          = j.value<float2>("clip range", m_clip_range);
+                m_histogram_height    = j.value<float>("histogram height", m_histogram_height);
+                m_playback_speed      = j.value<float>("playback speed", m_playback_speed);
+                m_colormap_index      = clamp<int>(j.value<int>("colormap index", 0), 0, std::size(m_colormaps));
+                m_show_developer_menu = j.value<bool>("show developer menu", m_show_developer_menu);
             }
             catch (json::exception &e)
             {
@@ -484,9 +488,10 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
         j["verbosity"]               = spdlog::get_level();
         j["file list mode"]          = m_file_list_mode;
         j["short names"]             = m_short_names;
-        j["draw clip warnings"]      = m_draw_clip_warnings;
+        j["clip warnings"]           = m_clip_warnings;
         j["show FPS"]                = m_show_FPS;
         j["clip range"]              = m_clip_range;
+        j["histogram height"]        = m_histogram_height;
         j["show developer menu"]     = m_show_developer_menu;
         j["playback speed"]          = m_playback_speed;
         j["colormap index"]          = m_colormap_index;
@@ -1080,14 +1085,22 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                    false,
                    &m_clamp_to_LDR});
         add(Action{{"Dither"}, ICON_MY_DITHER, 0, 0, []() {}, always_enabled, false, &m_dither});
-        add(Action{{"Clip warnings", "Zebra stripes"},
+        add(Action{{"Shadow clipping", "Zebra stripes: shadows"},
                    ICON_MY_ZEBRA_STRIPES,
                    0,
                    0,
                    []() {},
                    always_enabled,
                    false,
-                   &m_draw_clip_warnings});
+                   &m_clip_warnings.x});
+        add(Action{{"Highlight clipping", "Zebra stripes: highlights"},
+                   ICON_MY_ZEBRA_STRIPES,
+                   0,
+                   0,
+                   []() {},
+                   always_enabled,
+                   false,
+                   &m_clip_warnings.y});
 
         add(Action{{"Draw pixel grid"},
                    ICON_MY_SHOW_GRID,

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -209,7 +209,10 @@ HDRViewApp::WindowSetupInfo HDRViewApp::setup_dockable_windows()
                                          if (auto img = current_image())
                                              return img->draw_colorspace();
                                      }};
-    colorspace_window.imGuiWindowFlags = ImGuiWindowFlags_HorizontalScrollbar;
+    // The vertical scrollbar is unconditional: the chromaticity diagram's height is locked to the available
+    // width, so a scrollbar toggling in and out would resize the diagram, which can toggle it again every frame.
+    colorspace_window.imGuiWindowFlags =
+        ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysVerticalScrollbar;
 
     DockableWindow log_window{
         "Log", "LogSpace",

--- a/src/app.h
+++ b/src/app.h
@@ -225,10 +225,14 @@ public:
     bool       &draw_pixel_info_on() { return m_draw_pixel_info; }
     AxisScale  &histogram_x_scale() { return m_x_scale; }
     AxisScale  &histogram_y_scale() { return m_y_scale; }
+    float      &histogram_height() { return m_histogram_height; }
     Box2i      &roi_live() { return m_roi_live; }
     Box2i      &roi() { return m_roi; }
-    bool       &draw_clip_warnings() { return m_draw_clip_warnings; }
+    bool2      &clip_warnings() { return m_clip_warnings; }
     float2     &clip_range() { return m_clip_range; }
+
+    /// Height of the Pixel statistics histogram plot, in em, when it has never been resized
+    static constexpr float default_histogram_height = 9.f;
 
 private:
     void load_fonts();
@@ -379,11 +383,13 @@ private:
     float m_exposure = 0.f, m_exposure_live = 0.f, m_offset = 0.f, m_offset_live = 0.f, m_gamma = 1.0f,
           m_gamma_live  = 1.0f;
     AxisScale m_x_scale = AxisScale_Asinh, m_y_scale = AxisScale_Linear;
+    float     m_histogram_height = default_histogram_height;
 
     bool m_clamp_to_LDR = false, m_dither = true, m_draw_grid = true, m_draw_pixel_info = true,
-         m_draw_watched_pixels = true, m_draw_data_window = true, m_draw_display_window = true,
-         m_draw_clip_warnings = false, m_show_FPS = false;
-    float2 m_clip_range{0.f, 1.f}; ///< Values outside this range will have zebra stripes if m_draw_clip_warnings = true
+         m_draw_watched_pixels = true, m_draw_data_window = true, m_draw_display_window = true, m_show_FPS = false;
+    /// Zebra-stripe values below clip_range.x (x: shadows) and above clip_range.y (y: highlights)
+    bool2  m_clip_warnings{false, false};
+    float2 m_clip_range{0.f, 1.f};
     Box2i  m_roi{int2{0}}, m_roi_live{int2{0}};
 
     Tonemap_                   m_tonemap     = Tonemap_Gamma;

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1204,12 +1204,9 @@ void Image::draw_colorspace()
     auto bold_font = hdrview()->font("sans bold");
 
     static const ImGuiTableFlags table_flags = ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize;
-    ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32_BLACK_TRANS);
-    // Scroll this child rather than the table: a table's own ScrollY has no way to reserve scrollbar space
-    // unconditionally, so toggling it in and out changes the available width, which changes the height of the
-    // width-locked chromaticity diagram below, which can toggle the scrollbar again every frame.
-    ImGui::BeginChild("##ColorspaceScroll", ImVec2(0, 0), ImGuiChildFlags_None,
-                      ImGuiWindowFlags_AlwaysVerticalScrollbar);
+    // The enclosing window scrolls this panel (see the ImGuiWindowFlags_AlwaysVerticalScrollbar the Colorspace
+    // DockableWindow is created with), so the table itself neither scrolls nor sits in a scrolling child: the
+    // window's padding is what separates it from the scrollbar.
     if (ImGui::PE::Begin("Colorspace", table_flags))
     {
         // The diagram gets its own full-width row when the value column alone is too narrow to render it legibly.
@@ -1429,8 +1426,6 @@ void Image::draw_colorspace()
         ImGui::Unindent(ImGui::GetStyle().CellPadding.x);
         ImGui::PE::End();
     }
-    ImGui::EndChild();
-    ImGui::PopStyleColor();
 }
 
 void Image::draw_channel_stats()

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -34,6 +34,162 @@ static std::chrono::system_clock::time_point to_system_clock(std::filesystem::fi
                                                    system_clock::now());
 }
 
+/// What place_clip_warning_toggles() hit-tested, for paint_clip_warning_toggles() to render afterwards.
+struct ClipWarningToggles
+{
+    ImRect rect[2];
+    bool   hovered[2], held[2];
+};
+
+/// Index of a group's alpha channel, or -1 if it has none. Alpha is always the group's last channel.
+static int alpha_channel_index(const ChannelGroup &group)
+{
+    switch (group.type)
+    {
+    case ChannelGroup::RGBA_Channels:
+    case ChannelGroup::XYZA_Channels:
+    case ChannelGroup::YCA_Channels:
+    case ChannelGroup::YA_Channels: return group.num_channels - 1;
+    default: return -1;
+    }
+}
+
+/*!
+    Hit-tests the two clip-warning toggles in the histogram's top corners -- shadows on the left, highlights
+    on the right -- flipping \p warnings when one is clicked, and reports where they landed so
+    paint_clip_warning_toggles() can render them later. \p ui_font_size is the app's normal text size,
+    captured before the plot's reduced font was pushed, and is used for the tooltips.
+
+    Call between BeginPlot and EndPlot, *before* the drag tools. ImPlot hit-tests the whole plot rect with
+    ImGuiButtonFlags_AllowOverlap, so later items can still claim hover from it, but DragLineX's grab rect
+    does not allow overlap and spans the full plot height -- so whichever of the two is submitted first owns
+    the corner. These claim it; a drag line under one stays grabbable over the rest of its height. Painting
+    is deliberately deferred to the opposite end of that ordering, so the buttons sit *above* the lines.
+*/
+static ClipWarningToggles place_clip_warning_toggles(bool2 &warnings, float ui_font_size)
+{
+    const ImVec2 plot_pos  = ImPlot::GetPlotPos();
+    const ImVec2 plot_size = ImPlot::GetPlotSize();
+    const float  sz        = ImTrunc(ImGui::GetFrameHeight());
+    const float  pad       = EmSize(0.25f);
+
+    static const char *ids[2]      = {"##shadow clipping", "##highlight clipping"};
+    static const char *tooltips[2] = {"Toggle zebra stripes on values below the low clip bound.",
+                                      "Toggle zebra stripes on values above the high clip bound."};
+
+    // BeginPlot() already advanced the layout cursor past the whole plot, so park it back where it was once
+    // these manually-positioned buttons are placed -- otherwise whatever is drawn after EndPlot() starts at
+    // the last button's corner instead of below the plot.
+    const ImVec2       saved_cursor = ImGui::GetCursorScreenPos();
+    ClipWarningToggles toggles;
+
+    for (int e = 0; e < 2; ++e)
+    {
+        bool &on = e == 0 ? warnings.x : warnings.y;
+        ImGui::SetCursorScreenPos(
+            ImVec2{e == 0 ? plot_pos.x + pad : plot_pos.x + plot_size.x - pad - sz, plot_pos.y + pad});
+        ImGui::InvisibleButton(ids[e], ImVec2{sz, sz});
+        if (ImGui::IsItemClicked())
+            on = !on;
+        {
+            // draw_histogram() runs under a reduced font so the plot's own tick labels stay compact; the
+            // tooltip is ordinary UI text and should read at the app's normal size, which the caller has to
+            // supply -- by now style.FontSizeBase reports the reduced size, not the app's.
+            ImGui::ScopedFont f{nullptr, ui_font_size};
+            ImGui::SetItemTooltip("%s", tooltips[e]);
+        }
+
+        toggles.rect[e]    = ImRect{ImGui::GetItemRectMin(), ImGui::GetItemRectMax()};
+        toggles.hovered[e] = ImGui::IsItemHovered();
+        toggles.held[e]    = ImGui::IsItemActive();
+    }
+    ImGui::SetCursorScreenPos(saved_cursor);
+    return toggles;
+}
+
+/*!
+    Paints the clip-warning toggles placed by place_clip_warning_toggles(): a rounded square button holding
+    an upward isosceles triangle, i.e. an inverted take on a combo box's dropdown arrow button.
+
+    The button's background says whether that end's zebra striping is enabled (dark when off, light when on,
+    lighter still under the cursor), while the triangle says what is *currently* clipping, so it stays a live
+    indicator whether or not the striping is switched on. \p clip_colors carries that per-end color, with
+    `w == 0` meaning nothing crosses that bound.
+
+    Call between BeginPlot and EndPlot, *after* the drag tools, so the buttons cover the vertical lines
+    rather than the other way around.
+*/
+static void paint_clip_warning_toggles(const ClipWarningToggles &toggles, const bool2 &warnings,
+                                       const float4 clip_colors[2])
+{
+    ImDrawList *draw_list = ImGui::GetWindowDrawList();
+
+    for (int e = 0; e < 2; ++e)
+    {
+        const bool   on       = e == 0 ? warnings.x : warnings.y;
+        const ImRect rect     = toggles.rect[e];
+        const float  sz       = rect.GetWidth();
+        const float  rounding = ImGui::GetStyle().FrameRounding;
+
+        // ImGuiCol_FrameBgHovered is a translucent wash in both themes, so layering it over the base lifts
+        // either state a further step rather than replacing it
+        draw_list->AddRectFilled(rect.Min, rect.Max, ImGui::GetColorU32(on ? ImGuiCol_FrameBgActive : ImGuiCol_FrameBg),
+                                 rounding);
+        if (toggles.hovered[e] || toggles.held[e])
+            draw_list->AddRectFilled(rect.Min, rect.Max, ImGui::GetColorU32(ImGuiCol_FrameBgHovered), rounding);
+
+        // apex above the center, base an equal distance below it, so the triangle sits centered in the square
+        const float  cx = rect.Min.x + 0.5f * sz, cy = rect.Min.y + 0.5f * sz;
+        const float  hw = ImTrunc(sz * 0.28f), hh = ImTrunc(sz * 0.20f);
+        const ImVec2 apex{cx, cy - hh}, base_l{cx - hw, cy + hh}, base_r{cx + hw, cy + hh};
+
+        const ImU32 tri = clip_colors[e].w > 0.f ? ImGui::ColorConvertFloat4ToU32(clip_colors[e])
+                                                 : ImGui::GetColorU32(ImGuiCol_TextDisabled);
+        draw_list->AddTriangleFilled(base_r, base_l, apex, tri);
+    }
+}
+
+/*!
+    Draws the drag-to-resize grip below the histogram, modeled on the column-resize divider of a PE table:
+    ImGui's TableUpdateBorders()/TableGetColumnBorderCol() rotated 90 degrees, reusing its 4px hit band, its
+    delayed hover feedback, its Separator colors, and its double-click-to-restore gesture.
+*/
+static void draw_histogram_resize_grip()
+{
+    float &height = hdrview()->histogram_height();
+
+    const float hit_half = ImTrunc(4.f * ImGui::GetCurrentContext()->CurrentDpiScale);
+    const bool  pressed =
+        ImGui::InvisibleButton("##histogram_resize", ImVec2{-FLT_MIN, 2.f * hit_half},
+                               ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+    const ImRect rect{ImGui::GetItemRectMin(), ImGui::GetItemRectMax()};
+
+    const bool hovered = ImGui::IsItemHovered();
+    bool       held    = ImGui::IsItemActive();
+    if (pressed && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+    {
+        height = HDRViewApp::default_histogram_height;
+        ImGui::ClearActiveID();
+        held = false;
+    }
+    if (held)
+        height = ImClamp(height + ImGui::GetIO().MouseDelta.y / EmSize(1.f), 6.f, 40.f);
+
+    // Hover feedback waits out a short timer, as a table's resize borders do, so brushing past the grip on the
+    // way somewhere else doesn't flash the resize cursor.
+    if ((hovered && ImGui::GetCurrentContext()->HoveredIdTimer > 0.06f) || held)
+        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
+
+    // A short centered stub advertises the grip at rest; hovering or dragging extends it the full width, the
+    // same way NoBordersInBodyUntilResize reveals a table's column border only while it is being addressed.
+    const float y     = ImTrunc((rect.Min.y + rect.Max.y) * 0.5f);
+    const float inset = (hovered || held) ? 0.f : 0.5f * (rect.GetWidth() - EmSize(3.f));
+    ImGui::GetWindowDrawList()->AddLine(ImVec2{rect.Min.x + inset, y}, ImVec2{rect.Max.x - inset, y},
+                                        ImGui::GetColorU32(held      ? ImGuiCol_SeparatorActive
+                                                           : hovered ? ImGuiCol_SeparatorHovered
+                                                                     : ImGuiCol_TableBorderStrong));
+}
+
 void Image::draw_histogram()
 {
     static ImPlotCond plot_cond = ImPlotCond_Always;
@@ -100,11 +256,16 @@ void Image::draw_histogram()
 
     ImPlot::GetStyle().PlotMinSize = {100, 100};
 
-    ImGui::PushFont(hdrview()->font("sans regular"), ImGui::GetStyle().FontSizeBase * 10.f / 14.f);
+    // PushFont() overwrites style.FontSizeBase with whatever size it pushes (see UpdateCurrentFontSize), so
+    // the plot's reduced font below makes the style's value unusable as "the app's normal size" from here on.
+    // Capture it first, for the widgets inside the plot that want ordinary UI text.
+    const float ui_font_size = ImGui::GetStyle().FontSizeBase;
+
+    ImGui::PushFont(hdrview()->font("sans regular"), ui_font_size * 10.f / 14.f);
     ImPlot::PushStyleVar(ImPlotStyleVar_AnnotationPadding, ImVec2{2.0, 0.0});
     // float4 plot_bg{0.35f, 0.35f, 0.35f, 1.f};
     // ImGui::PushStyleColor(ImGuiCol_WindowBg, plot_bg);
-    if (ImPlot::BeginPlot("##Histogram", ImVec2(-1, 150.f)))
+    if (ImPlot::BeginPlot("##Histogram", ImVec2(-1, EmSize(hdrview()->histogram_height()))))
     {
         ImPlot::GetInputMap().ZoomRate = 0.03f;
         ImPlot::SetupAxis(ImAxis_Y1, nullptr, ImPlotAxisFlags_NoTickLabels);
@@ -118,6 +279,9 @@ void Image::draw_histogram()
         ImPlot::SetupAxesLimits(x_limits[0], x_limits[1], y_limits[0], y_limits[1], plot_cond);
 
         ImPlot::SetupMouseText(ImPlotLocation_SouthEast, ImPlotMouseTextFlags_NoFormat);
+        // ImPlot only assigns these when they differ from what was passed last frame, so this positions the
+        // legend once and still lets the user relocate it via the legend's own right-click menu.
+        ImPlot::SetupLegend(ImPlotLocation_North, ImPlotLegendFlags_Horizontal);
         switch (hdrview()->histogram_x_scale())
         {
         case AxisScale_Linear: ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Linear); break;
@@ -229,11 +393,22 @@ void Image::draw_histogram()
         {
             // PlotStairs holds each x[i]'s y-value constant across [x[i], x[i+1)), so hist_xs (each bin's
             // left edge) rather than a bin center is what aligns the steps with the true bin boundaries.
+            // The stairs themselves are invisible (ImPlot skips line rendering entirely at zero alpha) --
+            // the visible curve is the additive fill rasterized above. The item still has to be plotted,
+            // since it owns the legend entry whose Show flag gates that fill.
             ImPlotSpec spec;
-            spec.LineColor = float4{colors[c].xyz(), 1.0f};
+            spec.LineColor = float4{colors[c].xyz(), 0.f};
             spec.FillColor = float4{0.f};
             ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
                                PixelStats::NUM_BINS, spec);
+
+            // Re-register the same label opaque to recolor its legend swatch: PlotDummy adopts the first
+            // non-auto color in its spec as the legend icon color, and the legend isn't rendered until
+            // EndPlot, so this second, geometry-free item wins. Without it the swatch would inherit the
+            // transparent line color above and the legend would be invisible.
+            ImPlotSpec legend_spec;
+            legend_spec.LineColor = float4{colors[c].xyz(), 1.f};
+            ImPlot::PlotDummy(names[c].c_str(), legend_spec);
         }
 
         if (contains(hovered_pixel) && hdrview()->mouse_over_viewport())
@@ -251,6 +426,9 @@ void Image::draw_histogram()
                 ImPlot::TagX(color32[c], float4{colors[c].xyz(), 1.0f}, "%s", "");
             }
         }
+
+        auto &warnings = hdrview()->clip_warnings();
+        auto  toggles  = place_clip_warning_toggles(warnings, ui_font_size);
 
         Box1d xrange{-hdrview()->offset_live() * pow(2.f, -hdrview()->exposure_live()),
                      (1.0 - hdrview()->offset_live()) * pow(2.f, -hdrview()->exposure_live())};
@@ -291,20 +469,49 @@ void Image::draw_histogram()
         ImPlot::TagX(xrange.min.x, ImVec4(0, 0, 0, 1), "0");
         ImPlot::TagX(xrange.max.x, ImVec4(1, 1, 1, 1), "1");
 
-        if (hdrview()->draw_clip_warnings())
+        // The shader compares clip_range against display values (d = p * gain + offset), so map it into plot
+        // space -- which holds stored values p -- the same way the black/white points above do.
+        auto gain       = pow(2.f, hdrview()->exposure_live());
+        auto offset     = hdrview()->offset_live();
+        auto clip_range = double2((hdrview()->clip_range() - offset) / gain);
+        if (warnings.x)
         {
-            auto gain       = pow(2.f, hdrview()->exposure_live());
-            auto clip_range = double2(hdrview()->clip_range() / gain);
             if (ImPlot::DragLineX(2, &clip_range.x, ImVec4(0, 0, 0, 1), 1, ImPlotDragToolFlags_Delayed))
-                hdrview()->clip_range().x = (float)clip_range.x * gain;
-            if (ImPlot::DragLineX(3, &clip_range.y, ImVec4(1, 1, 1, 1), 1, ImPlotDragToolFlags_Delayed))
-                hdrview()->clip_range().y = (float)clip_range.y * gain;
+                hdrview()->clip_range().x = (float)clip_range.x * gain + offset;
             ImPlot::TagX(clip_range.x, ImVec4(0, 0, 0, 1), "clip");
+        }
+        if (warnings.y)
+        {
+            if (ImPlot::DragLineX(3, &clip_range.y, ImVec4(1, 1, 1, 1), 1, ImPlotDragToolFlags_Delayed))
+                hdrview()->clip_range().y = (float)clip_range.y * gain + offset;
             ImPlot::TagX(clip_range.y, ImVec4(1, 1, 1, 1), "clip");
         }
 
+        // Color each triangle by which channels cross its bound, summing their canonical colors additively
+        // the way the histogram fill does -- red plus blue reads magenta, all three read white. Alpha is
+        // left out, matching the shader, which only tests rgb. Both bounds are already in plot space, so
+        // they compare directly against the stored per-channel extremes.
+        float4 clip_colors[2] = {float4{0.f}, float4{0.f}};
+        for (int e = 0; e < 2; ++e)
+        {
+            float3 col{0.f};
+            for (int c = 0; c < std::min(4, group.num_channels); ++c)
+            {
+                if (c == alpha_channel_index(group) || !stats[c])
+                    continue;
+                if (e == 0 ? stats[c]->summary.minimum < clip_range.x : stats[c]->summary.maximum > clip_range.y)
+                    col += colors[c].xyz();
+            }
+            if (col != float3{0.f})
+                clip_colors[e] = float4{la::min(col, float3{1.f}), 1.f};
+        }
+
+        paint_clip_warning_toggles(toggles, warnings, clip_colors);
+
         ImPlot::EndPlot();
     }
+
+    draw_histogram_resize_grip();
     // ImGui::PopStyleColor();
     ImPlot::PopStyleVar();
     ImGui::PopFont();

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -397,7 +397,7 @@ void Image::draw_histogram()
             // the visible curve is the additive fill rasterized above. The item still has to be plotted,
             // since it owns the legend entry whose Show flag gates that fill.
             ImPlotSpec spec;
-            spec.LineColor = float4{colors[c].xyz(), 0.f};
+            spec.LineColor = float4{colors[c].xyz(), 0.1f};
             spec.FillColor = float4{0.f};
             ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
                                PixelStats::NUM_BINS, spec);


### PR DESCRIPTION
Two commits of GUI layout and histogram work.

## Status bar and Colorspace panel layout (`7b45e83`)

- Narrowed the status bar's hover color row from 25em to 18em, hoisting the width into one constant shared with the fit test that decides whether the hover zone is drawn at all, so the two can't drift apart.
- The Colorspace panel now scrolls at the window level like Pixel statistics, instead of inside a child window. A borderless child gets zero window padding, so its content ran flush into its own scrollbar; the window's padding now supplies the same margin its sibling panels have, and the scrollbar sits at the panel edge. The unconditional vertical scrollbar that keeps the width-locked chromaticity diagram from oscillating moved to the window's flags.

## Histogram legend, sizing, and clip warnings (`75ae7d1`)

**Legend.** Channel outlines exist only to own a legend entry — the visible curve is the additive fill rasterized underneath — but ImPlot derives the legend swatch from the same line color, so drawing them faintly made the legend faint too. They're now fully transparent (ImPlot skips line rendering at zero alpha) with each label re-registered opaque via `PlotDummy`, which adopts its spec's first non-auto color as the legend icon color. Legend is laid out horizontally across the top.

**Plot height.** Drag-resizable and persisted, replacing a hardcoded 150px that never scaled with DPI. The grip mirrors ImGui's own table column-resize divider: same hit band, hover delay, separator colors, and double-click to restore the default.

**Clip warnings** are now independent shadow and highlight toggles, each with its own bound in the View menu and its own draggable handle in the histogram, both reachable from Lightroom-style buttons in the plot's top corners. Each button's triangle is tinted by the canonical colors of whichever channels currently cross that bound — red alone reads red, red+blue magenta, all three white — using the same additive convention as the histogram fill, with alpha excluded to match the shader. Settings and sessions written before the split seed both ends from the old single flag.

Two clip-warning bugs fixed along the way:

- The handles mapped `clip_range` through gain but not the offset the shader also applies, so they drifted away from the striped region whenever offset was nonzero.
- Out-of-bounds samples read as 0, so any low bound above zero striped the entire background as crushed black. Striping is now gated on the data window.

## Notes for review

- Rebased onto `4fb1cdf`, which moved to hello_imgui v1.92.900 and with it **ImPlot 0.17 → 1.1 WIP**, replacing `PushStyleColor`/`SetNextLineStyle` with `ImPlotSpec`. The histogram lines are ported to the new API; the legend mechanism above was re-verified against 1.1's source.
- The `fs_params` uniform block gains an `ivec2 clip_warnings` in place of `int draw_clip_warnings`. Verified in the sokol-shdc-generated Metal output; the GLSL variant for Linux/Windows/Emscripten is generated by those builds and hasn't been exercised locally.
- Verified by build + `--help` smoke check on `macos-arm64-cpm`, plus manual GUI confirmation. None of this area is covered by the doctest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)