### PR TITLE
Show isolated channels without baked-in alpha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1634,8 +1634,8 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
 
   list(REMOVE_ITEM HDRVIEW_SOURCES src/hdrview.cpp)
   add_executable(hdrview_tests ${HDRVIEW_SOURCES} tests/test_pixel_stats.cpp tests/test_colorspace.cpp
-                                tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_assets.cpp
-                                tests/test_long_paths.cpp
+                                tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp
+                                tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -101,6 +101,7 @@ layout(binding=1) uniform fs_params {
     ivec2 clip_warnings;
     vec2  clip_range;
     int   primary_straight_alpha;
+    int   secondary_straight_alpha;
 } fsp;
 
 layout(binding=0) uniform texture2D colormap;
@@ -175,11 +176,14 @@ float rand_tent(vec2 xy)
 }
 
 // Isolating color channels shows them opaque, so undo the premultiply Image::finalize() applied on
-// load -- but only for files that stored straight alpha, since a premultiplied file's alpha=0 pixels
-// carry real color that dividing would blow up.
+// load. Only safe when every image feeding the value stored straight alpha: a premultiplied file's
+// alpha=0 pixels carry real color, and dividing those by a near-zero alpha blows up. With a reference
+// blended in, the alpha here is the composite's, so the reference has to qualify too.
 vec3 isolate(vec3 color, float alpha)
 {
-    return fsp.primary_straight_alpha != 0 ? color / max(k_small_alpha, alpha) : color;
+    bool straight = fsp.primary_straight_alpha != 0 &&
+                    (fsp.has_reference == 0 || fsp.secondary_straight_alpha != 0);
+    return straight ? color / max(k_small_alpha, alpha) : color;
 }
 
 vec4 choose_channel(vec4 rgba)

--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -39,6 +39,9 @@
 
 #define YCA_Channels    4
 #define YC_Channels     5
+
+// Keep in sync with k_small_alpha in image.h: guards the divide when undoing a premultiply.
+#define k_small_alpha (1.0 / 67108864.0)
 @end
 
 @vs vs
@@ -97,6 +100,7 @@ layout(binding=1) uniform fs_params {
     float time;
     ivec2 clip_warnings;
     vec2  clip_range;
+    int   primary_straight_alpha;
 } fsp;
 
 layout(binding=0) uniform texture2D colormap;
@@ -170,15 +174,23 @@ float rand_tent(vec2 xy)
     return (r < 0.0) ? 0.5 * rn : 0.5 * rp;
 }
 
+// Isolating color channels shows them opaque, so undo the premultiply Image::finalize() applied on
+// load -- but only for files that stored straight alpha, since a premultiplied file's alpha=0 pixels
+// carry real color that dividing would blow up.
+vec3 isolate(vec3 color, float alpha)
+{
+    return fsp.primary_straight_alpha != 0 ? color / max(k_small_alpha, alpha) : color;
+}
+
 vec4 choose_channel(vec4 rgba)
 {
     switch (fsp.channel)
     {
     case Channels_RGBA: return rgba;
-    case Channels_RGB: return vec4(rgba.rgb, 1.0);
-    case Channels_Red: return vec4(rgba.rrr, 1.0);
-    case Channels_Green: return vec4(rgba.ggg, 1.0);
-    case Channels_Blue: return vec4(rgba.bbb, 1.0);
+    case Channels_RGB: return vec4(isolate(rgba.rgb, rgba.a), 1.0);
+    case Channels_Red: return vec4(isolate(rgba.rrr, rgba.a), 1.0);
+    case Channels_Green: return vec4(isolate(rgba.ggg, rgba.a), 1.0);
+    case Channels_Blue: return vec4(isolate(rgba.bbb, rgba.a), 1.0);
     case Channels_Alpha: return vec4(rgba.aaa, 1.0);
     case Channels_Y: return vec4(vec3(dot(rgba.rgb, fsp.primary_yw)), rgba.a);
     }

--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -175,28 +175,28 @@ float rand_tent(vec2 xy)
     return (r < 0.0) ? 0.5 * rn : 0.5 * rp;
 }
 
-// Isolating color channels shows them opaque, so undo the premultiply Image::finalize() applied on
-// load. Only safe when every image feeding the value stored straight alpha: a premultiplied file's
-// alpha=0 pixels carry real color, and dividing those by a near-zero alpha blows up. With a reference
-// blended in, the alpha here is the composite's, so the reference has to qualify too.
-vec4 isolate(vec4 rgba)
+// Isolating color channels shows them opaque, so undo the premultiply Image::finalize() applied on load.
+// Only for files that stored straight alpha: a premultiplied file's alpha=0 pixels carry real color, which
+// has no straight form and would blow up on the divide.
+vec4 isolate(vec4 rgba, int straight_alpha)
 {
-    bool straight = fsp.primary_straight_alpha != 0 &&
-                    (fsp.has_reference == 0 || fsp.secondary_straight_alpha != 0);
-    return vec4(straight ? rgba.rgb / max(k_small_alpha, rgba.a) : rgba.rgb, 1.0);
+    return vec4(straight_alpha != 0 ? rgba.rgb / max(k_small_alpha, rgba.a) : rgba.rgb, 1.0);
 }
 
-vec4 choose_channel(vec4 rgba)
+// Applied to each image separately, before any blending: an isolated channel is then undone with its own
+// file's alpha rather than a composite's, and comparison blend modes operate on the values being compared
+// instead of on premultiplied ones.
+vec4 choose_channel(vec4 rgba, int straight_alpha, vec3 yw)
 {
     switch (fsp.channel)
     {
     case Channels_RGBA: return rgba;
-    case Channels_RGB: return isolate(rgba);
-    case Channels_Red: return isolate(rgba.rrra);
-    case Channels_Green: return isolate(rgba.ggga);
-    case Channels_Blue: return isolate(rgba.bbba);
+    case Channels_RGB: return isolate(rgba, straight_alpha);
+    case Channels_Red: return isolate(rgba.rrra, straight_alpha);
+    case Channels_Green: return isolate(rgba.ggga, straight_alpha);
+    case Channels_Blue: return isolate(rgba.bbba, straight_alpha);
     case Channels_Alpha: return vec4(rgba.aaa, 1.0);
-    case Channels_Y: return vec4(vec3(dot(rgba.rgb, fsp.primary_yw)), rgba.a);
+    case Channels_Y: return vec4(vec3(dot(rgba.rgb, yw)), rgba.a);
     }
     return rgba;
 }
@@ -265,6 +265,7 @@ void main()
         value.xyz = YC_to_RGB(value.xyz, fsp.primary_yw);
 
     value = fsp.primary_M_to_sRGB * value;
+    value = choose_channel(value, fsp.primary_straight_alpha, fsp.primary_yw);
 
     if (fsp.has_reference != 0)
     {
@@ -277,11 +278,12 @@ void main()
             reference_val.xyz = YC_to_RGB(reference_val.xyz, fsp.secondary_yw);
 
         reference_val = fsp.secondary_M_to_sRGB * reference_val;
+        reference_val = choose_channel(reference_val, fsp.secondary_straight_alpha, fsp.secondary_yw);
 
         value = blend(value, reference_val);
     }
 
-    vec4  foreground = choose_channel(value) * vec4(vec3(fsp.gain), 1.0) + vec4(vec3(fsp.offset * value.a), 0.0);
+    vec4  foreground = value * vec4(vec3(fsp.gain), 1.0) + vec4(vec3(fsp.offset * value.a), 0.0);
     vec4  tonemapped = tonemap(foreground) + background * (1.0 - foreground.a);
     bvec3 clipped    = greaterThan(foreground.rgb, fsp.clip_range.yyy);
     bvec3 crushed    = lessThan(foreground.rgb, fsp.clip_range.xxx);

--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -179,11 +179,11 @@ float rand_tent(vec2 xy)
 // load. Only safe when every image feeding the value stored straight alpha: a premultiplied file's
 // alpha=0 pixels carry real color, and dividing those by a near-zero alpha blows up. With a reference
 // blended in, the alpha here is the composite's, so the reference has to qualify too.
-vec3 isolate(vec3 color, float alpha)
+vec4 isolate(vec4 rgba)
 {
     bool straight = fsp.primary_straight_alpha != 0 &&
                     (fsp.has_reference == 0 || fsp.secondary_straight_alpha != 0);
-    return straight ? color / max(k_small_alpha, alpha) : color;
+    return vec4(straight ? rgba.rgb / max(k_small_alpha, rgba.a) : rgba.rgb, 1.0);
 }
 
 vec4 choose_channel(vec4 rgba)
