### PR TITLE
Fix the histogram comb: bin in the displayed axis space, at the source's bit depth

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -423,6 +423,10 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
                 m_show_FPS            = j.value<bool>("show FPS", m_show_FPS);
                 m_clip_range          = j.value<float2>("clip range", m_clip_range);
                 m_histogram_height    = j.value<float>("histogram height", m_histogram_height);
+                m_x_scale =
+                    clamp<int>(j.value<int>("histogram x scale", m_x_scale), 0, AxisScale_COUNT - 1);
+                m_y_scale =
+                    clamp<int>(j.value<int>("histogram y scale", m_y_scale), 0, AxisScale_COUNT - 1);
                 m_playback_speed      = j.value<float>("playback speed", m_playback_speed);
                 m_colormap_index      = clamp<int>(j.value<int>("colormap index", 0), 0, std::size(m_colormaps));
                 m_show_developer_menu = j.value<bool>("show developer menu", m_show_developer_menu);
@@ -492,6 +496,8 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
         j["show FPS"]                = m_show_FPS;
         j["clip range"]              = m_clip_range;
         j["histogram height"]        = m_histogram_height;
+        j["histogram x scale"]       = m_x_scale;
+        j["histogram y scale"]       = m_y_scale;
         j["show developer menu"]     = m_show_developer_menu;
         j["playback speed"]          = m_playback_speed;
         j["colormap index"]          = m_colormap_index;

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -408,7 +408,7 @@ void Image::draw_histogram()
             // the visible curve is the additive fill rasterized above. The item still has to be plotted,
             // since it owns the legend entry whose Show flag gates that fill.
             ImPlotSpec spec;
-            spec.LineColor = float4{colors[c].xyz(), 0.1f};
+            spec.LineColor = float4{colors[c].xyz(), 0.25f};
             spec.FillColor = float4{0.f};
             ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs[x_scale].data(), stats[c]->hist_ys[x_scale].data(),
                                stats[c]->num_bins, spec);

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -239,6 +239,9 @@ void Image::draw_histogram()
     string      names[4];
     auto        colors = group.colors();
 
+    // Each PixelStats holds one histogram per AxisScale; this picks the one the x axis is currently drawn in.
+    const AxisScale x_scale = hdrview()->histogram_x_scale();
+
     float2 x_limits = {std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()};
     float2 y_limits = x_limits;
     for (int c = 0; c < std::min(4, group.num_channels); ++c)
@@ -246,9 +249,9 @@ void Image::draw_histogram()
         auto &channel = channels[group.channels[c]];
         channel.update_stats(c, hdrview()->current_image(), hdrview()->reference_image());
         stats[c]    = channel.get_stats();
-        y_limits[0] = std::min(y_limits[0], stats[c]->hist_y_limits[0]);
-        y_limits[1] = std::max(y_limits[1], stats[c]->hist_y_limits[1]);
-        auto xl     = stats[c]->x_limits(hdrview()->exposure_live(), hdrview()->histogram_x_scale());
+        y_limits[0] = std::min(y_limits[0], stats[c]->hist_y_limits[x_scale][0]);
+        y_limits[1] = std::max(y_limits[1], stats[c]->hist_y_limits[x_scale][1]);
+        auto xl     = stats[c]->x_limits(hdrview()->exposure_live(), x_scale);
         x_limits[0] = std::min(x_limits[0], xl[0]);
         x_limits[1] = std::max(x_limits[1], xl[1]);
         names[c]    = Channel::tail(channel.name);
@@ -322,16 +325,22 @@ void Image::draw_histogram()
             int         px1        = (int)std::ceil(plot_pos.x + plot_size.x);
             ImDrawList *draw_list  = ImPlot::GetPlotDrawList();
 
-            // The histogram is piecewise-constant (one count per bin): the height across bin i's range is
-            // simply hist_ys[i]. Bins are uniform in the (nonlinear) asinh-transformed value space, not in
-            // raw pixel-value space, so finding the containing bin needs value_to_bin()'s asinh transform
-            // rather than a linear fraction of x's position in the range.
-            auto sample_height = [](const PixelStats *s, float x) -> float
+            // The histogram is piecewise-constant (one count per bin), so a screen column shows the tallest
+            // bin it covers. Reducing by the maximum keeps a bin narrower than a pixel from falling between
+            // samples, so a gap that survives is a range of values the source has no code for. The column's
+            // edges have to be resolved through value_to_bin() rather than scaled by their position, since
+            // the plot's x range follows exposure while the binned range follows the data.
+            auto column_height = [x_scale](const PixelStats *s, double xa, double xb) -> float
             {
-                int i = s->value_to_bin((double)x);
-                if (i < 0 || i >= PixelStats::NUM_BINS)
+                int i0 = s->value_to_bin(std::min(xa, xb), x_scale);
+                int i1 = s->value_to_bin(std::max(xa, xb), x_scale);
+                if (i1 < 0 || i0 >= s->num_bins)
                     return 0.f;
-                return s->hist_ys[i];
+
+                float h = 0.f;
+                for (int i = std::max(i0, 0); i <= std::min(i1, s->num_bins - 1); ++i)
+                    h = std::max(h, s->hist_ys[x_scale][i]);
+                return h;
             };
 
             // Raw ImDrawList calls (unlike ImPlot's own Plot* items, e.g. PlotStairs below) aren't
