### PR TITLE
Improve AppImage packaging diagnostics and add a packaged-artifact smoke check

### DIFF
--- a/.github/scripts/check-appimage.sh
+++ b/.github/scripts/check-appimage.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Smoke-check a packaged AppImage: verify it carries the compiled runtime assets, then verify it actually
+# starts and loads its shaders.
+#
+# The "Checking that HDRView runs" step can't catch either problem: it runs the build-tree binary, which
+# finds its assets through HDRVIEW_BUILD_TREE_ASSETS_DIR rather than the installed layout, and --help exits
+# long before any shader is loaded. An AppImage that shipped the uncompiled .sglsl shader sources instead of
+# the sokol-shdc output therefore passed CI and failed on every user's machine (issue #183).
+#
+# Usage: check-appimage.sh <path-to-.appimage>
+# Needs a display for the launch check; run it under xvfb-run on a headless machine.
+
+set -euo pipefail
+
+appimage=$(readlink -f "${1:?usage: check-appimage.sh <path-to-.appimage>}")
+[[ -f $appimage ]] || { echo "error: no such file: $appimage" >&2; exit 1; }
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+# --appimage-extract unpacks without needing FUSE, which GitHub runners don't provide.
+echo "Extracting $appimage"
+(cd "$workdir" && "$appimage" --appimage-extract >/dev/null)
+appdir=$workdir/squashfs-root
+
+# The four shaders the Linux/OpenGL build generates with sokol-shdc; see sokol_shdc_generate() in
+# CMakeLists.txt. Their names are what Shader::from_asset() asks for at runtime, plus the .glsl extension.
+shader_dir=$appdir/usr/bin/assets/shaders
+missing=()
+for shader in image-shader_vert.glsl image-shader_frag.glsl colorpass_vert.glsl colorpass_frag.glsl; do
+    [[ -f $shader_dir/$shader ]] || missing+=("$shader")
+done
+if ((${#missing[@]})); then
+    echo "error: AppImage is missing compiled shader(s): ${missing[*]}" >&2
+    echo "$shader_dir contains:" >&2
+    if [[ -d $shader_dir ]]; then ls -la "$shader_dir" >&2; else echo "    (no such directory)" >&2; fi
+    exit 1
+fi
+echo "Compiled shaders present in $shader_dir"
+
+# Launch it for real. HDRView has no run-and-exit mode, so let it come up and then kill it; what matters is
+# what it logged on the way, not its exit status. Poll rather than waiting out the timeout: a healthy start
+# takes a couple of seconds, and the timeout only bounds a hung one.
+log=$workdir/run.log
+echo "Launching the AppImage"
+"$appdir/AppRun" >"$log" 2>&1 &
+pid=$!
+for _ in $(seq 60); do
+    grep -q 'Loading shader from' "$log" && break
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 1
+done
+kill "$pid" 2>/dev/null || true
+wait "$pid" 2>/dev/null || true
+
+if grep -qE 'Shader initialization failed|Could not find a shader' "$log"; then
+    echo "error: the AppImage failed to initialize its shaders" >&2
+    cat "$log" >&2
+    exit 1
+fi
+if ! grep -q 'Loading shader from' "$log"; then
+    echo "error: the AppImage never got as far as loading a shader" >&2
+    cat "$log" >&2
+    exit 1
+fi
+
+echo "AppImage started and loaded its shaders:"
+sed -n '/Loading shader from/p' "$log"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -130,6 +130,14 @@ jobs:
         if: matrix.config.preset == 'linux-appimage'
         working-directory: ${{github.workspace}}/build/${{ matrix.config.preset }}
         run: cpack -C ${{ matrix.buildtype }} -G External
+
+      # Unpacks the AppImage and starts it, which is the only way to exercise the *installed* asset layout:
+      # the "Checking that HDRView runs" step above runs the build-tree binary, which finds its assets
+      # through HDRVIEW_BUILD_TREE_ASSETS_DIR and never loads a shader. xvfb-run because the runners have no
+      # display server, same as the GUI tests above.
+      - name: Checking that the AppImage runs
+        if: matrix.config.preset == 'linux-appimage'
+        run: xvfb-run -a ${{github.workspace}}/.github/scripts/check-appimage.sh ${{github.workspace}}/build/${{ matrix.config.preset }}/*.appimage
         
       - name: Archive package
         if: matrix.config.preset == 'linux-appimage'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake xorg-dev libglu1-mesa-dev zlib1g-dev libxrandr-dev ninja-build libglfw3-dev libfreetype-dev libjpeg-dev libimath-dev libopenexr-dev libpng-dev libtiff-dev liblcms2-dev libwebp-dev libraw-dev libheif-dev libaom-dev libde265-dev libx265-dev libjxl-dev libcli11-dev libspdlog-dev libfmt-dev libexif-dev libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y cmake xorg-dev libglu1-mesa-dev zlib1g-dev libxrandr-dev ninja-build libglfw3-dev libfreetype-dev libjpeg-dev libimath-dev libopenexr-dev libpng-dev libtiff-dev liblcms2-dev libwebp-dev libraw-dev libheif-dev libaom-dev libde265-dev libx265-dev libjxl-dev libcli11-dev libspdlog-dev libfmt-dev libexif-dev libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev xvfb
 
       - name: Install Python dependencies
         run: pip install --upgrade pip && pip install Pillow
@@ -173,6 +173,11 @@ jobs:
       - name: Package
         working-directory: ${{github.workspace}}/build/${{ matrix.config.preset }}
         run: cpack -C ${{ env.BUILD_TYPE }} -G External
+
+      # Verifies the artifact about to be published actually starts, unlike the build-tree --help check above
+      # (see .github/scripts/check-appimage.sh).
+      - name: Checking that the AppImage runs
+        run: xvfb-run -a ${{github.workspace}}/.github/scripts/check-appimage.sh ${{github.workspace}}/build/${{ matrix.config.preset }}/*.appimage
 
       # - name: Archive build artifacts
       #   uses: actions/upload-artifact@v6

--- a/src/hdrview.cpp
+++ b/src/hdrview.cpp
@@ -176,6 +176,9 @@ until another channel selector is encountered.)")
             spdlog::debug("Launching HDRView with no command line arguments.");
 
         spdlog::info("Welcome to HDRView!");
+        // Log the same string --version reports: bug reports usually arrive as a copy of this console
+        // output, and the version is the first thing needed to interpret them.
+        spdlog::info("{}", version_string);
         spdlog::info("Verbosity threshold set to level {:d}.", verbosity);
 
 #ifdef ASSETS_LOCATION

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -1,12 +1,15 @@
 #include "shader.h"
 
 #include <algorithm>        // for find
+#include <filesystem>       // for directory_iterator, path
 #include <spdlog/fmt/fmt.h> // for format, make_format_args, vformat_to
 #include <spdlog/spdlog.h>  // for error, info
 #include <sstream>          // for basic_ostringstream, bas...
 #include <string.h>         // for strncmp
 
 #include <hello_imgui/hello_imgui_assets.h> // for AssetFileData, AssetExists
+
+namespace fs = std::filesystem;
 
 using std::string;
 using std::string_view;
@@ -20,12 +23,62 @@ static const string shader_extensions[] = {".glsl",    ".vs",      ".fs",      "
 #endif
 static const size_t num_extensions = sizeof(shader_extensions) / sizeof(shader_extensions[0]);
 
+// Assemble a report of where a shader was looked for and what is in those folders instead. A packaging
+// mistake (a shipped assets folder holding the wrong files, or none) is otherwise indistinguishable from a
+// missing folder, since both surface only as a shader that could not be found.
+static string describe_search_locations(string_view basename)
+{
+    // The folders HelloImGui::AssetFileFullPath() consults, in the order it tries them. Its exe-relative
+    // fallback is not reachable through the public API, so it is named rather than expanded.
+    std::vector<string> folders;
+#ifdef ASSETS_LOCATION
+    folders.emplace_back(ASSETS_LOCATION);
+#endif
+    for (const auto &path : HelloImGui::GetAssetsSearchPaths()) folders.push_back(path);
+    std::error_code ec;
+    if (auto cwd = fs::current_path(ec); !ec)
+        folders.push_back((cwd / "assets").string());
+
+    const fs::path subdir = fs::path(string{basename}).parent_path();
+
+    std::ostringstream oss;
+    oss << "\n    Tried these extensions:";
+    for (size_t i = 0; i < num_extensions; ++i) oss << (i ? ", " : " ") << shader_extensions[i];
+    oss << "\n    Tried these asset folders:";
+    for (const auto &folder : folders)
+    {
+        const fs::path dir = fs::path(folder) / subdir;
+        oss << "\n        " << dir.string() << ": ";
+        if (!fs::is_directory(dir, ec))
+        {
+            oss << "(not a directory)";
+            continue;
+        }
+
+        constexpr int max_listed = 12;
+        int           num_listed = 0;
+        string        contents;
+        for (const auto &entry : fs::directory_iterator{dir, ec})
+        {
+            if (num_listed++ == max_listed)
+            {
+                contents += ", ...";
+                break;
+            }
+            contents += (num_listed > 1 ? ", " : "") + entry.path().filename().string();
+        }
+        oss << "contains " << (contents.empty() ? "nothing" : contents);
+    }
+    oss << "\n        plus exe_folder/assets, which HelloImGui resolves internally";
+    return oss.str();
+}
+
 string Shader::from_asset(string_view basename)
 {
     using namespace HelloImGui;
     for (size_t i = 0; i < num_extensions; ++i)
     {
-        string filename = basename.data() + shader_extensions[i];
+        string filename = string{basename} + shader_extensions[i];
 
         if (!AssetExists(filename))
             continue;
@@ -40,8 +93,9 @@ string Shader::from_asset(string_view basename)
         FreeAssetFileData(&shader_txt);
         return source;
     }
-    throw std::runtime_error(fmt::format(
-        "Could not find a shader with base filename \"{}\" with any known shader file extensions.", basename));
+    throw std::runtime_error(
+        fmt::format("Could not find a shader with base filename \"{}\" with any known shader file extensions.{}",
+                    basename, describe_search_locations(basename)));
 }
 
 string Shader::prepend_includes(string_view shader_string, const std::vector<string_view> &include_files)


### PR DESCRIPTION
Follow-up to #183, which reported HDRView failing at startup with `Could not find a shader with base filename "shaders/image-shader_frag"`. The cause — the AppImage shipping the uncompiled `.sglsl` shader sources instead of the sokol-shdc output — was already fixed in #177 and released in v2.9.0-beta.02. This PR addresses the three things that let it ship and made it hard to diagnose.

### 1. Nothing verified the packaged artifact

The "Checking that HDRView runs" step invokes the *build-tree* binary, which resolves assets through `HDRVIEW_BUILD_TREE_ASSETS_DIR` and exits on `--help` before loading any shader, so a broken installed asset layout passed CI unnoticed.

New `.github/scripts/check-appimage.sh` extracts the packaged AppImage (`--appimage-extract`, so no FUSE needed on runners), asserts the four sokol-shdc outputs are present under `usr/bin/assets/shaders`, then launches it and requires the `Loading shader from` log lines. It polls rather than waiting out its timeout, so a healthy run takes a couple of seconds. Wired into `ci-linux.yml` (after Package) and `release.yml` (before Release); the latter's apt list needed `xvfb` added.

Checked against both real release artifacts:

| Artifact | Result |
| --- | --- |
| `HDRView-2.8.3-x86_64.appimage` | fails, printing the missing shader names and the `.sglsl` files found instead |
| `HDRView-2.9.0-beta.02-x86_64.appimage` | passes, listing the four loaded shaders |

### 2. The shader-lookup failure was uninformative

It reported only the basename it wanted, with no way to tell a missing assets folder from one holding the wrong files. `Shader::from_asset()` now reports where it looked and what was there:

```
Could not find a shader with base filename "shaders/image-shader_frag" with any known shader file extensions.
    Tried these extensions: .glsl, .vs, .fs, ...
    Tried these asset folders:
        /home/…/build/linux-cpm/assets/shaders: contains image-shader.sglsl
        /home/…/HDRView/assets/shaders: contains colorpass.sglsl, colorspaces.sglsl, image-shader.sglsl
        plus exe_folder/assets, which HelloImGui resolves internally
```

(that's the #183 failure staged locally — the listing names the culprit directly). The folder list comes from `ASSETS_LOCATION`, `HelloImGui::GetAssetsSearchPaths()`, and `cwd/assets`; hello_imgui's exe-relative fallback isn't exposed through its public API, so it's named rather than expanded. Same function: `basename.data() + ext` assumed the `string_view` was null-terminated, now `string{basename} + ext`.

### 3. Startup logged no version

A pasted console log couldn't be tied to a release. `main()` now logs the same string `--version` reports:

```
[13:08:37 | info ]: Welcome to HDRView!
[13:08:37 | info ]: HDRView v2.9.0-beta.02-4-g2b3ff1f (64 bit). (built using GLFW 3 backend on 2026-08-25 13:07)
```

### Verification

`cmake --build --preset linux-cpm-release` clean (only pre-existing warnings in `image-gui.cpp`); `ctest -C Release -E hdrview_gui_tests` 38/38 passed; app launches and loads all four shaders normally.

`clang-format` isn't available on the machine this was written on, so the C++ style was matched by hand (120-column limit checked) — worth a formatting pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kf227vzpZj8vkAkV9hsGT4