@@ -191,10 +191,10 @@ vec4 choose_channel(vec4 rgba)
     switch (fsp.channel)
     {
     case Channels_RGBA: return rgba;
-    case Channels_RGB: return vec4(isolate(rgba.rgb, rgba.a), 1.0);
-    case Channels_Red: return vec4(isolate(rgba.rrr, rgba.a), 1.0);
-    case Channels_Green: return vec4(isolate(rgba.ggg, rgba.a), 1.0);
-    case Channels_Blue: return vec4(isolate(rgba.bbb, rgba.a), 1.0);
+    case Channels_RGB: return isolate(rgba);
+    case Channels_Red: return isolate(rgba.rrra);
+    case Channels_Green: return isolate(rgba.ggga);
+    case Channels_Blue: return isolate(rgba.bbba);
     case Channels_Alpha: return vec4(rgba.aaa, 1.0);
     case Channels_Y: return vec4(vec3(dot(rgba.rgb, fsp.primary_yw)), rgba.a);
     }

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -232,8 +232,9 @@ void HDRViewApp::draw_image() const
     auto set_color = [this](Target_ target, ConstImagePtr img)
     {
         float4x4 M_to_sRGB{la::identity};
-        int      channels_type = (int)ChannelGroup::Single_Channel;
-        float3   yw            = sRGB_Yw();
+        int      channels_type  = (int)ChannelGroup::Single_Channel;
+        int      straight_alpha = 0;
+        float3   yw             = sRGB_Yw();
 
         if (img)
         {
@@ -244,14 +245,18 @@ void HDRViewApp::draw_image() const
             // resulted in rapid flickering. So, for now, just pad the 3x3 matrix into a 4x4 one.
             M_to_sRGB = float4x4{
                 {img->M_to_sRGB[0], 0.f}, {img->M_to_sRGB[1], 0.f}, {img->M_to_sRGB[2], 0.f}, {0.f, 0.f, 0.f, 1.f}};
-            channels_type = (int)group.type;
-            yw            = img->luminance_weights;
+            channels_type  = (int)group.type;
+            straight_alpha = (int)(img->alpha_type == AlphaType_Straight);
+            yw             = img->luminance_weights;
         }
 
+        // Only the primary drives choose_channel(); with a reference loaded, blend() runs first and in
+        // premultiplied space, which is what its "over" expects.
         if (target == Target_Primary)
-            m_shader->set_uniform_block(
-                "fsp",
-                {{"primary_M_to_sRGB", M_to_sRGB}, {"primary_channels_type", channels_type}, {"primary_yw", yw}});
+            m_shader->set_uniform_block("fsp", {{"primary_M_to_sRGB", M_to_sRGB},
+                                                {"primary_channels_type", channels_type},
+                                                {"primary_yw", yw},
+                                                {"primary_straight_alpha", straight_alpha}});
         else
             m_shader->set_uniform_block(
                 "fsp",

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -267,20 +267,6 @@ void HDRViewApp::draw_image() const
     set_color(Target_Primary, current_image());
     set_color(Target_Secondary, reference_image());
 
-    // isolate() can only undo the premultiply when both images agree, so a mismatched pair silently keeps
-    // showing premultiplied values in the single-channel views. Say so once per pairing.
-    if (auto img = current_image(), ref = reference_image(); img && ref)
-        if (img->alpha_type != AlphaType_None && ref->alpha_type != AlphaType_None &&
-            (img->alpha_type == AlphaType_Straight) != (ref->alpha_type == AlphaType_Straight) &&
-            m_warned_alpha_mismatch != int2{img->id, ref->id})
-        {
-            m_warned_alpha_mismatch = int2{img->id, ref->id};
-            spdlog::warn("'{}' has {} alpha but reference '{}' has {}; isolated channel views will show "
-                         "premultiplied values while these two are compared.",
-                         img->short_name, alpha_type_name(img->alpha_type), ref->short_name,
-                         alpha_type_name(ref->alpha_type));
-        }
-
     if (current_image() && !current_image()->data_window.is_empty())
     {
         static mt19937 rng(53);

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -267,6 +267,20 @@ void HDRViewApp::draw_image() const
     set_color(Target_Primary, current_image());
     set_color(Target_Secondary, reference_image());
 
+    // isolate() can only undo the premultiply when both images agree, so a mismatched pair silently keeps
+    // showing premultiplied values in the single-channel views. Say so once per pairing.
+    if (auto img = current_image(), ref = reference_image(); img && ref)
+        if (img->alpha_type != AlphaType_None && ref->alpha_type != AlphaType_None &&
+            (img->alpha_type == AlphaType_Straight) != (ref->alpha_type == AlphaType_Straight) &&
+            m_warned_alpha_mismatch != int2{img->id, ref->id})
+        {
+            m_warned_alpha_mismatch = int2{img->id, ref->id};
+            spdlog::warn("'{}' has {} alpha but reference '{}' has {}; isolated channel views will show "
+                         "premultiplied values while these two are compared.",
+                         img->short_name, alpha_type_name(img->alpha_type), ref->short_name,
+                         alpha_type_name(ref->alpha_type));
+        }
+
     if (current_image() && !current_image()->data_window.is_empty())
     {
         static mt19937 rng(53);

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -250,17 +250,18 @@ void HDRViewApp::draw_image() const
             yw             = img->luminance_weights;
         }
 
-        // Only the primary drives choose_channel(); with a reference loaded, blend() runs first and in
-        // premultiplied space, which is what its "over" expects.
+        // Both targets report their alpha convention: choose_channel() runs after blend(), so undoing the
+        // premultiply on an isolated channel is only safe when the reference qualifies as well.
         if (target == Target_Primary)
             m_shader->set_uniform_block("fsp", {{"primary_M_to_sRGB", M_to_sRGB},
                                                 {"primary_channels_type", channels_type},
                                                 {"primary_yw", yw},
                                                 {"primary_straight_alpha", straight_alpha}});
         else
-            m_shader->set_uniform_block(
-                "fsp",
-                {{"secondary_M_to_sRGB", M_to_sRGB}, {"secondary_channels_type", channels_type}, {"secondary_yw", yw}});
+            m_shader->set_uniform_block("fsp", {{"secondary_M_to_sRGB", M_to_sRGB},
+                                                {"secondary_channels_type", channels_type},
+                                                {"secondary_yw", yw},
+                                                {"secondary_straight_alpha", straight_alpha}});
     };
 
     set_color(Target_Primary, current_image());

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -635,8 +635,9 @@ void HDRViewApp::reload_image(ImagePtr image, bool should_select)
     }
 
     spdlog::info("Reloading file '{}' with channel selector '{}'...", image->filename, image->channel_selector);
-    auto opts             = load_image_options();
-    opts.channel_selector = image->channel_selector;
+    auto opts                  = load_image_options();
+    opts.channel_selector      = image->channel_selector;
+    opts.alpha_is_transparency = image->alpha_is_transparency;
     m_image_loader.background_load(image->filename, {}, should_select, image, opts);
 }
 
@@ -761,10 +762,11 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
     for (auto &img : m_images)
     {
         json entry;
-        entry["path"]             = path_of(img);
-        entry["channel_selector"] = img->channel_selector;
-        entry["selected_group"]   = img->selected_group;
-        entry["reference_group"]  = img->reference_group;
+        entry["path"]                  = path_of(img);
+        entry["channel_selector"]      = img->channel_selector;
+        entry["alpha_is_transparency"] = img->alpha_is_transparency;
+        entry["selected_group"]        = img->selected_group;
+        entry["reference_group"]       = img->reference_group;
         images.push_back(entry);
     }
     j["images"] = images;
@@ -1047,16 +1049,18 @@ void HDRViewApp::begin_session_load(const json &j, const fs::path &dir)
 
         PendingSession::Entry e;
         e.path             = resolve(rel);
-        e.channel_selector = entry.value<string>("channel_selector", "");
-        e.selected_group   = entry.value<int>("selected_group", 0);
-        e.reference_group  = entry.value<int>("reference_group", 0);
+        e.channel_selector      = entry.value<string>("channel_selector", "");
+        e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
+        e.selected_group        = entry.value<int>("selected_group", 0);
+        e.reference_group       = entry.value<int>("reference_group", 0);
 
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
-        pending.unresolved[{e.path, e.channel_selector}].push_back(idx);
+        pending.unresolved[{e.path, e.channel_selector, e.alpha_is_transparency}].push_back(idx);
 
         ImageLoadOptions opts;
