### PR TITLE
Record the PNG transfer function in gAMA and sRGB, not only in cICP

### DIFF
--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -794,6 +794,42 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
     return images;
 }
 
+namespace
+{
+
+// How this build can record a transfer function in a PNG. Shared by the writer and the save-options GUI so
+// the dialog cannot describe an outcome different from the one saving produces.
+//
+// gAMA stores the exponent taking file samples toward linear light, inverted -- 1/2.2 for a 2.2 encode --
+// so only a pure power curve has an exact gAMA representation.
+struct TransferSignalling
+{
+    double file_gamma     = 0.0;   ///< gAMA value to write; 0 when the curve has no gAMA equivalent
+    bool   gamma_is_exact = true;  ///< false when gAMA merely approximates the curve
+    bool   srgb_chunk     = false; ///< the sRGB chunk describes it, if the primaries are sRGB's too
+};
+
+TransferSignalling transfer_signalling(TransferFunction tf)
+{
+    switch (tf.type)
+    {
+    case TransferFunction::Linear: return {1.0, true, false};
+    case TransferFunction::Gamma: return {(tf.gamma > 0.f) ? 1.0 / double(tf.gamma) : 0.0, true, false};
+    // sRGB and ITU are piecewise: a linear segment near black joined to a power curve. 1/2.2 is the
+    // long-standing convention for approximating either with gAMA, and sRGB has an exact chunk of its own.
+    case TransferFunction::sRGB: return {1.0 / 2.2, false, true};
+    case TransferFunction::ITU: return {1.0 / 2.2, false, false};
+    default: return {}; // PQ, HLG, the log curves and the rest: cICP or nothing
+    }
+}
+
+// cICP expresses any curve exactly, but it is a recent addition to the PNG specification: libpng before
+// 1.6.46 cannot write it, and most readers still ignore it. A file tagged only with cICP is one that only a
+// cICP-aware reader interprets correctly, which is why the older chunks are written alongside it.
+constexpr bool k_can_write_cicp = PNG_cICP_SUPPORTED_ENABLED;
+
+} // namespace
+
 void save_png_image(const Image &img, ostream &os, string_view /*filename*/, float gain, bool dither, bool interlaced,
                     bool sixteen_bit, TransferFunction tf)
 {
@@ -894,6 +930,39 @@ void save_png_image(const Image &img, ostream &os, string_view /*filename*/, flo
     png_set_cICP(png_ptr, info_ptr.get(), color_primaries, transfer_function, matrix_coefficients, video_full_range);
 #endif
 
+    // The sRGB chunk asserts the whole colorspace, primaries included, so it may only be written when those
+    // really are sRGB's: stated as BT.709 (1), left unspecified (2, in which case no cHRM is written either
+    // and a reader assumes sRGB), or unrecognized (< 0, where the pixels were converted to sRGB above). A
+    // genuinely wide gamut -- BT.2020, Display P3 -- gets cHRM and gAMA instead.
+    const bool primaries_are_srgb = cicp_primaries < 0 || cicp_primaries == 1 || cicp_primaries == 2;
+    const auto signalling         = transfer_signalling(tf);
+
+    if (signalling.srgb_chunk && primaries_are_srgb)
+        png_set_sRGB(png_ptr, info_ptr.get(), PNG_sRGB_INTENT_PERCEPTUAL);
+
+    if (signalling.file_gamma > 0.0)
+    {
+        png_set_gAMA(png_ptr, info_ptr.get(), signalling.file_gamma);
+        if (!signalling.gamma_is_exact)
+            spdlog::debug("PNG: approximating the {} curve as gAMA {:.5f} for readers that ignore cICP",
+                          transfer_function_name(tf), signalling.file_gamma);
+    }
+    else if (!k_can_write_cicp)
+        // Writing the file regardless would encode the pixels with this curve while recording no curve at
+        // all, which a reader cannot recover from: it assumes sRGB and silently returns wrong values.
+        throw runtime_error(fmt::format("PNG: cannot record the {} transfer function. It has no gAMA or sRGB "
+                                        "equivalent, and this build's libpng ({}) predates the cICP chunk added "
+                                        "in 1.6.46. Save to a format that can carry it, or rebuild against a "
+                                        "newer libpng.",
+                                        transfer_function_name(tf), PNG_LIBPNG_VER_STRING));
+    else
+        // Not an error -- the file is correct and HDRView reads it back exactly -- but the caveat belongs in
+        // front of the user, since it only arises for HDR curves and those are precisely the saves where
+        // being misread as sRGB elsewhere matters.
+        spdlog::warn("PNG: the {} curve can only be recorded in the cICP chunk, which most readers still "
+                     "ignore; other applications will interpret this file as sRGB",
+                     transfer_function_name(tf));
+
     png_write_info(png_ptr, info_ptr.get());
 
     // Ask libpng for the correct rowbytes (safer than w * n)
@@ -967,6 +1036,31 @@ PNGSaveOptions *png_parameters_gui()
         ImGui::PE::Combo("Pixel format", &s_opts.data_type_index, "UInt8\0UInt16\0");
 
         ImGui::PE::End();
+    }
+
+    // How faithfully the chosen curve can be recorded, said here rather than only in the log after the fact:
+    // this is the moment the user can still pick a different curve or a different format. The classification
+    // is the writer's own, so the two cannot disagree.
+    if (const auto signalling = transfer_signalling(s_opts.tf); signalling.file_gamma <= 0.0)
+    {
+        const string name = transfer_function_name(s_opts.tf);
+        const string note =
+            k_can_write_cicp
+                ? fmt::format(ICON_MY_LOG_LEVEL_WARN
+                              "  {} can only be recorded in PNG's cICP chunk, which most other applications "
+                              "still ignore. They will read this file as sRGB.",
+                              name)
+                : fmt::format(ICON_MY_LOG_LEVEL_ERROR
+                              "  {} cannot be recorded at all by this build's libpng ({}), which predates the "
+                              "cICP chunk. Saving will fail; choose another transfer function or format.",
+                              name, PNG_LIBPNG_VER_STRING);
+
+        ImGui::PushStyleColor(ImGuiCol_Text,
+                              k_can_write_cicp ? ImVec4{1.f, 0.75f, 0.25f, 1.f} : ImVec4{1.f, 0.4f, 0.4f, 1.f});
+        ImGui::PushTextWrapPos(0.f);
+        ImGui::TextUnformatted(note.c_str());
+        ImGui::PopTextWrapPos();
+        ImGui::PopStyleColor();
     }
 
     if (ImGui::Button("Reset options to defaults"))

--- a/tests/test_png_io.cpp
+++ b/tests/test_png_io.cpp
@@ -10,6 +10,14 @@
 #include "imageio/image_loader.h"
 #include "imageio/png.h"
 
+// For PNG_cICP_SUPPORTED. libpng gained the cICP chunk in 1.6.46, and older releases remain current on
+// common distributions (Ubuntu 24.04 ships 1.6.43), so -local builds can link a libpng without it. HDRView's
+// writer guards png_set_cICP() on this same macro (src/imageio/png.cpp), so without the chunk a saved PNG
+// records no transfer function at all: the pixels are encoded with one, but nothing in the file says which,
+// and a reload falls back to sRGB. The tests guarded below all depend on that record surviving a round-trip.
+#include <png.h>
+
+#include <cmath>
 #include <fstream>
 #include <sstream>
 
@@ -71,6 +79,7 @@ TEST_CASE("PNG save/load round-trips 8-bit and 16-bit pixel data without ditheri
     }
 }
 