@@ -354,11 +363,13 @@ void Image::draw_histogram()
             std::array<float, 4> heights;
             for (int px = px0; px < px1; ++px)
             {
-                double x = ImPlot::PixelsToPlot(ImVec2((float)px + 0.5f, plot_pos.y)).x;
+                double xa = ImPlot::PixelsToPlot(ImVec2((float)px, plot_pos.y)).x;
+                double xb = ImPlot::PixelsToPlot(ImVec2((float)px + 1.f, plot_pos.y)).x;
+                double x  = 0.5 * (xa + xb);
 
                 for (int c = 0; c < n_channels; ++c)
                 {
-                    heights[c] = shown[c] ? std::max(0.f, sample_height(stats[c], (float)x)) : 0.f;
+                    heights[c] = shown[c] ? std::max(0.f, column_height(stats[c], xa, xb)) : 0.f;
                     order[c]   = c;
                 }
                 std::sort(order.begin(), order.begin() + n_channels,
@@ -399,8 +410,8 @@ void Image::draw_histogram()
             ImPlotSpec spec;
             spec.LineColor = float4{colors[c].xyz(), 0.1f};
             spec.FillColor = float4{0.f};
-            ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs.data(), stats[c]->hist_ys.data(),
-                               PixelStats::NUM_BINS, spec);
+            ImPlot::PlotStairs(names[c].c_str(), stats[c]->hist_xs[x_scale].data(), stats[c]->hist_ys[x_scale].data(),
+                               stats[c]->num_bins, spec);
 
             // Re-register the same label opaque to recolor its legend swatch: PlotDummy adopts the first
             // non-auto color in its spec as the legend icon color, and the legend isn't rendered until
@@ -421,7 +432,7 @@ void Image::draw_histogram()
                 spec.Marker     = ImPlotMarker_Circle;
                 spec.MarkerSize = 2.f;
                 ImPlot::PlotStems(fmt::format("##hover_{}", c).c_str(), &color32[c],
-                                  &stats[c]->bin_y(stats[c]->value_to_bin(color32[c])), 1, 0, spec);
+                                  &stats[c]->bin_y(stats[c]->value_to_bin(color32[c], x_scale), x_scale), 1, 0, spec);
 
                 ImPlot::TagX(color32[c], float4{colors[c].xyz(), 1.0f}, "%s", "");
             }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -454,62 +454,93 @@ void PixelStats::calculate(const Channel &img, const Channel *alpha, int2 img_da
 
         //
         // compute histograms
+        //
+        // Bins are laid out uniformly in the same transformed space the x axis is drawn in, so each bin is
+        // equally wide on screen and its height can be a plain count: with equal widths, bar height and bar
+        // area say the same thing. Every scale is binned in this one pass, which costs an extra transform
+        // per sample but leaves switching the x axis free. The bin count comes from the source's bit depth,
+        // since an n-bit channel cannot fill more bins than it has levels.
+        //
+        // The bins span the channel's own range so that the histogram never depends on exposure. On a
+        // linear x axis a single very bright sample therefore stretches the bins far past the visible range
+        // and crowds everything into the first few; the nonlinear scales, which is what high-dynamic-range
+        // content wants anyway, are unaffected.
 
-        static constexpr int x_scale = AxisScale_Asinh;
-        hist_normalization[0]        = (float)axis_scale_fwd_xform(summary.minimum, (void *)&x_scale);
-        hist_normalization[1] = (float)axis_scale_fwd_xform(summary.maximum, (void *)&x_scale) - hist_normalization[0];
+        // A blended value lies on neither channel's lattice, so this is only exactly right without a
+        // reference; it stays the best available bound on how many distinct values can show up.
+        num_bins = bins_for_bit_depth(img.bits_per_sample);
 
-        for (int i = 0; i < NUM_BINS; ++i) hist_xs[i] = (float)bin_to_value(i);
-
-        // accumulate bin counts
-        for (int i = 0; i < croi.volume(); ++i)
+        // An all-NaN channel has no range to bin over, and leaves every histogram empty.
+        if (std::isfinite(summary.minimum) && std::isfinite(summary.maximum))
         {
-            if (canceled)
-                throw std::runtime_error("Canceling histogram accumulation");
-            bin_y(value_to_bin(pixel_value(i))) += 1;
+            for (int s = 0; s < AxisScale_COUNT; ++s)
+            {
+                AxisScale x_scale        = (AxisScale)s;
+                hist_normalization[s]    = float2{(float)axis_scale_fwd(summary.minimum, x_scale), 0.f};
+                hist_normalization[s][1] = (float)axis_scale_fwd(summary.maximum, x_scale) - hist_normalization[s][0];
+
+                // A channel whose samples are all equal transforms to a zero-width range; widen it so that
+                // the bin index stays finite and that single value lands in bin 0.
+                if (!(hist_normalization[s][1] > 0.f))
+                    hist_normalization[s][1] = std::max(std::abs(hist_normalization[s][0]), 1.f) * 1e-6f;
+
+                for (int i = 0; i <= num_bins; ++i) hist_xs[s][i] = (float)bin_to_value(i, x_scale);
+            }
+
+            // Counts are accumulated as integers: a large flat region in a many-megapixel image can push a
+            // single bin past 2^24, beyond which incrementing a float stops having any effect.
+            using Bins = std::array<std::array<uint32_t, MAX_BINS>, AxisScale_COUNT>;
+
+            size_t            block_size  = 1024 * 1024;
+            const size_t      num_threads = estimate_threads(croi.volume(), block_size, *ThreadPool::singleton());
+            std::vector<Bins> partials(max<size_t>(1, num_threads));
+
+            spdlog::trace("Breaking histogram accumulation into {} work units.", partials.size());
+
+            parallel_for(
+                blocked_range<size_t>(0u, croi.volume(), block_size),
+                [&partials, &canceled, &pixel_value, this](size_t begin, size_t end, int unit_index, int)
+                {
+                    Bins &bins = partials[unit_index];
+
+                    for (size_t i = begin; i != end; ++i)
+                    {
+                        if (canceled)
+                            throw std::runtime_error("Canceling histogram accumulation");
+
+                        float val = pixel_value((int)i);
+                        if (!std::isfinite(val)) //< the summary counts these instead
+                            continue;
+
+                        for (int s = 0; s < AxisScale_COUNT; ++s)
+                            ++bins[s][clamp_idx(value_to_bin(val, (AxisScale)s))];
+                    }
+                },
+                (int)num_threads);
+
+            for (const auto &bins : partials)
+                for (int s = 0; s < AxisScale_COUNT; ++s)
+                    for (int i = 0; i < num_bins; ++i) hist_ys[s][i] += (float)bins[s][i];
         }
 
-        // normalize histogram density by dividing bin counts by bin sizes
-        hist_y_limits[0] = std::numeric_limits<float>::infinity();
-        std::array<float, NUM_BINS> bin_sizes;
-        for (int i = 0; i < NUM_BINS; ++i)
+        for (int s = 0; s < AxisScale_COUNT; ++s)
         {
-            bin_sizes[i] = float(bin_to_value(i + 1) - bin_to_value(i));
-            hist_ys[i] /= bin_sizes[i];
-            hist_y_limits[0] = min(hist_y_limits[0], bin_sizes[i]);
+            // ImPlot's SymLog y scale is 2*asinh(y/2), which is defined at zero, so both y scales can start
+            // at the baseline.
+            hist_y_limits[s][0] = 0.f;
+
+            // Take the (drop+1)-th tallest bin rather than the tallest, so the one enormous spike that a
+            // flat background or a clipped highlight produces doesn't squash everything else flat. Those
+            // few bins run off the top of the plot, which reads correctly as "off the scale".
+            const int                   drop = std::min(num_bins - 1, 1 + num_bins / 128);
+            std::array<float, MAX_BINS> sorted;
+            std::copy_n(hist_ys[s].begin(), num_bins, sorted.begin());
+            std::nth_element(sorted.begin(), sorted.begin() + drop, sorted.begin() + num_bins, std::greater<float>());
+            hist_y_limits[s][1] = std::max(1.f, sorted[drop]);
         }
 
-        // Compute y limit for each histogram according to its 10th-largest bin
-        std::array<int, NUM_BINS> indices;
-        std::iota(indices.begin(), indices.end(), 0);
-        // Partially sort indices by descending hist_ys value
-        // auto idx = int(0.1 * NUM_BINS);
-        std::sort(indices.begin(), indices.end(), [&](int a, int b) { return hist_ys[a] < hist_ys[b]; });
-        // for logarithmic y-axis, we need a non-zero lower y-limit, so use half the smallest possible value
-        hist_y_limits[0] = settings.y_scale == AxisScale_Linear ? 0.f : hist_y_limits[0];
-        // for upper y-limit, accumulate bins in descending order until reaching perc% of total area
-
-        float total_area    = (float)croi.volume();
-        float required_area = 0.99f * total_area; // percentage of total area to accumulate
-
-        double accum_area = 0.0;
-        hist_y_limits[1]  = 1.f;
-        int i;
-        for (i = 0; i < int(0.95f * NUM_BINS); ++i)
-        {
-            int bin_idx = indices[i]; // sorted by descending hist_ys
-            accum_area += hist_ys[bin_idx] * bin_sizes[bin_idx];
-            if (accum_area >= required_area)
-                break;
-        }
-        hist_y_limits[1] = hist_ys[indices[i]];
-
-        // fallback if all bins are zero
-        if (hist_y_limits[1] == 0.f)
-            hist_y_limits[1] = 1.f;
-
-        spdlog::trace("Histogram computed in {} ms:\nx_limits: {}\ny_limits: {}", timer.lap(),
-                      float2{summary.minimum, summary.maximum}, hist_y_limits);
+        spdlog::trace("Histogram computed in {} ms into {} bins:\nx_limits: {}\ny_limits: {}", timer.lap(), num_bins,
+                      float2{summary.minimum, summary.maximum}, hist_y_limits[settings.x_scale]);
 
         computed = true;
     }
@@ -578,6 +609,8 @@ Texture *Channel::get_texture()
 
 bool PixelStats::Settings::match(const Settings &other) const
 {
+    // Only what changes the computed values counts. exposure never reaches the computation, every x_scale
+    // is binned, and y_scale only picks which stored histogram the plot draws.
     return (blend_mode == other.blend_mode && ref_id == other.ref_id && ref_group == other.ref_group) &&
            other.roi == roi;
 }
@@ -640,8 +673,8 @@ void Channel::update_stats(int c, ConstImagePtr img1, ConstImagePtr img2)
              ref_data_origin]()
             {
                 spdlog::debug("Starting a new stats computation");
-                async_stats->calculate(*this, alpha, img_data_origin, ref, ref_alpha, ref_data_origin,
-                                       desired_settings, *canceled);
+                async_stats->calculate(*this, alpha, img_data_origin, ref, ref_alpha, ref_data_origin, desired_settings,
+                                        *canceled);
             });
         async_settings = desired_settings;
     };