-        opts.channel_selector = e.channel_selector;
+        opts.channel_selector      = e.channel_selector;
+        opts.alpha_is_transparency = e.alpha_is_transparency;
         load_image(e.path.string(), {}, false, opts);
     }
 
@@ -1087,9 +1091,10 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
         // reload_image() already handle these correctly with no session-specific work.
         PendingSession::Entry e;
         e.path             = fs::path(zip_name) / fs::u8path(rel);
-        e.channel_selector = entry.value<string>("channel_selector", "");
-        e.selected_group   = entry.value<int>("selected_group", 0);
-        e.reference_group  = entry.value<int>("reference_group", 0);
+        e.channel_selector      = entry.value<string>("channel_selector", "");
+        e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
+        e.selected_group        = entry.value<int>("selected_group", 0);
+        e.reference_group       = entry.value<int>("reference_group", 0);
 
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
@@ -1104,10 +1109,11 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
             continue;
         }
 
-        pending.unresolved[{e.path, e.channel_selector}].push_back(idx);
+        pending.unresolved[{e.path, e.channel_selector, e.alpha_is_transparency}].push_back(idx);
 
         ImageLoadOptions opts;
-        opts.channel_selector = e.channel_selector;
+        opts.channel_selector      = e.channel_selector;
+        opts.alpha_is_transparency = e.alpha_is_transparency;
         m_image_loader.background_load(e.path.string(), *bytes, false, nullptr, opts);
     }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -581,11 +581,12 @@ void HDRViewApp::setup_frame_callbacks()
 
                 if (m_pending_session)
                 {
-                    // Resolve this arrival to the earliest not-yet-filled entry sharing its (path,
-                    // channel_selector) -- see PendingSession's comment in app.h for why matching by that
-                    // key (rather than by request order) is correct even when the same file is loaded more
-                    // than once in one session.
-                    auto key = std::make_pair(new_image->path, new_image->channel_selector);
+                    // Resolve this arrival to the earliest not-yet-filled entry sharing its load options
+                    // -- see PendingSession's comment in app.h for why matching by that key (rather than
+                    // by request order) is correct even when the same file is loaded more than once in
+                    // one session.
+                    auto key = PendingSession::Key{new_image->path, new_image->channel_selector,
+                                                   new_image->alpha_is_transparency};
                     if (auto it = m_pending_session->unresolved.find(key); it != m_pending_session->unresolved.end())
                     {
                         if (!it->second.empty())

--- a/src/app.h
+++ b/src/app.h
@@ -21,6 +21,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -521,6 +522,7 @@ private:
         {
             fs::path path;
             string   channel_selector;
+            bool     alpha_is_transparency = true;
             int      selected_group = 0, reference_group = 0;
             ImagePtr loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
         };
@@ -529,12 +531,13 @@ private:
         BlendMode_    blend_mode;
         json          view; ///< The session file's "view" sub-object, applied verbatim once loading completes
 
-        // An arriving image is matched to the earliest not-yet-filled entry sharing its (path, channel_selector).
+        // An arriving image is matched to the earliest not-yet-filled entry sharing its load options.
         // Entries sharing that key are guaranteed content-identical (loaded with identical options), so any
         // valid one-to-one assignment among them is correct regardless of which physical async load happens to
         // finish first -- this is what makes it safe to load the same file more than once in one session (e.g.
-        // to compare two channel groups of it side by side).
-        map<pair<fs::path, string>, deque<int>> unresolved;
+        // to compare two channel groups of it, or the same file with and without alpha as transparency).
+        using Key = std::tuple<fs::path, string, bool>; ///< path, channel_selector, alpha_is_transparency
+        map<Key, deque<int>> unresolved;
     };
     optional<PendingSession> m_pending_session;
 };

--- a/src/app.h
+++ b/src/app.h
@@ -388,9 +388,6 @@ private:
 
     bool m_clamp_to_LDR = false, m_dither = true, m_draw_grid = true, m_draw_pixel_info = true,
          m_draw_watched_pixels = true, m_draw_data_window = true, m_draw_display_window = true, m_show_FPS = false;
-    /// Ids of the current/reference pair whose clashing alpha conventions have already been logged, so
-    /// draw_image() reports each pairing once rather than every frame.
-    mutable int2 m_warned_alpha_mismatch{-1, -1};
     /// Zebra-stripe values below clip_range.x (x: shadows) and above clip_range.y (y: highlights)
     bool2  m_clip_warnings{false, false};
     float2 m_clip_range{0.f, 1.f};

--- a/src/app.h
+++ b/src/app.h
@@ -388,6 +388,9 @@ private:
 
     bool m_clamp_to_LDR = false, m_dither = true, m_draw_grid = true, m_draw_pixel_info = true,
          m_draw_watched_pixels = true, m_draw_data_window = true, m_draw_display_window = true, m_show_FPS = false;
+    /// Ids of the current/reference pair whose clashing alpha conventions have already been logged, so
+    /// draw_image() reports each pairing once rather than every frame.
+    mutable int2 m_warned_alpha_mismatch{-1, -1};
     /// Zebra-stripe values below clip_range.x (x: shadows) and above clip_range.y (y: highlights)
     bool2  m_clip_warnings{false, false};
     float2 m_clip_range{0.f, 1.f};

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -929,8 +929,31 @@ void Image::draw_info()
                               fmt::format("[{}, {}) {} [{}, {})", display_window.min.x, display_window.max.x,
                                           ICON_MY_TIMES, display_window.min.y, display_window.max.y));
             filtered_property("Alpha", alpha_type_name(alpha_type),
-                              "Type of alpha channel stored in the file. HDRView always converts the file's gamma to "
-                              "premultiplied alpha upon load.");
+                              "Type of alpha channel stored in the file. When treated as transparency, HDRView "
+                              "converts it to premultiplied alpha upon load.");
+            // Only offered when the file declares an alpha channel: a file that states its extra channel
+            // is data (e.g. TIFF's EXTRASAMPLE_UNSPECIFIED) isn't overridden from here.
+            if (alpha_type != AlphaType_None)
+            {
+                if (filter.PassFilter("Alpha is transparency"))
+                    ImGui::PE::Entry(
+                        "Is transparency",
+                        [this]
+                        {
+                            bool value = alpha_is_transparency;
+                            if (!ImGui::Checkbox("##Alpha is transparency", &value))
+                                return false;
+                            // The premultiply happens in-place on load, so switching interpretation means
+                            // re-reading the file; reload_image() carries the new setting through.
+                            alpha_is_transparency = value;
+                            // draw_info() is only ever drawn for the current image (see the Info window)
+                            hdrview()->reload_image(hdrview()->current_image());
+                            return true;
+                        },
+                        "Whether the alpha channel means transparency. Turn this off for files whose alpha is "
+                        "really a mask or other data: it is then shown as an ordinary channel of its own and "
+                        "nothing is premultiplied by it.\n\nChanging this re-reads the file from disk.");
+            }
             if (exif.valid())
                 filtered_property("EXIF data", fmt::format("{:.0h}", human_readible{exif.size()}),
                                   "Size of the EXIF metadata block embedded in the image file.");

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -837,6 +837,10 @@ void Image::build_layers_and_groups()
                 break;
             if (layer_channels.size() < group_channel_names.size())
                 continue;
+            // Skipping the alpha-bearing patterns lets the alpha-free one match instead, leaving 'A' to
+            // fall through to the single-channel groups created below.
+            if (!alpha_is_transparency && group_has_alpha(group_type))
+                continue;
             auto found = find_group_channels(layer_channels, layer.name, group_channel_names);
 
             // if we found all the group channels, then create them and remove from list of all channels