+#ifdef PNG_cICP_SUPPORTED
 TEST_CASE("PNG save/load round-trips HDR transfer functions (PQ, HLG) and wide gamut via the cICP chunk")
 {
     // HDRView cares specifically about HDR: CICPProfile::is_HDR() explicitly checks for PQ (CICP transfer
@@ -107,6 +116,140 @@ TEST_CASE("PNG save/load round-trips HDR transfer functions (PQ, HLG) and wide g
             CHECK(reloaded[0]->channels[c](2, 1) == doctest::Approx(img->channels[c](2, 1)).epsilon(1e-3));
     }
 }
+
+#endif // PNG_cICP_SUPPORTED
+
+TEST_CASE("PNG save records the transfer function in gAMA and sRGB, not only in cICP")
+{
+    // cICP is recent enough that most readers ignore it, so a file tagged only that way is read correctly
+    // only by HDRView. Every curve that gAMA or the sRGB chunk can express is written through those too.
+    auto img = make_test_image(int2{4, 3});
+
+    SUBCASE("linear is recorded as gAMA 1.0")
+    {
+        std::ostringstream out(std::ios::binary);
+        save_png_image(*img, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                       /*sixteen_bit*/ true, TransferFunction::Linear);
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_png_image(in, "test.png");
+        REQUIRE(reloaded.size() == 1);
+        auto &header = reloaded[0]->metadata["header"];
+
+        // The loader reports the reciprocal of the stored value, so a linear encode reads back as 1.0.
+        REQUIRE(header.contains("gAMA"));
+        CHECK(header["gAMA"]["value"].get<float>() == doctest::Approx(1.f).epsilon(1e-3));
+    }
+
+    SUBCASE("a pure power curve is recorded exactly")
+    {
+        std::ostringstream out(std::ios::binary);
+        save_png_image(*img, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                       /*sixteen_bit*/ true, TransferFunction{TransferFunction::Gamma, 2.4f});
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_png_image(in, "test.png");
+        REQUIRE(reloaded.size() == 1);
+        auto &header = reloaded[0]->metadata["header"];
+
+        REQUIRE(header.contains("gAMA"));
+        CHECK(header["gAMA"]["value"].get<float>() == doctest::Approx(2.4f).epsilon(1e-3));
+    }
+
+    SUBCASE("sRGB content carries the sRGB chunk and a gAMA companion")
+    {
+        std::ostringstream out(std::ios::binary);
+        save_png_image(*img, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                       /*sixteen_bit*/ false, TransferFunction::sRGB);
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_png_image(in, "test.png");
+        REQUIRE(reloaded.size() == 1);
+        auto &header = reloaded[0]->metadata["header"];
+
+        // A valid rendering intent, i.e. the chunk is present.
+        REQUIRE(header.contains("sRGB"));
+        CHECK(header["sRGB"]["value"].get<int>() >= 0);
+        // ...and gAMA alongside it, for readers that honor neither cICP nor sRGB.
+        REQUIRE(header.contains("gAMA"));
+        CHECK(header["gAMA"]["value"].get<float>() == doctest::Approx(2.2f).epsilon(1e-3));
+    }
+
+    SUBCASE("an sRGB curve over a wide gamut does not claim the sRGB chunk")
+    {
+        // The sRGB chunk asserts BT.709 primaries as well as the curve, so writing it here would misstate
+        // the gamut. gAMA carries the curve instead, and cHRM the primaries.
+        auto wide            = make_test_image(int2{4, 3});
+        wide->chromaticities = gamut_chromaticities(ColorGamut_BT2020_2100);
+
+        std::ostringstream out(std::ios::binary);
+        save_png_image(*wide, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                       /*sixteen_bit*/ true, TransferFunction::sRGB);
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_png_image(in, "test.png");
+        REQUIRE(reloaded.size() == 1);
+        auto &header = reloaded[0]->metadata["header"];
+
+        REQUIRE(header.contains("sRGB"));
+        CHECK(header["sRGB"]["value"].get<int>() < 0); // absent
+        REQUIRE(header.contains("gAMA"));
+        CHECK(header["gAMA"]["value"].get<float>() == doctest::Approx(2.2f).epsilon(1e-3));
+    }
+
+    SUBCASE("the ITU curve is approximated as gAMA 2.2")
+    {
+        std::ostringstream out(std::ios::binary);
+        save_png_image(*img, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                       /*sixteen_bit*/ true, TransferFunction::ITU);
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               reloaded = load_png_image(in, "test.png");
+        REQUIRE(reloaded.size() == 1);
+        auto &header = reloaded[0]->metadata["header"];
+
+        REQUIRE(header.contains("gAMA"));
+        CHECK(header["gAMA"]["value"].get<float>() == doctest::Approx(2.2f).epsilon(1e-3));
+        // ITU is not sRGB, so the sRGB chunk must not appear even though the primaries are BT.709.
+        CHECK(header["sRGB"]["value"].get<int>() < 0);
+    }
+}
+
+#ifdef PNG_cICP_SUPPORTED
+TEST_CASE("a curve only cICP can express is saved with no gAMA claim")
+{
+    // PQ has no power-curve equivalent, so nothing is written that would let a gAMA-only reader believe it
+    // knows the curve. The file is correct but understood only by cICP-aware readers, which save_png_image
+    // warns about.
+    auto img = make_test_image(int2{4, 3});
+
+    std::ostringstream out(std::ios::binary);
+    save_png_image(*img, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                   /*sixteen_bit*/ true, TransferFunction::BT2100_PQ);
+
+    std::istringstream in(out.str(), std::ios::binary);
+    auto               reloaded = load_png_image(in, "test.png");
+    REQUIRE(reloaded.size() == 1);
+    auto &header = reloaded[0]->metadata["header"];
+
+    CHECK(header["cICP"]["value"] != "<not present>");
+    REQUIRE(header.contains("gAMA"));
+    CHECK(std::isnan(header["gAMA"]["value"].get<float>())); // the loader reports an absent gAMA as NaN
+    CHECK(header["sRGB"]["value"].get<int>() < 0);
+}
+#else
+TEST_CASE("saving a curve this libpng cannot record fails instead of mislabelling the file")
+{
+    // Without cICP there is nowhere to put PQ, and writing the file anyway would encode the pixels with one
+    // curve while the file names another. Only reachable on a libpng older than 1.6.46.
+    auto img = make_test_image(int2{4, 3});
+
+    std::ostringstream out(std::ios::binary);
+    CHECK_THROWS_AS(save_png_image(*img, out, "test.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                                   /*sixteen_bit*/ true, TransferFunction::BT2100_PQ),
+                    std::runtime_error);
+}
+#endif // PNG_cICP_SUPPORTED
 
 TEST_CASE("is_png_image correctly identifies real PNG bytes and rejects garbage")
 {
@@ -289,6 +432,9 @@ TEST_CASE("PNG load respects the documented color-profile chunk priority: cICP >
         CHECK(header["sRGB"]["value"].get<int>() >= 0); // sRGB chunk present with a valid rendering intent
     }
 
+#ifdef PNG_cICP_SUPPORTED
+    // Reading the chunk is guarded on the same macro as writing it (png_get_cICP in src/imageio/png.cpp), so
+    // against an older libpng the loader never reports a cICP chunk however the file itself is tagged.
     SUBCASE("cICP chunk takes priority over everything else, with correct Display P3 primaries")
     {
         auto reloaded = load_test_png("testpngs/png-3", "cicp-display-p3_reencoded.png");
@@ -302,6 +448,7 @@ TEST_CASE("PNG load respects the documented color-profile chunk priority: cICP >
         Chromaticities p3{{0.680f, 0.320f}, {0.265f, 0.690f}, {0.150f, 0.060f}, {0.3127f, 0.3290f}};
         CHECK(approx_equal(*reloaded[0]->chromaticities, p3, 1e-3f));
     }
+#endif // PNG_cICP_SUPPORTED
 }
 
 #endif // HDRVIEW_TEST_PNG_CONTRIB_DIR


### PR DESCRIPTION
`save_png_image()` encodes pixels with the requested transfer function and then signalled it **exclusively** through the cICP chunk. cICP expresses any curve exactly, but it is a recent addition to the PNG specification: most readers still ignore it, and libpng only learned to write it in **1.6.46**. Two consequences followed, one of them silent.

**A file HDRView writes is interpreted correctly only by a cICP-aware reader.** Everything else — browsers, editors, other libraries — falls back to assuming sRGB, so a linear or PQ export is quietly misread everywhere but here.

**Worse, `png_set_cICP` is compiled out entirely against an older libpng, and nothing took its place.** The pixels were encoded with a curve while the file recorded no curve at all. Ubuntu 24.04 ships libpng 1.6.43, so any `-local` build saved PNGs whose transfer function could not be recovered, and reloading one returned wrong values with no diagnostic.

## What the writer does now

The older chunks are emitted whenever they can express the curve:

| curve | recorded as | exactness |
|---|---|---|
| `Linear` | `gAMA` 1.0 | exact |
| `Gamma(g)` | `gAMA` 1/g | exact |
| `sRGB` | `sRGB` chunk + `gAMA` 1/2.2 | chunk exact, gAMA conventional |
| `ITU` | `gAMA` 1/2.2 | approximation |
| PQ, HLG, log curves | cICP only, and warned about | — |

The `sRGB` chunk asserts the whole colorspace, primaries included, so it is written only when those are sRGB's: stated as BT.709, left unspecified, or unrecognized and therefore already converted to sRGB. A genuinely wide gamut gets `cHRM` and `gAMA` instead.

A curve with no `gAMA` or `sRGB` equivalent, on a build that cannot write cICP either, now **throws** rather than producing a file whose pixels are mislabelled as sRGB. An error at save time is recoverable; silently wrong pixels are not.

Nothing changes for a reader that understands cICP — the loader's priority is cICP > ICC > sRGB > gAMA, so the new chunks only matter to readers that would otherwise have guessed.

## Surfaced in the save dialog

The same information appears where the user can still act on it, rather than only in the log once the file exists:

- choosing a curve only cICP can carry notes that other applications will read the file as sRGB;
- on a libpng too old for cICP it says plainly that saving will fail, *before* the attempt.

The dialog and the writer read that classification from **one shared helper**, since a dialog that promised something the writer did not do would be worse than saying nothing.

## Tests

New tests cover every row of the table, including the two negative cases that are easiest to get wrong — and one of which I did get wrong first time:

- an sRGB curve over a wide gamut must **not** claim the sRGB chunk;
- a cICP-only curve must leave **no** gAMA for a reader to misplace its trust in.

Both sides of the `PNG_cICP_SUPPORTED` `#ifdef` are exercised, so the behavior for an inexpressible curve is asserted whichever libpng the build links: with cICP, saving succeeds and writes no gAMA; without it, saving throws.

Verified in a CI-matching container (ubuntu-24.04): `linux-cpm` 66/66, and `linux-local` 59/59 against the system libpng 1.6.43.

## Notes for review

- **The dialog's presentation is compile-checked only.** No GUI test covers the save-options panel; the classification it depends on is tested, the wording/placement/colors are not. There is no theme warning color exposed, so those are literals.
- **`ITU` is deliberately approximated** at `gAMA` 1/2.2, the long-standing convention for that piecewise curve. Treating it as inexpressible instead would make it throw on older libpng, which seemed the wrong trade for a common curve.
- **CI does not yet exercise the old-libpng path.** The `linux-local` matrix entry doesn't run tests today; enabling that is part of the separate ThreadSanitizer branch, which also gives `-local` builds a way to receive the vendored image corpora. Until that lands, the path this PR fixes is verified in a container rather than by CI.