--- a/src/image.h
+++ b/src/image.h
@@ -33,11 +33,15 @@ using namespace stp;
 // smallest value happens to be the denormal number 2^-24, so 2^-26 should be a good choice.
 static constexpr float k_small_alpha = 1.f / (1u << 26u);
 
-// Knee of the histogram x axis's nonlinear scales: below roughly this magnitude asinh and symlog stay
-// near-linear, and above it they turn logarithmic. 1.8 makes asinh and our symlog look roughly the same.
+// Knee of the histogram x axis's nonlinear scales: below roughly this magnitude they stay near-linear,
+// and above it they turn logarithmic.
 inline constexpr double axis_scale_eps     = 0.0001;
 inline constexpr double axis_scale_log_eps = -4; // std::log10(axis_scale_eps)
-inline constexpr double axis_scale_a_0     = axis_scale_eps * 1.8;
+
+// The asinh scale's knee sits well above axis_scale_eps so that the axis doesn't spend most of its width
+// below the darkest level an 8-bit source can represent: at 1.8e-4 the curve is logarithmic across all of
+// [0,1], which spreads consecutive dark levels tens of bins apart and combs the histogram.
+inline constexpr double axis_scale_a_0 = 0.01;
 
 //! Warp \p value into the space the histogram's x axis is drawn in.
 /*!

--- a/src/image.h
+++ b/src/image.h
@@ -33,38 +33,53 @@ using namespace stp;
 // smallest value happens to be the denormal number 2^-24, so 2^-26 should be a good choice.
 static constexpr float k_small_alpha = 1.f / (1u << 26u);
 
-inline double axis_scale_fwd_xform(double value, void *user_data)
-{
-    static constexpr double eps     = 0.0001;
-    static constexpr double log_eps = -4;        // std::log10(eps);
-    static constexpr double a_0     = eps * 1.8; // 1.8 makes asinh and our symlog looks roughly the same
+// Knee of the histogram x axis's nonlinear scales: below roughly this magnitude asinh and symlog stay
+// near-linear, and above it they turn logarithmic. 1.8 makes asinh and our symlog look roughly the same.
+inline constexpr double axis_scale_eps     = 0.0001;
+inline constexpr double axis_scale_log_eps = -4; // std::log10(axis_scale_eps)
+inline constexpr double axis_scale_a_0     = axis_scale_eps * 1.8;
 
-    const auto x_scale = *(AxisScale *)user_data;
+//! Warp \p value into the space the histogram's x axis is drawn in.
+/*!
+    Histogram bins are laid out uniformly in this space, and ImPlot positions the axis linearly in it as
+    well, so the bins come out uniformly wide on screen too.
+*/
+inline double axis_scale_fwd(double value, AxisScale x_scale)
+{
     if (x_scale == AxisScale_SRGB)
         return linear_to_sRGB(value);
     else if (x_scale == AxisScale_SymLog)
-        return value > 0 ? (std::log10(value + eps) - log_eps) : -(std::log10(-value + eps) - log_eps);
+        return value > 0 ? (std::log10(value + axis_scale_eps) - axis_scale_log_eps)
+                         : -(std::log10(-value + axis_scale_eps) - axis_scale_log_eps);
     else if (x_scale == AxisScale_Asinh)
-        return a_0 * std::asinh(value / a_0);
+        return axis_scale_a_0 * std::asinh(value / axis_scale_a_0);
     else
         return value;
 }
 
-inline double axis_scale_inv_xform(double value, void *user_data)
+//! Inverse of axis_scale_fwd().
+inline double axis_scale_inv(double value, AxisScale x_scale)
 {
-    static constexpr double eps     = 0.0001;
-    static constexpr double log_eps = -4;        // std::log10(eps);
-    static constexpr double a_0     = eps * 1.8; // 1.8 makes asinh and our symlog looks roughly the same
-
-    const auto x_scale = *(AxisScale *)user_data;
     if (x_scale == AxisScale_SRGB)
         return sRGB_to_linear(value);
     else if (x_scale == AxisScale_SymLog)
-        return value > 0 ? (std::pow(10., value + log_eps) - eps) : -(pow(10., -value + log_eps) - eps);
+        return value > 0 ? (std::pow(10., value + axis_scale_log_eps) - axis_scale_eps)
+                         : -(std::pow(10., -value + axis_scale_log_eps) - axis_scale_eps);
     else if (x_scale == AxisScale_Asinh)
-        return a_0 * std::sinh(value / a_0);
+        return axis_scale_a_0 * std::sinh(value / axis_scale_a_0);
     else
         return value;
+}
+
+// ImPlotTransform-compatible wrappers, for ImPlot::SetupAxisScale(); \p user_data points at an AxisScale.
+inline double axis_scale_fwd_xform(double value, void *user_data)
+{
+    return axis_scale_fwd(value, *(AxisScale *)user_data);
+}
+
+inline double axis_scale_inv_xform(double value, void *user_data)
+{
+    return axis_scale_inv(value, *(AxisScale *)user_data);
 }
 
 struct Channel;