@@ -1148,10 +1152,7 @@ void Image::finalize()
     {
         for (auto &g : groups)
         {
-            bool has_alpha =
-                g.num_channels > 1 && (g.type == ChannelGroup::RGBA_Channels || g.type == ChannelGroup::YA_Channels ||
-                                       g.type == ChannelGroup::YCA_Channels || g.type == ChannelGroup::XYZA_Channels);
-            if (!has_alpha)
+            if (g.num_channels <= 1 || !group_has_alpha(g.type))
                 continue;
 
             for (int c = 0; c < g.num_channels - 1; ++c)

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -300,8 +300,9 @@ float2 PixelStats::x_limits(float e, AxisScale scale) const
     return ret;
 }
 
-void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Channel *ref, int2 ref_data_origin,
-                           const Settings &desired, std::atomic<bool> &canceled)
+void PixelStats::calculate(const Channel &img, const Channel *alpha, int2 img_data_origin, const Channel *ref,
+                           const Channel *ref_alpha, int2 ref_data_origin, const Settings &desired,
+                           std::atomic<bool> &canceled)
 {
     try
     {
@@ -333,7 +334,12 @@ void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Chann
         if (croi.size() != rroi.size())
             spdlog::error("Image and reference channel ROIs are not the same size!");
 
-        auto pixel_value = [&img, img_data_origin, ref, &croi, &rroi, this](int i)
+        // Report what the file holds: a straight-alpha channel was premultiplied on load, so divide that
+        // back out (`alpha` is null for channels that weren't, and for the alpha channel itself).
+        auto sample = [](const Channel &c, const Channel *a, int2 p)
+        { return a ? c(p) / std::max(k_small_alpha, (*a)(p)) : c(p); };
+
+        auto pixel_value = [&img, alpha, img_data_origin, ref, ref_alpha, &croi, &rroi, sample, this](int i)
         {
             int2 i2d(i % croi.size().x, i / croi.size().x); // convert to 2D coordinates
             if (i2d.y >= croi.size().y)
@@ -341,13 +347,13 @@ void PixelStats::calculate(const Channel &img, int2 img_data_origin, const Chann
                 // spdlog::error("Pixel index {} ({}) out of bounds for ROI {}..{}", i, i2d, croi.min, croi.max);
                 return std::numeric_limits<float>::quiet_NaN(); // out of bounds
             }
-            float val = img(i2d + croi.min - img_data_origin);
+            float val = sample(img, alpha, i2d + croi.min - img_data_origin);
             // BlendMode_Normal discards the reference sample (blend() just returns `val`), and croi is only
             // intersected with rroi above when the reference is actually going to be sampled -- so sampling it
             // here regardless of blend mode risks indexing outside ref's bounds whenever the two channels
             // differ in size.
             if (ref && settings.blend_mode != BlendMode_Normal)
-                val = blend(val, (*ref)(i2d + croi.min - rroi.min), settings.blend_mode);
+                val = blend(val, sample(*ref, ref_alpha, i2d + croi.min - rroi.min), settings.blend_mode);
             return val;
         };
 
@@ -599,10 +605,23 @@ void Channel::update_stats(int c, ConstImagePtr img1, ConstImagePtr img2)
         hdrview()->exposure(),   hdrview()->histogram_x_scale(), hdrview()->histogram_y_scale(),   hdrview()->roi(),
         hdrview()->blend_mode(), img2 ? img2->id : -1,           img2 ? img2->reference_group : -1};
 
+    // The group's alpha channel, when this channel needs dividing by it to report the file's values.
+    // Null for the alpha channel itself, which is stored as the file had it.
+    auto alpha_of = [c](const ConstImagePtr &img, int group_idx) -> const Channel *
+    {
+        if (!img || !img->is_valid_group(group_idx))
+            return nullptr;
+        const ChannelGroup &g = img->groups[group_idx];
+        return img->unpremultiplies(g) && c != g.num_channels - 1 ? &img->channels[g.channels[g.num_channels - 1]]
+                                                                  : nullptr;
+    };
+
     auto recompute_async_stats = [this, desired_settings, img1, img_data_origin = img1->data_window.min,
+                                  alpha           = alpha_of(img1, img1->selected_group),
                                   ref             = (img2 && img2->is_valid_group(img2->reference_group))
                                                         ? &img2->channels[img2->groups[img2->reference_group].channels[c]]
                                                         : nullptr,
+                                  ref_alpha       = alpha_of(img2, img2 ? img2->reference_group : -1),
                                   ref_data_origin = img2 ? img2->data_window.min : int2{}]()
     {
         spdlog::debug("id: {}", img1->id);
@@ -617,10 +636,12 @@ void Channel::update_stats(int c, ConstImagePtr img1, ConstImagePtr img2)
         // create the new task
         async_canceled = make_shared<atomic<bool>>(false);
         async_tracker  = do_async(
-            [this, desired_settings, canceled = async_canceled, img_data_origin, ref, ref_data_origin]()
+            [this, desired_settings, canceled = async_canceled, img_data_origin, alpha, ref, ref_alpha,
+             ref_data_origin]()
             {
                 spdlog::debug("Starting a new stats computation");
-                async_stats->calculate(*this, img_data_origin, ref, ref_data_origin, desired_settings, *canceled);
+                async_stats->calculate(*this, alpha, img_data_origin, ref, ref_alpha, ref_data_origin,
+                                       desired_settings, *canceled);
             });
         async_settings = desired_settings;
     };
@@ -1278,6 +1299,12 @@ float4 Image::raw_pixel(int2 p, Target_ target) const
 
     float4 value{0.f};
     for (int c = 0; c < group.num_channels; ++c) value[c] = channels[group.channels[c]](p - data_window.min);
+
+    if (unpremultiplies(group))
+    {
+        float a = std::max(k_small_alpha, value[group.num_channels - 1]);
+        for (int c = 0; c < group.num_channels - 1; ++c) value[c] /= a;
+    }
 
     return value;
 }

--- a/src/image.h
+++ b/src/image.h
@@ -115,8 +115,9 @@ struct PixelStats
     PixelStats() = default;
 
     /// Populate the statistics from the provided img and settings
-    void calculate(const Channel &img, int2 img_data_origin, const Channel *ref, int2 ref_data_origin,
-                   const Settings &desired, std::atomic<bool> &canceled);
+    void calculate(const Channel &img, const Channel *alpha, int2 img_data_origin, const Channel *ref,
+                   const Channel *ref_alpha, int2 ref_data_origin, const Settings &desired,
+                   std::atomic<bool> &canceled);
 
     int    clamp_idx(int i) const { return std::clamp(i, 0, NUM_BINS - 1); }
     float &bin_y(int i) { return hist_ys[clamp_idx(i)]; }
@@ -379,6 +380,14 @@ public:
     void        apply_exif_orientation();
     void        compute_color_transform();
     std::string to_string() const;
+
+    //! True when `group`'s values were premultiplied by finalize() and so must be divided back out to
+    //! report what the file holds. Straight-alpha files only: a file that stored premultiplied values has
+    //! no straight form for its alpha=0 pixels.
+    bool unpremultiplies(const ChannelGroup &group) const
+    {
+        return alpha_type == AlphaType_Straight && group.num_channels > 1 && group_has_alpha(group.type);
+    }
 
     template <typename T>
     std::unique_ptr<T[]> as_interleaved(int *w, int *h, int *n, float gain = 1.f,

--- a/src/image.h
+++ b/src/image.h
@@ -248,6 +248,13 @@ public:
     float4x4 colors() const;
 };
 
+//! True for the group types whose last channel is an alpha channel.
+inline bool group_has_alpha(ChannelGroup::Type type)
+{
+    return type == ChannelGroup::RGBA_Channels || type == ChannelGroup::YA_Channels ||
+           type == ChannelGroup::YCA_Channels || type == ChannelGroup::XYZA_Channels;
+}
+
 struct Layer
 {
 public:
@@ -297,6 +304,9 @@ public:
     ColorGamut_                   color_space       = ColorGamut_Unspecified;
     WhitePoint_                   white_point       = WhitePoint_Unspecified;
     AlphaType            alpha_type = AlphaType_None; //!< Does the image have straight (unpremultiplied) alpha?
+    bool alpha_is_transparency = true; //!< When false, an 'A' channel is grouped on its own as ordinary data
+                                       //!< instead of joining an RGBA/YA/YCA/XYZA group, so nothing is
+                                       //!< premultiplied by it. Read by finalize(), so set it before calling.
     json                 metadata   = json::object();
     Exif                 exif;     //!< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; //!< The raw XMP data from the file, if any

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -512,6 +512,15 @@ vector<ImagePtr> load_exr_image(istream &is_, string_view filename, const ImageL
             continue;
         }
 
+        // EXR stores color channels premultiplied, so record that rather than leaving the default of
+        // AlphaType_None -- Image::finalize() and the display path both key off this.
+        for (const auto &c : img->channels)
+            if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
+            {
+                img->alpha_type = AlphaType_PremultipliedLinear;
+                break;
+            }
+
         part.setFrameBuffer(framebuffer);
         part.readPixels(dataWindow.min.y, dataWindow.max.y);
 

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -806,6 +806,12 @@ void draw_load_image_options_dialog(bool &open)
                        "only load layers which contain either of these two words, and \"-.A\" would exclude channels "
                        "named \"A\". Leave empty to load all parts.");
 
+        ImGui::Checkbox("Alpha channel is transparency", &s_opts.alpha_is_transparency);
+        ImGui::Tooltip("By default an alpha channel is treated as transparency: HDRView premultiplies the color "
+                       "channels by it on load, and composites the image against the background. Turn this off for "
+                       "files whose fourth channel is really a mask or other data, to load it as an ordinary "
+                       "channel of its own that nothing is multiplied by.");
+
         ImGui::Checkbox("Override file's color profile", &s_opts.override_profile);
         ImGui::Tooltip("By default, HDRView tries to detect the color profile of the image from metadata stored in the "
                        "file. Enabling this option instructs HDRView to ignore any color profile information in the "
@@ -992,8 +998,7 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
             throw invalid_argument("Invalid input stream");
 
         vector<ImagePtr> images;
-        int              num_successful = 0;
-        string           active_loader  = "";
+        string           active_loader = "";
         for (auto &loader : g_loaders)
         {
             if (!loader.enabled)
@@ -1017,14 +1022,41 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
         std::streampos size = is.tellg();
         is.seekg(pos);
 
+        // EXR and JPEG XL apply the channel selector while decoding, so they never read what they'd
+        // discard. Every other loader ignores it, so apply it here to whatever they produced.
+        ImGuiTextFilter filter{opts.channel_selector.c_str()};
+        filter.Build();
+
+        vector<ImagePtr> kept;
+        kept.reserve(images.size());
         for (auto i : images)
         {
             try
             {
-                i->finalize();
+                if (!opts.channel_selector.empty())
+                {
+                    // Qualify each channel by its part and prefix a '.', so a selector like "-.A" excludes
+                    // a bare "A" as well as a layer's "diffuse.A".
+                    auto excluded = [&](const Channel &c)
+                    {
+                        auto name = i->partname.empty() ? "." + c.name : fmt::format(".{}.{}", i->partname, c.name);
+                        return !filter.PassFilter(name.c_str());
+                    };
+                    i->channels.erase(remove_if(begin(i->channels), end(i->channels), excluded), end(i->channels));
+
+                    if (i->channels.empty())
+                    {
+                        spdlog::debug("Skipping part '{}': no channels match the selector '{}'", i->partname,
+                                      opts.channel_selector);
+                        continue;
+                    }
+                }
+
                 i->filename   = filename;
-                i->short_name = i->file_and_partname();
                 i->size_bytes = static_cast<size_t>(size);
+                // A loader that already knows the file's extra channel isn't alpha keeps that; the option
+                // can only turn transparency off, never assert it against what the file says.
+                i->alpha_is_transparency = i->alpha_is_transparency && opts.alpha_is_transparency;
 
                 // If multiple image "parts" were loaded and they have names, store these names in the image's
                 // channel selector. This is useful if we later want to reload a specific image part from the
@@ -1041,7 +1073,11 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
                     else
                         i->channel_selector = opts.channel_selector;
                 }
-                ++num_successful;
+                i->short_name = i->file_and_partname();
+
+                // finalize() consumes alpha_is_transparency, so it runs after the options are stamped on
+                i->finalize();
+                kept.push_back(i);
             }
             catch (const exception &e)
             {
@@ -1049,9 +1085,9 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
                 continue; // skip this image
             }
         }
-        spdlog::info("Loaded {} images from {} using {} in {:f} seconds.", num_successful, filename, active_loader,
+        spdlog::info("Loaded {} images from {} using {} in {:f} seconds.", kept.size(), filename, active_loader,
                      timer.elapsed() / 1000.f);
-        return images;
+        return kept;
     }
     catch (const exception &e)
     {

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -25,6 +25,10 @@ struct ImageLoadOptions
     //! Comma-separated list of channel names to include or exclude from the image. If empty, all channels are selected.
     string channel_selector;
 
+    //! When false, an alpha channel is loaded as ordinary data instead of transparency: it is grouped on its own
+    //! and the color channels are not premultiplied by it. See Image::alpha_is_transparency.
+    bool alpha_is_transparency = true;
+
     bool override_profile = false;
     //! Override any metadata in the file and decode pixel values using this color gamut.
     ColorGamut_ gamut_override = ColorGamut_sRGB_BT709;

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -144,41 +144,57 @@ struct TiffInput
     static void unmap(thandle_t, tdata_t, toff_t) {}
 };
 
-// Custom TIFF I/O for writing to ostream
+// Custom TIFF I/O for writing to an ostream. libtiff seeks past the end of the output while laying out a
+// file and expects the gap to be filled, which ostringstream (HDRView's only save path) refuses to do, so
+// assemble the file in a memory buffer that grows on such seeks and hand it over once libtiff closes it.
 struct TiffOutput
 {
     ostream     *os;
     vector<char> buffer;
+    size_t       pos = 0;
 
     explicit TiffOutput(ostream *os) : os(os) {}
 
-    static tsize_t read(thandle_t /*handle*/, tdata_t /*data*/, tsize_t /*size*/) { return 0; }
+    static tsize_t read(thandle_t handle, tdata_t data, tsize_t size)
+    {
+        auto tiff      = reinterpret_cast<TiffOutput *>(handle);
+        auto available = tiff->pos < tiff->buffer.size() ? tsize_t(tiff->buffer.size() - tiff->pos) : tsize_t(0);
+        size           = std::min(size, available);
+        if (size <= 0)
+            return 0;
+        memcpy(data, tiff->buffer.data() + tiff->pos, size_t(size));
+        tiff->pos += size_t(size);
+        return size;
+    }
 
     static tsize_t write(thandle_t handle, tdata_t data, tsize_t size)
     {
         auto tiff = reinterpret_cast<TiffOutput *>(handle);
-        tiff->os->write(reinterpret_cast<const char *>(data), size);
-        return tiff->os->good() ? size : 0;
+        if (tiff->pos + size_t(size) > tiff->buffer.size())
+            tiff->buffer.resize(tiff->pos + size_t(size), 0);
+        memcpy(tiff->buffer.data() + tiff->pos, data, size_t(size));
+        tiff->pos += size_t(size);
+        return size;
     }
 
     static toff_t seek(thandle_t handle, toff_t offset, int whence)
     {
         auto tiff = reinterpret_cast<TiffOutput *>(handle);
-        tiff->os->seekp(offset, whence == SEEK_SET ? ios::beg : (whence == SEEK_CUR ? ios::cur : ios::end));
-        return tiff->os->tellp();
+        auto base = whence == SEEK_SET  ? toff_t(0)
+                    : whence == SEEK_CUR ? toff_t(tiff->pos)
+                                         : toff_t(tiff->buffer.size());
+        tiff->pos = size_t(base + offset);
+        return toff_t(tiff->pos);
     }
 
-    static int close(thandle_t) { return 0; }
-
-    static toff_t get_size(thandle_t handle)
+    static int close(thandle_t handle)
     {
         auto tiff = reinterpret_cast<TiffOutput *>(handle);
-        auto pos  = tiff->os->tellp();
-        tiff->os->seekp(0, ios::end);
-        auto size = tiff->os->tellp();
-        tiff->os->seekp(pos);
-        return size;
+        tiff->os->write(tiff->buffer.data(), std::streamsize(tiff->buffer.size()));
+        return tiff->os->good() ? 0 : -1;
     }
+
+    static toff_t get_size(thandle_t handle) { return toff_t(reinterpret_cast<TiffOutput *>(handle)->buffer.size()); }
 };
 
 // Helper to check TIFF signature
@@ -330,7 +346,9 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         uint16_t  num_extra_samples   = 0;
         uint16_t *extra_samples_types = nullptr;
 
-        if (TIFFGetField(tif, TIFFTAG_EXTRASAMPLES, &num_extra_samples, &extra_samples_types))
+        const bool has_extra_samples =
+            TIFFGetField(tif, TIFFTAG_EXTRASAMPLES, &num_extra_samples, &extra_samples_types) != 0;
+        if (has_extra_samples)
         {
             // Look for alpha channel in extra samples
             for (uint16_t i = 0; i < num_extra_samples; ++i)
@@ -352,8 +370,9 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
             }
         }
 