@@ -72,8 +87,20 @@ struct Image;
 
 struct PixelStats
 {
-    static constexpr int NUM_BINS = 512;
+    static constexpr int MAX_BINS = 512;
     using Ptr                     = std::shared_ptr<PixelStats>;
+
+    //! Number of histogram bins appropriate for a source with \p bits bits per sample.
+    /*!
+        An n-bit source holds at most 2^n distinct levels, so binning any finer than that leaves bins empty
+        by construction. \p bits is 0 when the samples are floating point or their depth is unknown, which
+        gets the full resolution.
+    */
+    static constexpr int bins_for_bit_depth(int bits)
+    {
+        // the depth test comes first: 1 << bits is undefined for large bits
+        return (bits <= 0 || bits >= 16) ? MAX_BINS : (1 << bits);
+    }
 
     struct Settings
     {
@@ -105,35 +132,56 @@ struct PixelStats
 
     bool computed = false; ///< Did we finish computing the stats?
 
-    // histogram
-    float2 hist_y_limits      = {0.f, 1.f};
-    float2 hist_normalization = {0.f, 1.f};
+    // Histogram, binned separately for every AxisScale. Switching the x axis is then free, at the cost of
+    // transforming each sample once per scale in the single pass over the pixels that fills these.
+    // Fixed-size arrays rather than vectors: the GUI reads these from stats objects that have not been
+    // computed yet, which is only safe as long as they always hold storage.
 
-    std::array<float, NUM_BINS> hist_xs{}; // left edge of each bin's range; {}: value-initialized to zeros
-    std::array<float, NUM_BINS> hist_ys{}; // {}: value-initialized to zeros
+    int num_bins = MAX_BINS; ///< Only [0, num_bins) of each histogram below is meaningful
 
-    PixelStats() = default;
+    std::array<float2, AxisScale_COUNT> hist_y_limits{};
+    std::array<float2, AxisScale_COUNT> hist_normalization{}; ///< Offset and span of the binned range
+
+    /// Bin edges: hist_xs[s][i] is bin i's left edge, and hist_xs[s][num_bins] the last bin's right edge
+    std::array<std::array<float, MAX_BINS + 1>, AxisScale_COUNT> hist_xs{};
+    /// Number of samples in each bin
+    std::array<std::array<float, MAX_BINS>, AxisScale_COUNT> hist_ys{};
+
+    //! Leaves every histogram empty but with usable ranges, since the GUI draws stats objects that have
+    //! not been computed yet.
+    PixelStats()
+    {
+        hist_y_limits.fill(float2{0.f, 1.f});
+        hist_normalization.fill(float2{0.f, 1.f});
+    }
 
     /// Populate the statistics from the provided img and settings
     void calculate(const Channel &img, const Channel *alpha, int2 img_data_origin, const Channel *ref,
                    const Channel *ref_alpha, int2 ref_data_origin, const Settings &desired,
                    std::atomic<bool> &canceled);
 
-    int    clamp_idx(int i) const { return std::clamp(i, 0, NUM_BINS - 1); }
-    float &bin_y(int i) { return hist_ys[clamp_idx(i)]; }
+    int    clamp_idx(int i) const { return std::clamp(i, 0, num_bins - 1); }
+    float &bin_y(int i, AxisScale x_scale) { return hist_ys[x_scale][clamp_idx(i)]; }
 
-    int value_to_bin(double value) const
+    //! Index of the bin containing \p value under \p x_scale.
+    /*!
+        Returns a negative index for a value below the binned range or for one with no bin at all (NaN), and
+        num_bins for one above it. The clamp keeps the result representable: casting a non-finite double to
+        int is undefined, and the GUI does ask about values far outside the range.
+    */
+    int value_to_bin(double value, AxisScale x_scale) const
     {
-        static constexpr int x_scale = AxisScale_Asinh;
-        return int(std::floor((axis_scale_fwd_xform(value, (void *)&x_scale) - hist_normalization[0]) /
-                              hist_normalization[1] * NUM_BINS));
+        double t = (axis_scale_fwd(value, x_scale) - hist_normalization[x_scale][0]) / hist_normalization[x_scale][1];
+        if (std::isnan(t))
+            return -1;
+        return int(std::floor(std::clamp(t * num_bins, -1.0, double(num_bins))));
     }
 
-    double bin_to_value(double value) const
+    //! Value at bin edge \p bin under \p x_scale; bin == num_bins gives the last bin's right edge.
+    double bin_to_value(double bin, AxisScale x_scale) const
     {
-        static constexpr int   x_scale  = AxisScale_Asinh;
-        static constexpr float inv_bins = 1.f / NUM_BINS;
-        return axis_scale_inv_xform(hist_normalization[1] * value * inv_bins + hist_normalization[0], (void *)&x_scale);
+        return axis_scale_inv(hist_normalization[x_scale][1] * bin / num_bins + hist_normalization[x_scale][0],
+                              x_scale);
     }
 
     float2 x_limits(float exposure, AxisScale x_scale) const;
@@ -141,6 +189,10 @@ struct PixelStats
 
 struct Channel : public Array2Df
 {
+    //! Bits per sample of this channel's samples in the file, or 0 when the file stores them as floating
+    //! point or their depth is unknown. Sets the histogram's bin count, via bins_for_bit_depth().
+    int bits_per_sample = 0;
+
 private:
     PixelStats::Ptr                    cached_stats;
     ThreadPool::TaskTracker            async_tracker;
@@ -380,6 +432,12 @@ public:
     void        apply_exif_orientation();
     void        compute_color_transform();
     std::string to_string() const;
+
+    //! Record the file's sample depth on every channel; see Channel::bits_per_sample.
+    void set_bits_per_sample(int bits)
+    {
+        for (auto &c : channels) c.bits_per_sample = bits;
+    }
 
     //! True when `group`'s values were premultiplied by finalize() and so must be divided back out to
     //! report what the file holds. Straight-alpha files only: a file that stored premultiplied values has

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -501,6 +501,9 @@ vector<ImagePtr> load_exr_image(istream &is_, string_view filename, const ImageL
             name = c.name();
 
             img->channels.emplace_back(name, size);
+            // EXR records a pixel type per channel, so one part can mix depths. Only UINT is quantized;
+            // half and float get the histogram's full bin resolution.
+            img->channels.back().bits_per_sample = c.channel().type == Imf::UINT ? 32 : 0;
             framebuffer.insert(c.name(), Imf::Slice::Make(Imf::FLOAT, img->channels.back().data(), dataWindow, 0, 0,
                                                           c.channel().xSampling, c.channel().ySampling));
         }

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -352,7 +352,10 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
         if (bpp_storage != cpp * 16 && bpp_storage != cpp * 8)
             throw runtime_error(fmt::format("Unsupported bits per pixel: {}", bpp_storage));
         if (p == 0)
+        {
             image->metadata["pixel format"] = fmt::format("{}-bit ({} bpc)", size.z * bpc, bpc);
+            image->set_bits_per_sample(bpc);
+        }
         float bpc_div = 1.f / ((1 << bpc) - 1);
 
         // copy pixels into a contiguous float buffer and normalize values to [0,1]

--- a/src/imageio/jpg.cpp
+++ b/src/imageio/jpg.cpp
@@ -223,6 +223,7 @@ std::vector<ImagePtr> load_jpg_image(std::istream &is, std::string_view filename
         image->metadata["pixel format"] =
             fmt::format("{} ({} channel{}, {} bpc)", color_space_name(cinfo.jpeg_color_space), cinfo.num_components,
                         cinfo.num_components > 1 ? "s" : "", cinfo.data_precision);
+        image->set_bits_per_sample(cinfo.data_precision);
 #if JPEG_LIB_VERSION >= 80
         image->metadata["header"]["Is baseline"] = {
             {"value", cinfo.is_baseline}, {"string", cinfo.is_baseline ? "yes" : "no"}, {"type", "bool"}};

--- a/src/imageio/jxl.cpp
+++ b/src/imageio/jxl.cpp
@@ -588,6 +588,8 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
                      (has_encoded_profile ? color_encoding_info(file_enc) : "    no encoded color profile")}};
             image->metadata["pixel format"] =
                 fmt::format("{}-bit ({} bpc)", size.z * info.bits_per_sample, info.bits_per_sample);
+            // exponent bits mark the samples as floating-point, which has no quantization lattice
+            image->set_bits_per_sample(info.exponent_bits_per_sample ? 0 : info.bits_per_sample);
             image->metadata["header"]["intrinsic width"] = {
                 {"value", int(info.intrinsic_xsize)}, {"string", to_string(info.intrinsic_xsize)}, {"type", "int"}};
             image->metadata["header"]["intrinsic height"] = {

--- a/src/imageio/pfm.cpp
+++ b/src/imageio/pfm.cpp
@@ -147,6 +147,7 @@ vector<ImagePtr> load_pfm_image(std::istream &is, std::string_view filename, con
     auto      image                  = make_shared<Image>(size.xy(), size.z);
     image->filename                  = filename;
     image->metadata["pixel format"]  = fmt::format("{}-bit (32-bit float per channel)", size.z * 32);
+    image->set_bits_per_sample(0); //< floating point
     image->metadata["color profile"] = opts.override_profile
                                            ? color_profile_name(ColorGamut_Unspecified, opts.tf_override)
                                            : color_profile_name(ColorGamut_Unspecified, TransferFunction::Linear);

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -690,6 +690,8 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         image->alpha_type     = size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None;
         image->chromaticities = chr;
         image->metadata       = metadata;
+        // A palette's IHDR depth counts bits per index; png_set_palette_to_rgb() expands those to 8-bit RGB.
+        image->set_bits_per_sample(color_type == PNG_COLOR_TYPE_PALETTE ? 8 : file_bit_depth);
         if (exif.valid())
             image->exif = exif;
         if (!xmp_data.empty())

--- a/src/imageio/qoi.cpp
+++ b/src/imageio/qoi.cpp
@@ -88,6 +88,7 @@ vector<ImagePtr> load_qoi_image(istream &is, string_view filename, const ImageLo
     image->alpha_type               = size.z > 3 ? AlphaType_Straight : AlphaType_None;
     image->metadata["loader"]       = "qoi";
     image->metadata["pixel format"] = fmt::format("{}-bit (8 bpc)", size.z * 8);
+    image->set_bits_per_sample(8);
 
     TransferFunction tf =
         desc.colorspace == QOI_LINEAR ? TransferFunction{TransferFunction::Linear, 1.f} : TransferFunction::sRGB;

--- a/src/imageio/raw.cpp
+++ b/src/imageio/raw.cpp
@@ -821,6 +821,9 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
                 image->partname                 = "main";
                 image->metadata["loader"]       = fmt::format("LibRaw; {}", libraw_unpack_function_name(&idata));
                 image->metadata["pixel format"] = pixel_format;
+                // Demosaicing interpolates between photosites, so the output no longer sits on the sensor's
+                // lattice; 16 is the finest binning the result can justify.
+                image->set_bits_per_sample(16);
                 if (!exif_ctx.metadata.empty())
                     image->metadata["exif"] = exif_ctx.metadata;
 
@@ -907,6 +910,7 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
                     cfa_img->partname                 = "cfa";
                     cfa_img->metadata["loader"]       = "LibRaw (CFA)";
                     cfa_img->metadata["pixel format"] = pixel_format;
+                    cfa_img->set_bits_per_sample(idata.color.raw_bps); //< undemosaiced, still on the lattice
                     if (!exif_ctx.metadata.empty())
                         cfa_img->metadata["exif"] = exif_ctx.metadata;
 
@@ -995,6 +999,7 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
                 timg->filename                           = filename;
                 timg->partname                           = fmt::format("thumbnail:{}", ti);
                 timg->metadata["pixel format"]           = fmt::format("{}-bit ({} bpc)", n * thumb->bits, thumb->bits);
+                timg->set_bits_per_sample(thumb->bits);
                 timg->metadata["loader"]                 = "LibRaw";
                 timg->metadata["header"]["Is thumbnail"] = {{"value", true},
                                                             {"string", "Yes"},

--- a/src/imageio/stb.cpp
+++ b/src/imageio/stb.cpp
@@ -283,6 +283,9 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
         else
             image->metadata["pixel format"] = fmt::format("{} bbp", 8);
 
+        // RGBE decodes to floating point, so like any float source it has no quantization lattice
+        image->set_bits_per_sample(is_hdr ? 0 : (is_16_bit ? 16 : 8));
+
         if (j.contains("header"))
             image->metadata["header"] = j["header"];
 

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -403,6 +403,11 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
                 fmt::format("{}-bit unsigned int ({} bpc)", bits_per_sample * samples_per_pixel, bits_per_sample);
 
         image->metadata["pixel format"] = format_str;
+        // file_bits_per_sample is the depth before the rounding above; the RGBA interface overrides it,
+        // since it always hands back 8-bit samples.
+        image->set_bits_per_sample(sample_format == SAMPLEFORMAT_IEEEFP ? 0
+                                   : use_rgba_interface                 ? 8
+                                                                        : file_bits_per_sample);
 
         if (use_rgba_interface)
         {

--- a/src/imageio/webp.cpp
+++ b/src/imageio/webp.cpp
@@ -339,6 +339,7 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
             // Start with base metadata common to all frames
             frame_image->metadata                 = base_metadata;
             frame_image->metadata["pixel format"] = has_alpha ? "RGBA 8-bit" : "RGB 8-bit";
+            frame_image->set_bits_per_sample(8);
 
             // Check if frame is lossy or lossless
             WebPBitstreamFeatures features;

--- a/tests/test_exr_io.cpp
+++ b/tests/test_exr_io.cpp
@@ -8,11 +8,17 @@
 
 #include "image.h"
 #include "imageio/exr.h"
-#include "imageio/image_loader.h"
 #include "imageio/exr_save_options.h"
+#include "imageio/image_loader.h"
 
 #include <fstream>
 #include <sstream>
+
+#include <ImfChannelList.h>
+#include <ImfFrameBuffer.h>
+#include <ImfHeader.h>
+#include <ImfOutputFile.h>
+#include <ImfStdIO.h>
 
 #ifdef HDRVIEW_TEST_OPENEXR_DIR
 #include <algorithm>
@@ -193,6 +199,7 @@ TEST_CASE("EXR save/load precision depends on the chosen pixel type")
         opts.pixel_type  = 1; // HALF
         auto reloaded    = save_and_reload(*img, opts);
         REQUIRE(reloaded.size() == 1);
+        CHECK(reloaded[0]->channels[0].bits_per_sample == 0); //< floating point, so no quantization lattice
         float value = reloaded[0]->channels[0](0, 0);
         CHECK(value != doctest::Approx(0.1f).epsilon(1e-6));  // not exact
         CHECK(value == doctest::Approx(0.1f).epsilon(1e-3));  // but close, within half precision
@@ -206,6 +213,48 @@ TEST_CASE("EXR save/load precision depends on the chosen pixel type")
         REQUIRE(reloaded.size() == 1);
         CHECK(reloaded[0]->channels[0](0, 0) == doctest::Approx(0.1f).epsilon(1e-6));
     }
+}
+
+TEST_CASE("EXR channels report their own sample depths independently")
+{
+    // A part can mix pixel types, which is why the depth that sets the histogram's bin count lives on the
+    // channel rather than the image. Only UINT is quantized; half and float report 0.
+    const int2 size{4, 4};
+
+    Imf::Header header(size.x, size.y);
+    header.channels().insert("H", Imf::Channel(Imf::HALF));
+    header.channels().insert("F", Imf::Channel(Imf::FLOAT));
+    header.channels().insert("U", Imf::Channel(Imf::UINT));
+
+    std::vector<half>     halves(size.x * size.y, half(0.5f));
+    std::vector<float>    floats(size.x * size.y, 0.5f);
+    std::vector<uint32_t> uints(size.x * size.y, 7u);
+
+    std::ostringstream out(std::ios::binary);
+    {
+        Imf::StdOSStream os;
+        Imf::FrameBuffer fb;
+        fb.insert("H", Imf::Slice(Imf::HALF, (char *)halves.data(), sizeof(half), sizeof(half) * size.x));
+        fb.insert("F", Imf::Slice(Imf::FLOAT, (char *)floats.data(), sizeof(float), sizeof(float) * size.x));
+        fb.insert("U", Imf::Slice(Imf::UINT, (char *)uints.data(), sizeof(uint32_t), sizeof(uint32_t) * size.x));
+
+        Imf::OutputFile file(os, header);
+        file.setFrameBuffer(fb);
+        file.writePixels(size.y);
+        out << os.str();
+    }
+
+    std::istringstream in(out.str(), std::ios::binary);
+    auto               images = load_exr_image(in, "mixed.exr");
+    REQUIRE(images.size() == 1);
+
+    std::map<std::string, int> depths;
+    for (const auto &c : images[0]->channels) depths[c.name] = c.bits_per_sample;
+
+    REQUIRE(depths.size() == 3);
+    CHECK(depths["H"] == 0);
+    CHECK(depths["F"] == 0);
+    CHECK(depths["U"] == 32);
 }
 
 TEST_CASE("is_exr_image correctly identifies real EXR bytes and rejects garbage")
@@ -260,8 +309,8 @@ TEST_CASE("EXR load splits a real multi-part file into one Image per part, with 
     for (const auto &img : reloaded) actual_names.insert(img->partname);
     CHECK(actual_names == expected_names);
 
-    auto depth_left =
-        std::find_if(reloaded.begin(), reloaded.end(), [](const ImagePtr &img) { return img->partname == "depth_left"; });
+    auto depth_left = std::find_if(reloaded.begin(), reloaded.end(),
+                                   [](const ImagePtr &img) { return img->partname == "depth_left"; });
     REQUIRE(depth_left != reloaded.end());
     REQUIRE((*depth_left)->channels.size() == 1);
     CHECK((*depth_left)->channels[0].name == "Z");
@@ -277,8 +326,8 @@ TEST_CASE("EXR load up-samples subsampled channels to full resolution with block
 
     auto find_channel = [&](const char *name) -> Channel &
     {
-        auto it = std::find_if(img.channels.begin(), img.channels.end(),
-                               [&](const Channel &c) { return c.name == name; });
+        auto it =
+            std::find_if(img.channels.begin(), img.channels.end(), [&](const Channel &c) { return c.name == name; });
         REQUIRE(it != img.channels.end());
         return *it;
     };

--- a/tests/test_pixel_stats.cpp
+++ b/tests/test_pixel_stats.cpp
@@ -211,6 +211,22 @@ TEST_CASE("Every 8-bit level gets its own bin on the sRGB axis")
     }
 }
 
+TEST_CASE("The asinh axis keeps 8-bit levels within a bin or two of each other")
+{
+    // asinh's knee has to sit well above the darkest 8-bit level, or the curve is logarithmic across the
+    // whole of [0,1] and flings consecutive dark levels tens of bins apart.
+    auto stats = compute(make_8bit_sRGB_ramp());
+    REQUIRE(stats.num_bins == 256);
+
+    int longest = 0, run = 0;
+    for (int i = 0; i < stats.num_bins; ++i)
+    {
+        run     = stats.hist_ys[AxisScale_Asinh][i] == 0.f ? run + 1 : 0;
+        longest = std::max(longest, run);
+    }
+    CHECK(longest <= 4); //< a run this short is under a pixel wide once the fill reduces bins to columns
+}
+
 TEST_CASE("Histogram bins hold plain counts of the valid pixels")
 {
     // Bins are equally wide on screen, so their heights are counts rather than densities.

--- a/tests/test_pixel_stats.cpp
+++ b/tests/test_pixel_stats.cpp
@@ -43,7 +43,278 @@ Channel make_identifiable_channel(int w, int h)
     return c;
 }
 
+// A 256x1 channel holding every 8-bit sRGB code, decoded to linear the way the PNG and JPEG loaders do.
+Channel make_8bit_sRGB_ramp()
+{
+    Channel c("ramp", int2{256, 1});
+    c.bits_per_sample = 8;
+    for (int k = 0; k < 256; ++k) c(k, 0) = sRGB_to_linear(k / 255.f);
+    return c;
+}
+
+// Number of bins holding no samples at all, which is what the "comb" artifact looks like in the data.
+int count_empty_bins(const PixelStats &stats, AxisScale x_scale)
+{
+    int empty = 0;
+    for (int i = 0; i < stats.num_bins; ++i)
+        if (stats.hist_ys[x_scale][i] == 0.f)
+            ++empty;
+    return empty;
+}
+
+double total_bin_count(const PixelStats &stats, AxisScale x_scale)
+{
+    double sum = 0.0;
+    for (int i = 0; i < stats.num_bins; ++i) sum += stats.hist_ys[x_scale][i];
+    return sum;
+}
+
+PixelStats compute(const Channel &c, PixelStats::Settings settings = {})
+{
+    std::atomic<bool> canceled{false};
+    PixelStats        stats;
+    stats.calculate(c, nullptr, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
+    return stats;
+}
+
 } // namespace
+
+TEST_CASE("PixelStats::calculate bins every axis scale in a single pass")
+{
+    // Binning follows the axis the histogram is drawn in, and all of them are computed up front so that
+    // switching the x-axis combo never has to rescan the image.
+    auto stats = compute(make_8bit_sRGB_ramp());
+
+    REQUIRE(stats.computed);
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        CAPTURE(s);
+        CHECK(total_bin_count(stats, (AxisScale)s) == doctest::Approx(stats.summary.valid_pixels));
+        CHECK(stats.hist_normalization[s][1] > 0.f);
+    }
+
+    // The scales agree at the ends of the range but place the bins in between differently.
+    CHECK(stats.hist_xs[AxisScale_SRGB][128] != stats.hist_xs[AxisScale_Linear][128]);
+    CHECK(stats.hist_xs[AxisScale_Asinh][128] != stats.hist_xs[AxisScale_Linear][128]);
+}
+
+TEST_CASE("PixelStats::Settings::match ignores settings that only affect drawing")
+{
+    PixelStats::Settings a;
+    PixelStats::Settings b;
+    REQUIRE(a.match(b));
+
+    SUBCASE("exposure never reaches the computation")
+    {
+        b.exposure = 3.f;
+        CHECK(a.match(b));
+    }
+    SUBCASE("every x scale is binned, so switching between them needs no recompute")
+    {
+        b.x_scale = AxisScale_SRGB;
+        CHECK(a.match(b));
+    }
+    SUBCASE("the y scale only picks how the stored histogram is drawn")
+    {
+        b.y_scale = AxisScale_SymLog;
+        CHECK(a.match(b));
+    }
+    SUBCASE("but the region of interest does")
+    {
+        b.roi = Box2i{int2{0}, int2{4}};
+        CHECK_FALSE(a.match(b));
+    }
+}
+
+TEST_CASE("PixelStats::calculate takes its bin count from the channel's bit depth")
+{
+    Channel c("test", int2{16, 16});
+    c.apply([](float, int x, int y) { return (x + y) / 30.f; });
+
+    auto bins_for = [&c](int bits)
+    {
+        c.bits_per_sample = bits;
+        return compute(c).num_bins;
+    };
+
+    CHECK(bins_for(0) == PixelStats::MAX_BINS); //< floating point or unknown
+    CHECK(bins_for(32) == PixelStats::MAX_BINS);
+    CHECK(bins_for(16) == PixelStats::MAX_BINS);
+    CHECK(bins_for(8) == 256);
+    CHECK(bins_for(4) == 16);
+    CHECK(bins_for(1) == 2);
+}
+
+TEST_CASE("Channels in one image can carry different bit depths")
+{
+    // EXR records a pixel type per channel, so the bin count has to be a per-channel property.
+    Channel eight("eight", int2{8, 8});
+    Channel floating("floating", int2{8, 8});
+    eight.bits_per_sample    = 8;
+    floating.bits_per_sample = 0;
+    eight.apply([](float, int x, int) { return x / 8.f; });
+    floating.apply([](float, int x, int) { return x / 8.f; });
+
+    CHECK(compute(eight).num_bins == 256);
+    CHECK(compute(floating).num_bins == PixelStats::MAX_BINS);
+}
+
+TEST_CASE("Each x scale's bins are uniform in that scale's own space")
+{
+    auto stats = compute(make_8bit_sRGB_ramp());
+    REQUIRE(stats.num_bins == 256);
+
+    auto edges_uniform_in = [&stats](AxisScale x_scale)
+    {
+        double first =
+            axis_scale_fwd(stats.hist_xs[x_scale][1], x_scale) - axis_scale_fwd(stats.hist_xs[x_scale][0], x_scale);
+        for (int i = 1; i < stats.num_bins; ++i)
+        {
+            double w = axis_scale_fwd(stats.hist_xs[x_scale][i + 1], x_scale) -
+                       axis_scale_fwd(stats.hist_xs[x_scale][i], x_scale);
+            if (std::abs(w - first) > 1e-4 * std::abs(first))
+                return false;
+        }
+        return true;
+    };
+
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        CAPTURE(s);
+        CHECK(edges_uniform_in((AxisScale)s));
+        // The bins span the channel's own range, so the outer edges land on its extremes.
+        CHECK(stats.hist_xs[s][0] == doctest::Approx(stats.summary.minimum));
+        CHECK(stats.hist_xs[s][stats.num_bins] == doctest::Approx(stats.summary.maximum));
+    }
+}
+
+TEST_CASE("Every 8-bit level gets its own bin on the sRGB axis")
+{
+    // The comb artifact: 8-bit content has at most 256 distinct levels, so binning it any finer leaves
+    // gaps that read as a row of detached spikes.
+    auto ramp = make_8bit_sRGB_ramp();
+
+    SUBCASE("at a bin count matched to the source's depth")
+    {
+        auto stats = compute(ramp);
+        REQUIRE(stats.num_bins == 256);
+        // The 1/255 lattice and the 1/256 bin grid drift by up to a bin, leaving at most one gap.
+        CHECK(count_empty_bins(stats, AxisScale_SRGB) <= 1);
+    }
+
+    SUBCASE("binning finer than the source leaves most bins empty")
+    {
+        ramp.bits_per_sample = 0;
+        auto stats           = compute(ramp);
+        REQUIRE(stats.num_bins == PixelStats::MAX_BINS);
+        CHECK(count_empty_bins(stats, AxisScale_SRGB) >= 250);
+    }
+}
+
+TEST_CASE("Histogram bins hold plain counts of the valid pixels")
+{
+    // Bins are equally wide on screen, so their heights are counts rather than densities.
+    Channel c("test", int2{20, 20});
+    c.apply([](float, int x, int y) { return (x * 20 + y) / 400.f; });
+
+    auto stats = compute(c);
+    CHECK(stats.summary.valid_pixels == 400);
+    CHECK(total_bin_count(stats, AxisScale_Linear) == doctest::Approx(400.0));
+}
+
+TEST_CASE("NaN and Inf pixels are left out of the histogram")
+{
+    Channel c("test", int2{4, 4});
+    c.apply([](float, int, int) { return 0.5f; });
+    c(0, 0) = std::numeric_limits<float>::quiet_NaN();
+    c(1, 0) = std::numeric_limits<float>::infinity();
+    c(2, 0) = -std::numeric_limits<float>::infinity();
+
+    auto stats = compute(c);
+    CHECK(stats.summary.nan_pixels == 1);
+    CHECK(stats.summary.inf_pixels == 2);
+    CHECK(stats.summary.valid_pixels == 13);
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        CAPTURE(s);
+        CHECK(total_bin_count(stats, (AxisScale)s) == doctest::Approx(13.0));
+    }
+}
+
+TEST_CASE("A constant-valued channel produces a finite histogram")
+{
+    // min == max transforms to a zero-width range, which would divide by zero when indexing bins.
+    Channel c("test", int2{4, 4});
+    c.apply([](float, int, int) { return 0.5f; });
+
+    auto stats = compute(c);
+    REQUIRE(stats.computed);
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        CAPTURE(s);
+        CHECK(total_bin_count(stats, (AxisScale)s) == doctest::Approx(16.0));
+        CHECK(stats.hist_ys[s][0] == doctest::Approx(16.f)); //< all of them in the first bin
+        CHECK(std::isfinite(stats.hist_y_limits[s][1]));
+        for (int i = 0; i <= stats.num_bins; ++i) CHECK(std::isfinite(stats.hist_xs[s][i]));
+    }
+}
+
+TEST_CASE("An all-NaN channel produces an empty but valid histogram")
+{
+    Channel c("test", int2{4, 4});
+    c.apply([](float, int, int) { return std::numeric_limits<float>::quiet_NaN(); });
+
+    auto stats = compute(c);
+    CHECK(stats.computed);
+    CHECK(stats.summary.valid_pixels == 0);
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        CAPTURE(s);
+        CHECK(total_bin_count(stats, (AxisScale)s) == doctest::Approx(0.0));
+        CHECK(stats.hist_y_limits[s][0] == 0.f);
+        CHECK(stats.hist_y_limits[s][1] == 1.f);
+    }
+}
+
+TEST_CASE("The upper y limit ignores the tallest few bins")
+{
+    // One flat region -- a black background, a blown highlight -- would otherwise squash the rest flat.
+    Channel c("test", int2{100, 10});
+    c.apply([](float, int x, int y) { return x < 90 ? 0.f : (x - 90 + y * 10) / 100.f; });
+
+    auto stats = compute(c);
+    REQUIRE(stats.summary.valid_pixels == 1000);
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        CAPTURE(s);
+        CHECK(stats.hist_y_limits[s][0] == 0.f); //< ImPlot's SymLog is defined at zero
+        CHECK(stats.hist_y_limits[s][1] >= 1.f);
+        CHECK(stats.hist_y_limits[s][1] < 900.f); //< the spike itself runs off the top
+    }
+}
+
+TEST_CASE("value_to_bin and bin_to_value round-trip")
+{
+    auto stats = compute(make_8bit_sRGB_ramp());
+    REQUIRE(stats.num_bins == 256);
+
+    for (int s = 0; s < AxisScale_COUNT; ++s)
+    {
+        auto x_scale = (AxisScale)s;
+        CAPTURE(s);
+
+        for (int i = 0; i < stats.num_bins; ++i)
+            CHECK(stats.value_to_bin(stats.bin_to_value(i + 0.5, x_scale), x_scale) == i);
+
+        CHECK(stats.value_to_bin(stats.summary.minimum, x_scale) == 0);
+        CHECK(stats.clamp_idx(stats.value_to_bin(stats.summary.maximum, x_scale)) == stats.num_bins - 1);
+
+        // Non-finite input has no bin, and must not be cast to int unclamped.
+        CHECK(stats.value_to_bin(std::numeric_limits<double>::quiet_NaN(), x_scale) < 0);
+        CHECK(stats.value_to_bin(-std::numeric_limits<double>::infinity(), x_scale) < 0);
+        CHECK(stats.value_to_bin(std::numeric_limits<double>::infinity(), x_scale) >= stats.num_bins);
+    }
+}
 
 TEST_CASE("PixelStats::calculate uses the selected sub-region, not the image origin")
 {
@@ -224,4 +495,25 @@ TEST_CASE("PixelStats::calculate reports straight values when given an alpha cha
 
         CHECK(stats.summary.average == doctest::Approx(0.5));
     }
+}
+
+TEST_CASE("Unpremultiplying puts 8-bit samples back on the source's lattice")
+{
+    // finalize() multiplies by max(k_small_alpha, alpha) and calculate() divides by the same clamped
+    // denominator, so the file's levels survive the round trip and still bin one-to-one.
+    auto    ramp = make_8bit_sRGB_ramp();
+    Channel alpha("alpha", int2{256, 1});
+    for (int k = 0; k < 256; ++k) alpha(k, 0) = std::max(k_small_alpha, (k % 255 + 1) / 255.f);
+
+    Channel premultiplied("premultiplied", int2{256, 1});
+    premultiplied.bits_per_sample = 8;
+    for (int k = 0; k < 256; ++k) premultiplied(k, 0) = alpha(k, 0) * ramp(k, 0);
+
+    std::atomic<bool>    canceled{false};
+    PixelStats::Settings settings;
+    PixelStats           stats;
+    stats.calculate(premultiplied, &alpha, int2{0, 0}, nullptr, nullptr, int2{0, 0}, settings, canceled);
+
+    REQUIRE(stats.num_bins == 256);
+    CHECK(count_empty_bins(stats, AxisScale_SRGB) <= 1);
 }