-        // If no EXTRASAMPLES tag, infer alpha presence from channel count
-        if (!has_alpha && num_channels == 4)
+        // Only guess when the file said nothing. An EXTRASAMPLES tag naming something other than alpha
+        // (EXTRASAMPLE_UNSPECIFIED) is the file stating the extra sample is arbitrary data, so honor it.
+        if (!has_alpha && !has_extra_samples && num_channels == 4)
         {
             has_alpha = true;
             // Default to straight alpha if not specified
@@ -365,6 +384,10 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         // Track what type of alpha the file contained (not what we convert it to internally)
         image->alpha_type =
             has_alpha ? (is_premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight) : AlphaType_None;
+        // An EXTRASAMPLES tag that names something other than alpha states the extra sample is arbitrary
+        // data, so keep it out of an alpha-bearing group entirely.
+        if (has_extra_samples && !has_alpha)
+            image->alpha_is_transparency = false;
         image->metadata["loader"] = "libtiff";
         image->partname           = partname;
 
@@ -905,27 +928,8 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
 
         image->metadata["color profile"] = profile_desc;
 
-        // Convert straight alpha to premultiplied if needed (HDRView uses premultiplied alpha pipeline)
-        // Note: image->alpha_type tracks what the file contained, not our internal representation
-        if (has_alpha && !is_premultiplied && num_channels == 4)
-        {
-            spdlog::debug("Converting straight alpha to premultiplied");
-            int block_size = std::max(1, 1024 * 1024);
-            parallel_for(blocked_range<int>(0, (int)(width * height), block_size),
-                         [&float_pixels](int begin, int end, int, int)
-                         {
-                             for (int i = begin; i < end; ++i)
-                             {
-                                 size_t pixel_idx = i * 4;
-                                 float  alpha     = float_pixels[pixel_idx + 3];
-
-                                 // Premultiply RGB channels by alpha
-                                 float_pixels[pixel_idx + 0] *= alpha;
-                                 float_pixels[pixel_idx + 1] *= alpha;
-                                 float_pixels[pixel_idx + 2] *= alpha;
-                             }
-                         });
-        }
+        // Straight alpha is premultiplied by Image::finalize(), which is the single place that does so
+        // for every format; image->alpha_type above tells it what the file contained.
 
         // Copy processed pixels to image channels
         for (int c = 0; c < num_channels; ++c)
@@ -1277,6 +1281,14 @@ void save_tiff_image(const Image &img, std::ostream &os, std::string_view filena
     TIFFSetField(tif, TIFFTAG_IMAGELENGTH, h);
     TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, n);
     TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+
+    // The pixels below are written premultiplied (as_interleaved is asked not to undo it), which is
+    // what EXTRASAMPLE_ASSOCALPHA describes.
+    if (n == 2 || n == 4)
+    {
+        uint16_t extra_samples[] = {EXTRASAMPLE_ASSOCALPHA};
+        TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, uint16_t(1), extra_samples);
+    }
 
     // Set photometric interpretation
     if (n == 1)