--- a/tests/test_png_io.cpp
+++ b/tests/test_png_io.cpp
@@ -204,15 +204,19 @@ TEST_CASE("PNG load handles the full PngSuite bit-depth/color-type matrix withou
 {
     // one representative file per PngSuite color-type code: 0g=gray, 2c=truecolor, 3p=palette (expanded to RGB),
     // 4a=gray+alpha, 6a=truecolor+alpha; expected channel count reflects HDRView's post-expansion representation
+    // expected_bits is the file's own sample depth, which sets the histogram's bin count; palette entries are
+    // 8-bit RGB however few bits the indices took.
     struct Case
     {
         const char *file;
         int          expected_channels;
+        int         expected_bits;
     };
     static const Case cases[] = {
-        {"basn0g01.png", 1}, {"basn0g02.png", 1}, {"basn0g04.png", 1}, {"basn0g08.png", 1}, {"basn0g16.png", 1},
-        {"basn2c08.png", 3}, {"basn2c16.png", 3}, {"basn3p01.png", 3}, {"basn3p02.png", 3}, {"basn3p04.png", 3},
-        {"basn3p08.png", 3}, {"basn4a08.png", 2}, {"basn4a16.png", 2}, {"basn6a08.png", 4}, {"basn6a16.png", 4},
+        {"basn0g01.png", 1, 1},  {"basn0g02.png", 1, 2}, {"basn0g04.png", 1, 4},  {"basn0g08.png", 1, 8},
+        {"basn0g16.png", 1, 16}, {"basn2c08.png", 3, 8}, {"basn2c16.png", 3, 16}, {"basn3p01.png", 3, 8},
+        {"basn3p02.png", 3, 8},  {"basn3p04.png", 3, 8}, {"basn3p08.png", 3, 8},  {"basn4a08.png", 2, 8},
+        {"basn4a16.png", 2, 16}, {"basn6a08.png", 4, 8}, {"basn6a16.png", 4, 16},
     };
 
     for (const auto &c : cases)
@@ -221,6 +225,7 @@ TEST_CASE("PNG load handles the full PngSuite bit-depth/color-type matrix withou
         auto reloaded = load_test_png("pngsuite", c.file);
         REQUIRE(reloaded.size() == 1);
         CHECK(reloaded[0]->channels.size() == (size_t)c.expected_channels);
+        for (const auto &ch : reloaded[0]->channels) CHECK(ch.bits_per_sample == c.expected_bits);
     }
 }
 

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -41,8 +41,7 @@ std::string tiff_with_extra_samples(uint16_t value)
     std::string bytes(reinterpret_cast<const char *>(k_rgba_tiff), sizeof(k_rgba_tiff));
 
     auto read_u16 = [&](size_t o) { return uint16_t(uint8_t(bytes[o]) | (uint8_t(bytes[o + 1]) << 8)); };
-    auto read_u32 = [&](size_t o)
-    { return uint32_t(read_u16(o)) | (uint32_t(read_u16(o + 2)) << 16); };
+    auto read_u32 = [&](size_t o) { return uint32_t(read_u16(o)) | (uint32_t(read_u16(o + 2)) << 16); };
 
     REQUIRE(bytes.compare(0, 2, "II") == 0); // the fixture is little-endian
     const uint32_t ifd     = read_u32(4);
@@ -71,6 +70,12 @@ ImagePtr load_tiff(const std::string &bytes)
 }
 
 } // namespace
+
+TEST_CASE("TIFF channels report the file's sample depth")
+{
+    auto img = load_tiff(tiff_with_extra_samples(2)); // EXTRASAMPLE_UNASSALPHA
+    for (const auto &c : img->channels) CHECK(c.bits_per_sample == 8);
+}
 
 TEST_CASE("TIFF with unassociated alpha is premultiplied exactly once")
 {


### PR DESCRIPTION
Opening an 8-bit image drew the channel histogram as a row of detached vertical
spikes rather than a continuous curve.

## Why it combed

Three independent causes compounded:

1. **Over-binning.** `PixelStats::NUM_BINS` was a fixed 512, and bins were laid
   out uniformly in a **hardcoded asinh space** regardless of which x scale the
   plot was actually drawn in. An 8-bit channel has at most 256 distinct levels,
   so it could never fill more than half the bins.
2. **Point-sampled rasterization.** The visible curve is a hand-rolled
   per-screen-column fill, and it sampled exactly *one* bin per column. Empty
   bins rendered as gaps, and occupied bins narrower than a pixel could be
   skipped entirely.
3. **Density normalization.** Counts were divided by bin width. With asinh bins
   spanning orders of magnitude, an isolated occupied bin near zero became an
   enormous spike.

Compounding all three, bin edges and screen positions disagreed: the ImPlot axis
followed the user's x-scale pick while the binning ignored it.

## What changed

Bins are now laid out uniformly in **the same transformed space the x axis is
drawn in**. That makes them equally wide on screen, which in turn makes a raw
count the geometrically honest bar height — so the density division and its
spike pathology are gone.

Every `AxisScale` is binned in the *single* pass over the pixels. That costs one
extra transform per sample but makes switching the x axis free, keeps `x_scale`
out of the stats cache key, and avoids any scheduling or priority ordering. The
accumulation loop is also parallelized now, mirroring the summary pass directly
above it, so this comes out faster than before on the recomputes that already
existed (ROI drag, reference/blend change).

The bin count comes from a new **per-channel** `bits_per_sample`, populated by
the loaders. Per channel rather than per image because EXR records a pixel type
per channel and a single part can mix half, float, and uint.

The rasterizer now reduces by the maximum over the bins each column covers, the
way GIMP's histogram widget fits its bins into the widget's width.

A second commit moves the asinh scale's knee (`a_0`) from `1.8e-4` to `0.01`. At
the old value the curve is logarithmic across all of `[0,1]`, spending most of
the axis below the darkest level an 8-bit source can represent — no bin count
can fix that, and the gap is far too wide for max-reduction to absorb. Tick
label *values* are unaffected: a custom `ImPlotTransform` leaves ImPlot's default
locator in place, so only their screen positions shift.

That commit also persists the histogram's x and y scale, which previously reset
to asinh/linear on every launch.

## Bugs fixed along the way

All of these are pre-existing and were reachable in the shipping build:

- **NaN and Inf pixels were being binned.** `value_to_bin` did
  `int(std::floor(NaN))`, which is undefined behavior; in practice every NaN and
  −Inf pixel was counted into bin 0 while +Inf landed somewhere arbitrary. The
  summary reported them separately, so the histogram silently disagreed with it.
  The unclamped cast was also reachable from the GUI, where `PixelsToPlot` under
  an asinh/SymLog inverse returns astronomically large values for columns near
  the plot edge. `value_to_bin` now clamps before casting and reports "no bin"
  for non-finite input.
- **A constant-valued channel divided by zero.** When every sample is equal,
  `fwd(min) == fwd(max)`, so the normalization span was 0 and every bin index
  came out NaN. The range is now widened to one bin's worth.
- **An all-NaN channel produced garbage normalization** (`minimum = +inf`,
  `maximum = -inf`). It now yields an empty but valid histogram.
- **Bin counts silently stopped counting past 2^24.** They accumulated directly
  into a `float`, past which `+= 1` is a no-op — reachable on a many-megapixel
  image with a large flat region (a black background, a blown sky). Counts are
  now accumulated as `uint32_t` and converted once.
- **The last bin's extent was never drawn.** `PlotStairs` draws segments
  *between* points, but `hist_xs` held only `NUM_BINS` entries. It now holds
  `num_bins + 1`, including the final right edge.
- **The y-limit rule didn't do what it said.** The comment claimed the indices
  were sorted descending, but the comparator sorted ascending, so the
  "accumulate to 99% of total area" loop essentially never fired and the
  effective rule was "the 26th-tallest of 512 bins". Replaced with an explicit
  n-th-tallest rule via `nth_element` (no full sort), which is also what the unit
  change from densities to counts required.

## Measured effect

On a 256×1 channel holding every 8-bit sRGB code:

| binning | occupied bins | largest gap |
|---|---|---|
| before (512 bins, asinh `a_0`=1.8e-4) | 212 / 512 | 70 bins (13.7% of plot width) |
| after, asinh `a_0`=0.01 (256 bins) | 200 / 256 | 2 bins (0.8%) |
| after, sRGB axis (256 bins) | 255 / 256 | 1 bin |

## Known limitation, deliberately not fixed

Binning in the displayed axis space regresses **Linear axis + HDR content**. The
bins span the channel's own range so the histogram never depends on exposure,
but `x_limits()` derives the *visible* range from exposure — so an EXR whose max
is 1000 gets 512 linear bins of width ~2 and the entire visible plot falls inside
bin 0. Fraction of bins inside the default view at exposure 0, for max = 1000:
asinh 65% (fine), sRGB 8% (coarse but usable), linear 0.1% (unusable).

Fixing it means capping the linear bin range at the white point and clamping
out-of-range samples into the edge bin, which forces `exposure` into the cache
key — and therefore a full O(N) rescan on every committed exposure change, where
today exposure costs nothing. That's a steep price for a non-default axis, so
it's left as a follow-up with a comment at the binning site.

## Testing

The histogram previously had **zero** test coverage — `test_pixel_stats.cpp` and
`tests/gui/test_gui_stats.cpp` asserted only on `stats.summary`, never on
`hist_xs`/`hist_ys`/`hist_y_limits`/`value_to_bin`/`bin_to_value`.

This adds 16 test cases, including one for each bug listed above, plus:

- a hand-written EXR fixture mixing half, float, and uint channels, which pins
  why the depth field lives on `Channel` rather than `Image`;
- `bits_per_sample` assertions across the full PngSuite bit-depth/color-type
  matrix (palette files correctly report 8, not their index depth);
- a round-trip test proving straight alpha survives premultiply/unpremultiply
  back onto the source's quantization lattice, so 8-bit RGBA still bins 1:1.

`ctest` is green (64/64) and `HDRView --help` runs. Verified visually on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