--- a/src/imageio/webp.cpp
+++ b/src/imageio/webp.cpp
@@ -286,9 +286,10 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
         int              frame_idx = 0;
         const ScopeGuard iter_guard{[&iter] { WebPDemuxReleaseIterator(&iter); }};
         do {
-            // Check channel filter
+            // Select whole frames by name here; load_image() applies the selector per channel afterwards,
+            // so a still image has no name to match against and must not be filtered out on that basis.
             string partname = has_animation ? fmt::format("frame {:04}", frame_idx) : "";
-            if (!filter.PassFilter(partname.c_str()))
+            if (has_animation && !filter.PassFilter(partname.c_str()))
             {
                 spdlog::debug("Skipping frame {} (filtered out)", frame_idx);
                 frame_idx++;

--- a/tests/test_exr_io.cpp
+++ b/tests/test_exr_io.cpp
@@ -8,6 +8,7 @@
 
 #include "image.h"
 #include "imageio/exr.h"
+#include "imageio/image_loader.h"
 #include "imageio/exr_save_options.h"
 
 #include <fstream>
@@ -111,6 +112,31 @@ TEST_CASE("EXR load respects channel_selector, including selectors matching noth
         CHECK(reloaded[0]->channels[0].name == "R");
     }
 
+    SUBCASE("excluding an unqualified channel name")
+    {
+        // "-.A" is a substring search for ".A", which a bare "A" doesn't contain -- load_image()
+        // normalizes each channel to a dot-prefixed name so the documented example works either way.
+        const int2 size{2, 2};
+        auto       rgba = std::make_shared<Image>(size, 4);
+        for (auto &c : rgba->channels)
+            for (int y = 0; y < size.y; ++y)
+                for (int x = 0; x < size.x; ++x) c(x, y) = 0.5f;
+        rgba->finalize();
+
+        std::ostringstream out(std::ios::binary);
+        auto               save_opts = exr_default_save_options(*rgba);
+        save_exr_image(*rgba, out, "test.exr", &save_opts);
+
+        std::istringstream in(out.str(), std::ios::binary);
+        ImageLoadOptions   load_opts;
+        load_opts.channel_selector = "-.A";
+        auto reloaded              = load_image(in, "test.exr", load_opts);
+
+        REQUIRE(reloaded.size() == 1);
+        REQUIRE(reloaded[0]->channels.size() == 3);
+        for (const auto &c : reloaded[0]->channels) CHECK(c.name != "A");
+    }
+
     SUBCASE("selector matching no channels yields no images")
     {
         std::ostringstream out(std::ios::binary);
@@ -123,6 +149,32 @@ TEST_CASE("EXR load respects channel_selector, including selectors matching noth
         auto reloaded              = load_exr_image(in, "test.exr", load_opts);
 
         CHECK(reloaded.empty());
+    }
+}
+
+TEST_CASE("EXR load reports the format's premultiplied alpha convention")
+{
+    // EXR color channels are premultiplied by convention, so an alpha-bearing part must not be
+    // reported as straight -- Image::finalize() would premultiply values that already are.
+    SUBCASE("a part with an alpha channel")
+    {
+        const int2 size{2, 2};
+        auto       img = std::make_shared<Image>(size, 4);
+        for (auto &c : img->channels)
+            for (int y = 0; y < size.y; ++y)
+                for (int x = 0; x < size.x; ++x) c(x, y) = 0.5f;
+        img->finalize();
+
+        auto reloaded = save_and_reload(*img);
+        REQUIRE(reloaded.size() == 1);
+        CHECK(reloaded[0]->alpha_type == AlphaType_PremultipliedLinear);
+    }
+
+    SUBCASE("a part without an alpha channel")
+    {
+        auto reloaded = save_and_reload(*make_test_image(int2{2, 2}));
+        REQUIRE(reloaded.size() == 1);
+        CHECK(reloaded[0]->alpha_type == AlphaType_None);
     }
 }
 

--- a/tests/test_image_groups.cpp
+++ b/tests/test_image_groups.cpp
@@ -69,6 +69,30 @@ TEST_CASE("alpha_is_transparency=false splits alpha off and skips the premultipl
     CHECK(img->channels[3](0, 0) == doctest::Approx(0.5f));
 }
 
+TEST_CASE("raw_pixel reports the file's values for a straight-alpha image")
+{
+    SUBCASE("straight alpha is divided back out")
+    {
+        auto img = make_rgba_image(AlphaType_Straight, /*alpha_is_transparency*/ true);
+
+        // Stored premultiplied as 0.5; the file held 1.0.
+        CHECK(img->channels[0](0, 0) == doctest::Approx(0.5f));
+        auto p = img->raw_pixel(int2{0, 0});
+        CHECK(p.x == doctest::Approx(1.f));
+        CHECK(p.w == doctest::Approx(0.5f)); // the alpha channel itself is untouched
+    }
+
+    SUBCASE("a premultiplied file is reported as stored")
+    {
+        // Its alpha=0 pixels have no straight form, so its values are what the author intended.
+        auto img = make_rgba_image(AlphaType_PremultipliedLinear, /*alpha_is_transparency*/ true);
+
+        auto p = img->raw_pixel(int2{0, 0});
+        CHECK(p.x == doctest::Approx(1.f));
+        CHECK(p.w == doctest::Approx(0.5f));
+    }
+}
+
 TEST_CASE("alpha_is_transparency=false leaves premultiplied files untouched too")
 {
     auto img = make_rgba_image(AlphaType_PremultipliedLinear, /*alpha_is_transparency*/ false);

--- a/tests/test_image_groups.cpp
+++ b/tests/test_image_groups.cpp
@@ -1,0 +1,80 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "image.h"
+
+#include <string>
+
+namespace
+{
+
+// A 1x1 RGBA image whose color channels are 1 and whose alpha is 0.5, so a premultiply is visible.
+ImagePtr make_rgba_image(AlphaType alpha_type, bool alpha_is_transparency)
+{
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
+    img->channels[3](0, 0)      = 0.5f;
+    img->alpha_type             = alpha_type;
+    img->alpha_is_transparency  = alpha_is_transparency;
+    img->finalize();
+    return img;
+}
+
+const ChannelGroup *find_group(const ImagePtr &img, const std::string &name)
+{
+    for (const auto &g : img->groups)
+        if (g.name == name)
+            return &g;
+    return nullptr;
+}
+
+} // namespace
+
+TEST_CASE("straight alpha is premultiplied into one RGBA group by default")
+{
+    auto img = make_rgba_image(AlphaType_Straight, /*alpha_is_transparency*/ true);
+
+    REQUIRE(img->groups.size() == 1);
+    auto *rgba = find_group(img, "R,G,B,A");
+    REQUIRE(rgba != nullptr);
+    CHECK(rgba->type == ChannelGroup::RGBA_Channels);
+    CHECK(rgba->num_channels == 4);
+
+    CHECK(img->channels[0](0, 0) == doctest::Approx(0.5f));
+}
+
+TEST_CASE("alpha_is_transparency=false splits alpha off and skips the premultiply")
+{
+    auto img = make_rgba_image(AlphaType_Straight, /*alpha_is_transparency*/ false);
+
+    // R,G,B group next in the table, with A left over as its own single-channel group.
+    REQUIRE(img->groups.size() == 2);
+    auto *rgb = find_group(img, "R,G,B");
+    REQUIRE(rgb != nullptr);
+    CHECK(rgb->type == ChannelGroup::RGB_Channels);
+    CHECK(rgb->num_channels == 3);
+
+    auto *a = find_group(img, "A");
+    REQUIRE(a != nullptr);
+    CHECK(a->type == ChannelGroup::Single_Channel);
+    CHECK(a->num_channels == 1);
+
+    // No alpha-bearing group means finalize() has nothing to premultiply.
+    CHECK(img->channels[0](0, 0) == doctest::Approx(1.f));
+    CHECK(img->channels[3](0, 0) == doctest::Approx(0.5f));
+}
+
+TEST_CASE("alpha_is_transparency=false leaves premultiplied files untouched too")
+{
+    auto img = make_rgba_image(AlphaType_PremultipliedLinear, /*alpha_is_transparency*/ false);
+
+    REQUIRE(img->groups.size() == 2);
+    CHECK(find_group(img, "R,G,B") != nullptr);
+    CHECK(find_group(img, "A") != nullptr);
+    CHECK(img->channels[0](0, 0) == doctest::Approx(1.f));
+}

--- a/tests/test_pixel_stats.cpp
+++ b/tests/test_pixel_stats.cpp
@@ -55,7 +55,7 @@ TEST_CASE("PixelStats::calculate uses the selected sub-region, not the image ori
 
     PixelStats        stats;
     std::atomic<bool> canceled{false};
-    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+    stats.calculate(img, nullptr, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
 
     CHECK(stats.summary.valid_pixels == 4);
     CHECK(stats.summary.minimum == doctest::Approx(33.f));
@@ -76,7 +76,7 @@ TEST_CASE("PixelStats::calculate covers the whole image when no selection is act
 
     PixelStats        stats;
     std::atomic<bool> canceled{false};
-    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+    stats.calculate(img, nullptr, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
 
     // values range from 0 (0,0) to 33 (3,3) across all 16 pixels
     CHECK(stats.summary.valid_pixels == 16);
@@ -97,7 +97,7 @@ TEST_CASE("PixelStats::calculate offsets a non-zero image data origin correctly"
 
     PixelStats        stats;
     std::atomic<bool> canceled{false};
-    stats.calculate(img, int2{5, 5}, nullptr, int2{0, 0}, settings, canceled);
+    stats.calculate(img, nullptr, int2{5, 5}, nullptr, nullptr, int2{0, 0}, settings, canceled);
 
     CHECK(stats.summary.valid_pixels == 4);
     CHECK(stats.summary.minimum == doctest::Approx(33.f));
@@ -119,7 +119,7 @@ TEST_CASE("PixelStats::calculate counts NaN/Inf pixels separately and excludes t
 
     PixelStats        stats;
     std::atomic<bool> canceled{false};
-    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+    stats.calculate(img, nullptr, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
 
     CHECK(stats.summary.nan_pixels == 1);
     CHECK(stats.summary.inf_pixels == 2);
@@ -143,7 +143,7 @@ TEST_CASE("PixelStats::calculate applies each blend mode against a reference ima
 
         PixelStats        stats;
         std::atomic<bool> canceled{false};
-        stats.calculate(img, int2{0, 0}, &ref, int2{0, 0}, settings, canceled);
+        stats.calculate(img, nullptr, int2{0, 0}, &ref, nullptr, int2{0, 0}, settings, canceled);
 
         CHECK(stats.summary.valid_pixels == 4);
         // constant inputs -> every blended pixel is identical -> zero spread
@@ -172,7 +172,7 @@ TEST_CASE("PixelStats::calculate tolerates a reference channel smaller than the 
 
     PixelStats        stats;
     std::atomic<bool> canceled{false};
-    stats.calculate(img, int2{0, 0}, &ref, int2{0, 0}, settings, canceled);
+    stats.calculate(img, nullptr, int2{0, 0}, &ref, nullptr, int2{0, 0}, settings, canceled);
 
     CHECK(stats.summary.valid_pixels == 100);
     CHECK(stats.summary.minimum == doctest::Approx(0.f));
@@ -187,10 +187,41 @@ TEST_CASE("PixelStats::calculate resets to the default, uncomputed state when ca
 
     PixelStats        stats;
     std::atomic<bool> canceled{true}; // already canceled before calculate() even starts
-    stats.calculate(img, int2{0, 0}, nullptr, int2{0, 0}, settings, canceled);
+    stats.calculate(img, nullptr, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
 
     CHECK_FALSE(stats.computed);
     CHECK(stats.summary.valid_pixels == 0);
     CHECK(stats.summary.minimum == std::numeric_limits<float>::infinity());
     CHECK(stats.summary.maximum == -std::numeric_limits<float>::infinity());
+}
+
+TEST_CASE("PixelStats::calculate reports straight values when given an alpha channel")
+{
+    // A channel premultiplied on load (see Image::finalize()) has to be divided back out so the histogram
+    // and summary describe what the file holds rather than HDRView's internal representation.
+    Channel img("img", int2{2, 2});
+    Channel alpha("alpha", int2{2, 2});
+    alpha.apply([](float, int, int) { return 0.5f; });
+    img.apply([](float, int, int) { return 0.5f; }); // 1.0 straight, premultiplied by an alpha of 0.5
+
+    PixelStats::Settings settings;
+    std::atomic<bool>    canceled{false};
+
+    SUBCASE("with the alpha channel")
+    {
+        PixelStats stats;
+        stats.calculate(img, &alpha, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
+
+        CHECK(stats.summary.valid_pixels == 4);
+        CHECK(stats.summary.average == doctest::Approx(1.0));
+        CHECK(stats.summary.maximum == doctest::Approx(1.f));
+    }
+
+    SUBCASE("without it, the stored value is reported as-is")
+    {
+        PixelStats stats;
+        stats.calculate(img, nullptr, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
+
+        CHECK(stats.summary.average == doctest::Approx(0.5));
+    }
 }

--- a/tests/test_png_io.cpp
+++ b/tests/test_png_io.cpp
@@ -7,6 +7,7 @@
 #include <doctest/doctest.h>
 
 #include "image.h"
+#include "imageio/image_loader.h"
 #include "imageio/png.h"
 
 #include <fstream>
@@ -122,6 +123,60 @@ TEST_CASE("is_png_image correctly identifies real PNG bytes and rejects garbage"
 
     std::istringstream empty("", std::ios::binary);
     CHECK_FALSE(is_png_image(empty));
+}
+
+TEST_CASE("channel_selector drops channels in formats that don't filter during decode")
+{
+    // Only EXR and JPEG XL apply the selector while decoding; for every other format load_image()
+    // applies it centrally afterwards, so "-.A" has to work here just as it does for EXR.
+    const int2 size{2, 2};
+    auto       img = std::make_shared<Image>(size, 4);
+    for (auto &c : img->channels)
+        for (int y = 0; y < size.y; ++y)
+            for (int x = 0; x < size.x; ++x) c(x, y) = 0.5f;
+    img->finalize();
+
+    std::ostringstream out(std::ios::binary);
+    save_png_image(*img, out, "rgba.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                   /*sixteen_bit*/ false, TransferFunction::Linear);
+
+    SUBCASE("excluding the alpha channel by name")
+    {
+        ImageLoadOptions opts;
+        opts.channel_selector = "-.A";
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_image(in, "rgba.png", opts);
+
+        REQUIRE(reloaded.size() == 1);
+        REQUIRE(reloaded[0]->channels.size() == 3);
+        for (const auto &c : reloaded[0]->channels) CHECK(c.name != "A");
+        // save_png_image unpremultiplied on the way out, so the file holds 1.0 here; with the alpha
+        // channel filtered away there is nothing left to premultiply it back down by.
+        CHECK(reloaded[0]->channels[0](0, 0) == doctest::Approx(1.f).epsilon(0.005));
+    }
+
+    SUBCASE("selecting a single channel by name")
+    {
+        ImageLoadOptions opts;
+        opts.channel_selector = "G";
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_image(in, "rgba.png", opts);
+
+        REQUIRE(reloaded.size() == 1);
+        REQUIRE(reloaded[0]->channels.size() == 1);
+        CHECK(reloaded[0]->channels[0].name == "G");
+    }
+
+    SUBCASE("a selector matching nothing yields no images")
+    {
+        ImageLoadOptions opts;
+        opts.channel_selector = "NoSuchChannel";
+
+        std::istringstream in(out.str(), std::ios::binary);
+        CHECK(load_image(in, "rgba.png", opts).empty());
+    }
 }
 
 // The following tests need libpng's own vendored test image sets (PngSuite and testpngs), which HDRView's own

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -1,0 +1,125 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "image.h"
+#include "imageio/tiff.h"
+
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// A 2x1 8-bit RGBA uncompressed TIFF tagged EXTRASAMPLE_UNASSALPHA (straight alpha).
+// Pixel 0 is opaque white; pixel 1 is white at alpha 128/255.
+const unsigned char k_rgba_tiff[] = {
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x01, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00, 0x01, 0x01, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x01,
+    0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x92, 0x00, 0x00, 0x00, 0x03, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x06, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x11, 0x01,
+    0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x9a, 0x00, 0x00, 0x00, 0x15, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x00, 0x00, 0x16, 0x01, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x17, 0x01,
+    0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x1c, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x52, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x08, 0x00, 0x08, 0x00, 0x08, 0x00, 0x08, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x80};
+
+constexpr uint16_t k_extra_samples_tag = 338;
+constexpr float    k_half              = 128.f / 255.f;
+
+// Returns k_rgba_tiff with its EXTRASAMPLES tag rewritten, so the fixtures under test differ in
+// nothing but how the file describes its fourth sample. Walks the little-endian IFD rather than
+// hardcoding a byte offset.
+std::string tiff_with_extra_samples(uint16_t value)
+{
+    std::string bytes(reinterpret_cast<const char *>(k_rgba_tiff), sizeof(k_rgba_tiff));
+
+    auto read_u16 = [&](size_t o) { return uint16_t(uint8_t(bytes[o]) | (uint8_t(bytes[o + 1]) << 8)); };
+    auto read_u32 = [&](size_t o)
+    { return uint32_t(read_u16(o)) | (uint32_t(read_u16(o + 2)) << 16); };
+
+    REQUIRE(bytes.compare(0, 2, "II") == 0); // the fixture is little-endian
+    const uint32_t ifd     = read_u32(4);
+    const uint16_t entries = read_u16(ifd);
+    for (uint16_t i = 0; i < entries; ++i)
+    {
+        const size_t entry = ifd + 2 + size_t(i) * 12;
+        if (read_u16(entry) != k_extra_samples_tag)
+            continue;
+        // SHORT, count 1: the value lives inline in the first half of the entry's value field
+        bytes[entry + 8] = char(value & 0xff);
+        bytes[entry + 9] = char(value >> 8);
+        return bytes;
+    }
+    FAIL("fixture has no EXTRASAMPLES tag");
+    return bytes;
+}
+
+ImagePtr load_tiff(const std::string &bytes)
+{
+    std::istringstream in(bytes, std::ios::binary);
+    auto               images = load_tiff_image(in, "rgba.tif");
+    REQUIRE(images.size() == 1);
+    images[0]->finalize();
+    return images[0];
+}
+
+} // namespace
+
+TEST_CASE("TIFF with unassociated alpha is premultiplied exactly once")
+{
+    // EXTRASAMPLE_UNASSALPHA == 2
+    auto img = load_tiff(tiff_with_extra_samples(2));
+
+    REQUIRE(img->channels.size() == 4);
+    CHECK(img->alpha_type == AlphaType_Straight);
+    CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
+
+    // Premultiplying twice would leave k_half*k_half here instead.
+    CHECK(img->channels[0](0, 0) == doctest::Approx(1.f).epsilon(0.001));
+    CHECK(img->channels[0](1, 0) == doctest::Approx(k_half).epsilon(0.001));
+}
+
+TEST_CASE("TIFF tagged EXTRASAMPLE_UNSPECIFIED keeps its fourth sample as data")
+{
+    // EXTRASAMPLE_UNSPECIFIED == 0: the file states the extra sample is not alpha, so nothing is
+    // premultiplied and the color channels keep their stored values.
+    auto img = load_tiff(tiff_with_extra_samples(0));
+
+    REQUIRE(img->channels.size() == 4);
+    CHECK(img->alpha_type == AlphaType_None);
+    CHECK_FALSE(img->alpha_is_transparency);
+    CHECK(img->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
+    CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
+
+    // The extra sample stands on its own rather than joining an RGBA group that would composite it.
+    REQUIRE(img->groups.size() == 2);
+    CHECK(img->groups[0].type == ChannelGroup::RGB_Channels);
+    CHECK(img->groups[1].type == ChannelGroup::Single_Channel);
+}
+
+TEST_CASE("TIFF save/load round-trips alpha without repeated premultiplication")
+{
+    auto original = load_tiff(tiff_with_extra_samples(2));
+
+    // Saving to a std::ostringstream is the only path HDRView has -- draw_save_as_dialog() renders
+    // into one and then writes the buffer out. Float samples keep the comparison about alpha rather
+    // than about transfer-function encoding or 8-bit quantization.
+    std::ostringstream out(std::ios::binary);
+    save_tiff_image(*original, out, "roundtrip.tif", /*gain*/ 1.f, TransferFunction::Linear,
+                    /*compression*/ 0, /*data_type*/ 2);
+    REQUIRE(out.str().size() > 64);
+
+    auto reloaded = load_tiff(out.str());
+
+    REQUIRE(reloaded->channels.size() == 4);
+    for (int c = 0; c < 4; ++c)
+        for (int x = 0; x < 2; ++x)
+            CHECK(reloaded->channels[c](x, 0) == doctest::Approx(original->channels[c](x, 0)).epsilon(0.001));
+}


### PR DESCRIPTION
Fixes #182.

Selecting a single channel on a file with straight alpha showed it darkened by transparency:
`Image::finalize()` premultiplies the color channels on load and the display path never undid it, so
`choose_channel()` returned `R*A` with alpha forced opaque. The RGBA view was unaffected and already
matched Photoshop.

### Changes

- **Make `alpha_type` trustworthy.** EXR reports `AlphaType_PremultipliedLinear` for alpha-bearing parts
  (it said `None`). TIFF drops its loader-side premultiply, which ran *in addition to* `finalize()`'s and
  squared the alpha; honors `EXTRASAMPLE_UNSPECIFIED` instead of overriding it back to straight; and tags
  saved files `ASSOCALPHA` to match the premultiplied pixels actually written.
- **Convention-aware display.** RGB/Red/Green/Blue divide the premultiply back out, gated on *both* the
  current and reference images having stored straight alpha - a premultiplied file's `alpha=0` pixels
  carry real color that dividing would blow up. Mismatched pairs log a warning once per pairing.
- **"Alpha is transparency" load option.** When off, an `A` channel is grouped on its own as ordinary
  data and nothing is premultiplied by it. In the loading-options dialog and per image in the Info panel;
  carried through `reload_image()` and saved sessions. A file that states its extra channel is data
  (TIFF `EXTRASAMPLE_UNSPECIFIED`) keeps that; the option can only turn transparency off.
- **`channel_selector` applies per channel in every format.** Only EXR and JPEG XL filtered during
  decode; the rest ignored it. Now applied centrally in `load_image()` against a dot-prefixed,
  part-qualified name, so `-.A` excludes a bare `A` as well as a layer's `diffuse.A` - it previously
  matched neither in most formats, nor bare channels in EXR.

### Unrelated bug found along the way

TIFF export was producing a 17-byte stub. libtiff seeks past the end of the output while laying out a
file, which the `ostringstream` that every save goes through refuses to extend. `TiffOutput` now
assembles into a memory buffer and hands it over on close.

### Testing

`hdrview_tests` goes from 35 to 40 cases (352 assertions), all passing. Each fix was confirmed failing
before the corresponding change. Adds `tests/test_tiff_io.cpp` and `tests/test_image_groups.cpp`.