### PR TITLE
Third bug hunt: nine fixes for silently wrong decodes, plus two session crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1638,7 +1638,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1638,7 +1638,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1361,6 +1361,17 @@ if(HDRVIEW_ENABLE_LIBRAW)
       message(STATUS "Will build libraw library")
       mark_as_system_library(libraw::libraw_r)
       disable_target_warnings(libraw::libraw_r)
+      # LibRaw sizes its raw store from raw_width x raw_height but its unpackers fill only the active area,
+      # so on a sensor whose frame carries a masked margin the rest is whatever malloc last held. HDRView
+      # keeps that margin (see the CFA part in imageio/raw.cpp), so this switches those allocations to
+      # calloc and makes the untouched photosites a deterministic zero instead. Both of LibRaw-cmake's
+      # targets get it: they compile the same sources under the same symbol names and both reach the link
+      # line, so whichever one resolves has to behave the same. A system LibRaw decides this for itself.
+      foreach(libraw_target raw raw_r)
+        if(TARGET ${libraw_target})
+          target_compile_definitions(${libraw_target} PRIVATE LIBRAW_CALLOC_RAWSTORE)
+        endif()
+      endforeach()
   elseif(LibRaw_FOUND AND TARGET libraw::libraw_r)
     message(STATUS "Using system-installed libraw library (version ${LIBRAW_VERSION})")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1638,7 +1638,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1638,7 +1638,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1649,7 +1649,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1638,7 +1638,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -380,6 +380,12 @@ void HDRViewApp::draw_background()
 
 void HDRViewApp::set_image_textures()
 {
+    // Every binding below goes through the shader, which setup_rendering() creates once the graphics
+    // backend is up. Images can arrive before that -- a session passed on the command line resolves and
+    // refreshes its textures as it loads -- and the next frame binds them anyway.
+    if (!m_shader)
+        return;
+
     try
     {
         // bind the primary and secondary images, or a placehold black texture when we have no current or

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -1204,6 +1204,11 @@ void HDRViewApp::finish_pending_session()
 
     m_request_sort = true;
     m_pending_session.reset();
+
+    // m_images was rebuilt above, and m_visible_images indexes into it -- the file list reads one through
+    // the other, so leaving the old indices in place walks off the end of the new vector. Every other path
+    // that touches m_images ends here too.
+    update_visibility();
 }
 
 void HDRViewApp::draw_confirm_load_session_dialog(bool &open)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -49,6 +49,12 @@ void init_hdrview(optional<float> exposure, optional<float> gamma, optional<bool
     spdlog::info("Overriding Apple-keyboard behavior: {}", apple_keys.has_value());
 
     g_hdrview = new HDRViewApp(exposure, gamma, dither, force_sdr, apple_keys, in_files);
+
+    // Loading is deliberately not part of construction: it reaches code that calls hdrview(), and until
+    // the assignment above returns there is nothing for that to return. A session is the case that gets
+    // there synchronously -- it resolves its entries and refreshes the textures on the spot -- so
+    // `HDRView some.hsess` used to dereference a null singleton before the window ever opened.
+    g_hdrview->load_images(in_files);
 }
 
 HDRViewApp *hdrview() { return g_hdrview; }
@@ -82,9 +88,6 @@ HDRViewApp::HDRViewApp(optional<float> force_exposure, optional<float> force_gam
     setup_frame_callbacks();
     setup_dialogs(in_files);
     setup_actions(window_setup.mod_key, window_setup.window_info);
-
-    // load any passed-in images
-    load_images(in_files);
 }
 
 void HDRViewApp::setup_window_and_backend(optional<bool> force_sdr)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -111,15 +111,18 @@ bool split_zip_entry(string_view filename, string &zip_path, string &entry_path)
     }
 }
 
+// The three functions below each stream over `input` line by line. They take a copy rather than reading
+// through input.data(): a string_view need not be null-terminated, so a view over part of a larger buffer
+// would otherwise be read well past its end.
 void process_lines(string_view input, function<void(string_view)> op)
 {
-    istringstream iss(input.data());
+    istringstream iss{string(input)};
     for (string line; getline(iss, line);) op(line);
 }
 
 string add_line_numbers(string_view input)
 {
-    istringstream iss(input.data());
+    istringstream iss{string(input)};
     ostringstream oss;
     size_t        line_number = 1;
 
@@ -139,7 +142,7 @@ string add_line_numbers(string_view input)
 
 string indent(string_view input, bool also_indent_first, int amount)
 {
-    istringstream iss(input.data());
+    istringstream iss{string(input)};
     ostringstream oss;
     string        spacer(amount, ' ');
     bool          first_line = !also_indent_first;

--- a/src/common.h
+++ b/src/common.h
@@ -422,7 +422,7 @@ std::pair<float, std::string> human_readable_size(size_t bytes);
 bool split_zip_entry(std::string_view filename, std::string &zip_path, std::string &entry_path);
 
 /// Run func on each line of the input string
-void process_lines(std::string_view input, std::function<void(std::string_view &)> op);
+void process_lines(std::string_view input, std::function<void(std::string_view)> op);
 /// Indent the input string by amount spaces. Skips the first line by default, unless also_indent_first is true
 std::string                     indent(std::string_view input, bool also_indent_first = false, int amount = 2);
 std::string                     add_line_numbers(std::string_view input);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1008,8 +1008,38 @@ void Image::apply_exif_orientation()
     if (orientation != 1)
     {
         spdlog::debug("Applying EXIF orientation: {}", orientation);
+
+        // These move the samples, so the windows have to move with them. Only matters when the display
+        // window is something other than the whole frame -- a raw CFA part marks the sensor's active area
+        // with it -- but then a flip lands it on the opposite edge from where it belongs.
+        auto reflect_windows = [this](bool horizontal)
+        {
+            const int extent =
+                horizontal ? data_window.min.x + data_window.max.x : data_window.min.y + data_window.max.y;
+            auto reflect = [extent, horizontal](Box2i &b)
+            {
+                int      &lo     = horizontal ? b.min.x : b.min.y;
+                int      &hi     = horizontal ? b.max.x : b.max.y;
+                const int new_lo = extent - hi, new_hi = extent - lo;
+                lo = new_lo;
+                hi = new_hi;
+            };
+            reflect(display_window);
+            reflect(data_window);
+        };
+        auto transpose_windows = [this]()
+        {
+            auto swap_axes = [](Box2i &b)
+            {
+                std::swap(b.min.x, b.min.y);
+                std::swap(b.max.x, b.max.y);
+            };
+            swap_axes(display_window);
+            swap_axes(data_window);
+        };
+
         // Helper lambdas for flipping/rotating
-        auto flip_horizontal = [this]()
+        auto flip_horizontal = [this, &reflect_windows]()
         {
             for (auto &channel : channels)
             {
@@ -1024,8 +1054,9 @@ void Image::apply_exif_orientation()
                                               std::swap(channel(x, y), channel(w - 1 - x, y));
                                   });
             }
+            reflect_windows(true);
         };
-        auto flip_vertical = [this]()
+        auto flip_vertical = [this, &reflect_windows]()
         {
             for (auto &channel : channels)
             {
@@ -1040,8 +1071,9 @@ void Image::apply_exif_orientation()
                                               std::swap(channel(x, y), channel(x, h - 1 - y));
                                   });
             }
+            reflect_windows(false);
         };
-        auto transpose = [this]()
+        auto transpose = [this, &transpose_windows]()
         {
             for (auto &channel : channels)
             {
@@ -1061,8 +1093,7 @@ void Image::apply_exif_orientation()
                                           for (int x = 0; x < tmp.width(); ++x) channel(x, y) = tmp(x, y);
                                   });
             }
-            std::swap(data_window.max.x, data_window.max.y);
-            std::swap(display_window.max.x, display_window.max.y);
+            transpose_windows();
         };
 
         // Apply orientation according to EXIF spec

--- a/src/imageio/dds.cpp
+++ b/src/imageio/dds.cpp
@@ -745,11 +745,15 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
             image->filename = filename;
             if (image->partname.empty())
                 image->partname = dds.array_size() > 1 ? cubemap_face_names[p % 6] : "";
-            image->alpha_type =
-                image->channels.size() >= 4 || image->channels.size() == 2
-                    ? (dds.alpha_mode == DDSFile::ALPHA_MODE_PREMULTIPLIED ? AlphaType_PremultipliedLinear
-                                                                           : AlphaType_Straight)
-                    : AlphaType_None;
+            // DXT2 and DXT4 are the premultiplied-alpha spellings of DXT3 and DXT5, and a DX9 file carries
+            // that only in its FourCC -- there is no misc_flags2 to read it from. Without this the values,
+            // which arrive already multiplied by alpha, would be premultiplied a second time by finalize().
+            const bool premultiplied = dds.alpha_mode == DDSFile::ALPHA_MODE_PREMULTIPLIED ||
+                                       dds.compression == DDSFile::Compression::BC2_DXT2 ||
+                                       dds.compression == DDSFile::Compression::BC3_DXT4;
+            image->alpha_type         = image->channels.size() >= 4 || image->channels.size() == 2
+                                            ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
+                                            : AlphaType_None;
             image->metadata["loader"] = "smalldds";
             image->metadata["pixel format"] =
                 dds.bitmasked ? header["bitmask_string"]["string"].get<string>()

--- a/src/imageio/icc.cpp
+++ b/src/imageio/icc.cpp
@@ -9,6 +9,44 @@ using std::string_view;
 using std::vector;
 using namespace stp;
 
+namespace
+{
+
+// Reads the four code points of an ICC `cicp` tag (ICC.1:2022, 9.2.16) out of a profile's bytes, leaving
+// `quad` untouched when the profile has no such tag. The tag table is walked directly rather than through
+// LCMS because LCMS only gained cmsSigcicpTag in 2.16, and HDRView links whichever LCMS the build supplies.
+void parse_icc_cicp_tag(const uint8_t *data, size_t size, std::array<int, 4> &quad)
+{
+    // Header is 128 bytes, followed by a 4-byte tag count and that many 12-byte tag table entries.
+    if (!data || size < 132)
+        return;
+
+    auto be32 = [data](size_t o)
+    { return (uint32_t)data[o] << 24 | (uint32_t)data[o + 1] << 16 | (uint32_t)data[o + 2] << 8 | data[o + 3]; };
+
+    const uint64_t tag_count = be32(128);
+    if (132 + tag_count * 12 > size)
+        return;
+
+    for (uint64_t t = 0; t < tag_count; ++t)
+    {
+        const size_t   entry  = 132 + (size_t)t * 12;
+        const uint64_t offset = be32(entry + 4), tag_size = be32(entry + 8);
+
+        // The tag's own type signature repeats in its first four bytes, then four reserved bytes, then the
+        // four code points -- twelve in all, which is also the smallest a well-formed tag can be.
+        if (be32(entry) != 0x63696370u || tag_size < 12 || offset + tag_size > size)
+            continue;
+        if (be32((size_t)offset) != 0x63696370u)
+            continue;
+
+        for (int i = 0; i < 4; ++i) quad[i] = data[(size_t)offset + 8 + i];
+        return;
+    }
+}
+
+} // namespace
+
 #if HDRVIEW_ENABLE_LCMS2
 #include <lcms2.h>
 
@@ -75,7 +113,7 @@ ICCProfile::ICCProfile(const uint8_t *icc_profile, size_t icc_profile_size) :
     m_profile(cmsOpenProfileFromMemTHR(CmsContext::thread_local_instance().get(), (const void *)icc_profile,
                                        (cmsUInt32Number)icc_profile_size))
 {
-    // empty
+    parse_icc_cicp_tag(icc_profile, icc_profile_size, m_cicp);
 }
 
 ICCProfile::~ICCProfile()
@@ -385,6 +423,12 @@ bool ICCProfile::transform_pixels(float *pixels, int3 size, const ICCProfile &pr
 bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries, string *tf_description,
                                   Chromaticities *c) const
 {
+    // When the profile's own `cicp` tag declares PQ or HLG, it is the only part of the profile that can
+    // describe the encoding: the ICC PCS is normalized to media white, so transforming an HDR image through
+    // the profile clamps everything above it and the extra range is gone. Linearize from the code points.
+    if (auto codes = cicp(); codes.valid() && codes.is_HDR())
+        return codes.linearize_pixels(pixels, size, keep_primaries, tf_description, c);
+
     ICCProfile profile_out = nullptr;
     // create the output profile and store either the input or output primaries in c
     if (keep_primaries)
@@ -425,7 +469,10 @@ std::vector<uint8_t> ICCProfile::dump_to_memory() const
 
 // Stubs for builds without LCMS2 which just return failure for operations that require LCMS functionality.
 
-ICCProfile::ICCProfile(const uint8_t * /*icc_profile*/, size_t /*icc_profile_size*/) : m_profile(nullptr) {}
+ICCProfile::ICCProfile(const uint8_t *icc_profile, size_t icc_profile_size) : m_profile(nullptr)
+{
+    parse_icc_cicp_tag(icc_profile, icc_profile_size, m_cicp);
+}
 ICCProfile::~ICCProfile() {}
 ICCProfile           ICCProfile::linear_RGB(const Chromaticities           &/*chr*/) { return ICCProfile(nullptr); }
 ICCProfile           ICCProfile::linear_Gray(const float2           &/*whitepoint*/) { return ICCProfile(nullptr); }
@@ -450,6 +497,8 @@ bool ICCProfile::linearize_pixels(float * /*pixels*/, int3 /*size*/, bool /*keep
 }
 
 #endif // HDRVIEW_ENABLE_LCMS2
+
+CICPProfile ICCProfile::cicp() const { return CICPProfile{m_cicp}; }
 
 // --- CICPProfile implementation -------------------------------------------------
 

--- a/src/imageio/icc.cpp
+++ b/src/imageio/icc.cpp
@@ -423,10 +423,11 @@ bool ICCProfile::transform_pixels(float *pixels, int3 size, const ICCProfile &pr
 bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries, string *tf_description,
                                   Chromaticities *c) const
 {
-    // When the profile's own `cicp` tag declares PQ or HLG, it is the only part of the profile that can
-    // describe the encoding: the ICC PCS is normalized to media white, so transforming an HDR image through
-    // the profile clamps everything above it and the extra range is gone. Linearize from the code points.
-    if (auto codes = cicp(); codes.valid() && codes.is_HDR())
+    // A `cicp` tag is the profile stating its encoding in CICP's own terms (ICC.1:2022), so it is taken as
+    // authoritative -- the same standing a PNG cICP chunk has over an iCCP profile. For HDR it is also the
+    // only part of the profile that *can* describe the encoding: the ICC PCS is normalized to media white,
+    // so transforming a PQ or HLG image through the profile clamps away everything above it.
+    if (auto codes = cicp(); codes.valid())
         return codes.linearize_pixels(pixels, size, keep_primaries, tf_description, c);
 
     ICCProfile profile_out = nullptr;
@@ -499,6 +500,13 @@ bool ICCProfile::linearize_pixels(float * /*pixels*/, int3 /*size*/, bool /*keep
 #endif // HDRVIEW_ENABLE_LCMS2
 
 CICPProfile ICCProfile::cicp() const { return CICPProfile{m_cicp}; }
+
+CICPProfile icc_cicp_tag(const uint8_t *icc_profile, size_t icc_profile_size)
+{
+    std::array<int, 4> quad{{-1, -1, -1, -1}};
+    parse_icc_cicp_tag(icc_profile, icc_profile_size, quad);
+    return CICPProfile{quad};
+}
 
 // --- CICPProfile implementation -------------------------------------------------
 

--- a/src/imageio/icc.h
+++ b/src/imageio/icc.h
@@ -296,6 +296,14 @@ private:
     std::array<int, 4> m_quad;
 };
 
+/*! The code points from an ICC profile's `cicp` tag (ICC.1:2022), or an invalid profile if it has none.
+
+    Reads the profile bytes directly, needing neither LCMS nor a constructed ICCProfile: LCMS only learned
+    the tag in 2.16, and a caller may need the code points -- the range flag in particular -- before it has
+    decided how to read the pixels at all.
+*/
+CICPProfile icc_cicp_tag(const uint8_t *icc_profile, size_t icc_profile_size);
+
 // version of linearize_pixels that uses chromaticities and transfer function (instead of ICC or CICP profiles)
 bool linearize_pixels(float *pixels, int3 size, const Chromaticities &gamut, const TransferFunction &tf,
                       bool keep_primaries, std::string *profile_description, Chromaticities *c,

--- a/src/imageio/icc.h
+++ b/src/imageio/icc.h
@@ -7,9 +7,12 @@
 
 #include "colorspace.h"
 #include "fwd.h"
+#include <array>
 #include <cstdint>
 #include <string>
 #include <sys/types.h>
+
+class CICPProfile;
 
 /*! Wrapper for an ICC profile providing utility routines used by HDRView.
 
@@ -89,6 +92,13 @@ public:
     std::string description() const;
     bool        extract_chromaticities(Chromaticities *c) const;
 
+    /*! The code points from this profile's `cicp` tag (ICC.1:2022), or an invalid profile if it has none.
+
+        Read straight out of the profile bytes rather than through LCMS, which only learned the tag in 2.16
+        and would otherwise make this depend on which LCMS a given build links.
+    */
+    CICPProfile cicp() const;
+
     std::vector<uint8_t> dump_to_memory() const;
 
     bool is_CMYK() const; ///< Check if this is a CMYK profile.
@@ -146,6 +156,9 @@ private:
     /// Internal constructor from raw profile pointer.
     ICCProfile(void *profile) : m_profile{profile} {}
     void *m_profile = nullptr;
+
+    /// Raw `cicp` code points, filled in at construction; all -1 when the profile carries no such tag.
+    std::array<int, 4> m_cicp{{-1, -1, -1, -1}};
 };
 
 /*! A class to manage color profiles defined via Coding-independent code points (CICP).

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -509,6 +509,18 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
             {"value", "<not present>"}, {"string", "<not present>"}, {"type", "array"}, {"description", cicp_desc}};
     }
 
+    // A file can carry its code points in the ICC profile's `cicp` tag (ICC.1:2022) instead of a cICP chunk,
+    // and that tag holds the same narrow/full range flag. Read it here, before the samples are dequantized
+    // below, since without it a narrow-range file is stretched as though it were full range. The chunk wins
+    // when both are present, matching the PNG-3 priority order that puts cICP ahead of iCCP.
+    if (!cicp.valid() && !icc_profile.empty())
+        if (auto codes = icc_cicp_tag(icc_profile.data(), icc_profile.size()); codes.valid())
+        {
+            video_full_range_flag = codes.fr() ? 1 : 0;
+            spdlog::info("No cICP chunk; taking the video range ({}) from the ICC profile's cicp tag.",
+                         video_full_range_flag ? "full" : "narrow");
+        }
+
     // Done reading color chunks
     //
 

--- a/src/imageio/qoi.cpp
+++ b/src/imageio/qoi.cpp
@@ -127,7 +127,7 @@ vector<ImagePtr> load_qoi_image(istream &is, string_view filename, const ImageLo
         image->channels[c].copy_from_interleaved(reinterpret_cast<uint8_t *>(decoded_data.get()), size.x, size.y,
                                                  size.z, c, [](uint8_t v) { return dequantize_full(v); });
     // then apply transfer function
-    if (opts.tf_override.type != TransferFunction::Linear)
+    if (tf.type != TransferFunction::Linear)
     {
         int num_color_channels = size.z >= 3 ? 3 : 1;
         to_linear(image->channels[0].data(), size.z > 1 ? image->channels[1].data() : nullptr,

--- a/src/imageio/raw.cpp
+++ b/src/imageio/raw.cpp
@@ -954,13 +954,20 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
 
             if (pass_cfa_filter)
             {
-                int raw_w = idata.sizes.raw_width;
-                int raw_h = idata.sizes.raw_height;
+                // The sensor's active area within the raw frame. LibRaw sizes rawdata.raw_image from
+                // raw_width x raw_height, but its unpackers only fill this rectangle; a frame that carries
+                // masked columns or rows around it leaves those holding whatever the allocation did, which
+                // for several Olympus bodies is values no 12-bit sensor could produce, differing from one
+                // build to the next. Only what LibRaw actually decodes is exposed.
+                const int cfa_w = idata.sizes.width;
+                const int cfa_h = idata.sizes.height;
+                const int x0    = idata.sizes.left_margin;
+                const int y0    = idata.sizes.top_margin;
 
-                // Expose the raw CFA data as a grayscale Image if available.
-                if (pass_cfa_filter && idata.rawdata.raw_image && raw_w > 0 && raw_h > 0)
+                if (idata.rawdata.raw_image && cfa_w > 0 && cfa_h > 0 && x0 + cfa_w <= idata.sizes.raw_width &&
+                    y0 + cfa_h <= idata.sizes.raw_height)
                 {
-                    auto cfa_img                      = std::make_shared<Image>(int2{raw_w, raw_h}, 1);
+                    auto cfa_img                      = std::make_shared<Image>(int2{cfa_w, cfa_h}, 1);
                     cfa_img->filename                 = filename;
                     cfa_img->partname                 = "cfa";
                     cfa_img->metadata["loader"]       = "LibRaw (CFA)";
@@ -969,21 +976,30 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
                     if (!exif_ctx.metadata.empty())
                         cfa_img->metadata["exif"] = exif_ctx.metadata;
 
-                    // Copy raw ushort values into float buffer without scaling
-                    std::vector<float> cfa_pixels((size_t)raw_w * raw_h);
-                    ushort            *rawp = idata.rawdata.raw_image;
+                    // Copy raw ushort values into float buffer without scaling. raw_image is LibRaw's
+                    // one-component (Bayer) buffer, and it sets raw_pitch to raw_width * 2 for it; the
+                    // three- and four-component sensors that stride differently leave raw_image null and
+                    // are skipped above.
+                    std::vector<float> cfa_pixels((size_t)cfa_w * cfa_h);
+                    const ushort      *rawp       = idata.rawdata.raw_image;
+                    const size_t       raw_stride = idata.sizes.raw_width;
 
                     constexpr float scale = 1.0f / 65535.0f;
-                    stp::parallel_for(stp::blocked_range<int>(0, raw_w * raw_h, 1024),
+                    stp::parallel_for(stp::blocked_range<int>(0, cfa_h, 64),
                                       [&](int begin, int end, int /*unit_index*/, int /*thread_index*/)
                                       {
-                                          for (int i = begin; i < end; ++i) cfa_pixels[i] = rawp[i] * scale;
+                                          for (int y = begin; y < end; ++y)
+                                          {
+                                              const ushort *src = rawp + (size_t)(y0 + y) * raw_stride + x0;
+                                              float        *dst = cfa_pixels.data() + (size_t)y * cfa_w;
+                                              for (int x = 0; x < cfa_w; ++x) dst[x] = src[x] * scale;
+                                          }
                                       });
 
                     // Copy into single channel
-                    cfa_img->channels[0].copy_from_interleaved<float>(cfa_pixels.data(), raw_w, raw_h, 1, 0,
+                    cfa_img->channels[0].copy_from_interleaved<float>(cfa_pixels.data(), cfa_w, cfa_h, 1, 0,
                                                                       [](float v) { return v; });
-                    cfa_img->display_window = Box2i{{0, 0}, {raw_w, raw_h}};
+                    cfa_img->display_window = Box2i{{0, 0}, {cfa_w, cfa_h}};
 
                     images.push_back(cfa_img);
                 }

--- a/src/imageio/raw.cpp
+++ b/src/imageio/raw.cpp
@@ -954,20 +954,13 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
 
             if (pass_cfa_filter)
             {
-                // The sensor's active area within the raw frame. LibRaw sizes rawdata.raw_image from
-                // raw_width x raw_height, but its unpackers only fill this rectangle; a frame that carries
-                // masked columns or rows around it leaves those holding whatever the allocation did, which
-                // for several Olympus bodies is values no 12-bit sensor could produce, differing from one
-                // build to the next. Only what LibRaw actually decodes is exposed.
-                const int cfa_w = idata.sizes.width;
-                const int cfa_h = idata.sizes.height;
-                const int x0    = idata.sizes.left_margin;
-                const int y0    = idata.sizes.top_margin;
+                const int raw_w = idata.sizes.raw_width;
+                const int raw_h = idata.sizes.raw_height;
 
-                if (idata.rawdata.raw_image && cfa_w > 0 && cfa_h > 0 && x0 + cfa_w <= idata.sizes.raw_width &&
-                    y0 + cfa_h <= idata.sizes.raw_height)
+                // Expose the raw CFA data as a grayscale Image if available.
+                if (idata.rawdata.raw_image && raw_w > 0 && raw_h > 0)
                 {
-                    auto cfa_img                      = std::make_shared<Image>(int2{cfa_w, cfa_h}, 1);
+                    auto cfa_img                      = std::make_shared<Image>(int2{raw_w, raw_h}, 1);
                     cfa_img->filename                 = filename;
                     cfa_img->partname                 = "cfa";
                     cfa_img->metadata["loader"]       = "LibRaw (CFA)";
@@ -976,30 +969,33 @@ vector<ImagePtr> load_raw_image(std::istream &is, string_view filename, const Im
                     if (!exif_ctx.metadata.empty())
                         cfa_img->metadata["exif"] = exif_ctx.metadata;
 
-                    // Copy raw ushort values into float buffer without scaling. raw_image is LibRaw's
-                    // one-component (Bayer) buffer, and it sets raw_pitch to raw_width * 2 for it; the
-                    // three- and four-component sensors that stride differently leave raw_image null and
-                    // are skipped above.
-                    std::vector<float> cfa_pixels((size_t)cfa_w * cfa_h);
-                    const ushort      *rawp       = idata.rawdata.raw_image;
-                    const size_t       raw_stride = idata.sizes.raw_width;
+                    // Copy raw ushort values into float buffer without scaling
+                    std::vector<float> cfa_pixels((size_t)raw_w * raw_h);
+                    const ushort      *rawp = idata.rawdata.raw_image;
 
                     constexpr float scale = 1.0f / 65535.0f;
-                    stp::parallel_for(stp::blocked_range<int>(0, cfa_h, 64),
+                    stp::parallel_for(stp::blocked_range<int>(0, raw_w * raw_h, 1024),
                                       [&](int begin, int end, int /*unit_index*/, int /*thread_index*/)
                                       {
-                                          for (int y = begin; y < end; ++y)
-                                          {
-                                              const ushort *src = rawp + (size_t)(y0 + y) * raw_stride + x0;
-                                              float        *dst = cfa_pixels.data() + (size_t)y * cfa_w;
-                                              for (int x = 0; x < cfa_w; ++x) dst[x] = src[x] * scale;
-                                          }
+                                          for (int i = begin; i < end; ++i) cfa_pixels[i] = rawp[i] * scale;
                                       });
 
                     // Copy into single channel
-                    cfa_img->channels[0].copy_from_interleaved<float>(cfa_pixels.data(), cfa_w, cfa_h, 1, 0,
+                    cfa_img->channels[0].copy_from_interleaved<float>(cfa_pixels.data(), raw_w, raw_h, 1, 0,
                                                                       [](float v) { return v; });
-                    cfa_img->display_window = Box2i{{0, 0}, {cfa_w, cfa_h}};
+
+                    // The whole raw frame is the data window, but LibRaw's unpackers fill only the active
+                    // area: a frame carrying masked columns or rows leaves the rest holding whatever the
+                    // allocation did, which for several Olympus bodies is values no 12-bit sensor could
+                    // produce. Those photosites are still worth keeping -- some cameras do write optical
+                    // black there -- so the display window marks the region LibRaw actually decodes and
+                    // the rest stays available outside it.
+                    const int2 active_min{idata.sizes.left_margin, idata.sizes.top_margin};
+                    const int2 active_max{active_min.x + idata.sizes.width, active_min.y + idata.sizes.height};
+                    cfa_img->display_window = (idata.sizes.width > 0 && idata.sizes.height > 0 &&
+                                               active_max.x <= raw_w && active_max.y <= raw_h)
+                                                  ? Box2i{active_min, active_max}
+                                                  : Box2i{{0, 0}, {raw_w, raw_h}};
 
                     images.push_back(cfa_img);
                 }

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -537,10 +537,24 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
             const uint64_t int_max_value = file_bits_per_sample == 0    ? 1ull
                                            : file_bits_per_sample >= 64 ? ~0ull
                                                                         : ((1ull << file_bits_per_sample) - 1);
-            const float    int_inv_divisor = 1.0f / (float)int_max_value;
-            const float    int_bias        = sample_format == SAMPLEFORMAT_INT && file_bits_per_sample > 0
+            float          int_inv_divisor = 1.0f / (float)int_max_value;
+            float          int_bias        = sample_format == SAMPLEFORMAT_INT && file_bits_per_sample > 0
                                                  ? (float)(1ull << (file_bits_per_sample - 1))
                                                  : 0.0f;
+
+            // TIFF has no field of its own for the video range, but a profile carrying CICP code points
+            // (ICC.1:2022) states it there. Narrow range puts black at 16 and white at 235, scaled by the
+            // sample depth, so it is the same normalization with a different divisor and offset -- and
+            // deliberately not clamped, since a narrow-range image may carry excursions beyond both.
+            if (sample_format == SAMPLEFORMAT_UINT && file_bits_per_sample >= 8 && file_bits_per_sample <= 16)
+                if (auto codes = icc_cicp_tag(image->icc_data.data(), image->icc_data.size());
+                    codes.valid() && !codes.fr())
+                {
+                    const float scale = (float)(1ull << (file_bits_per_sample - 8));
+                    int_inv_divisor   = 1.f / (219.f * scale);
+                    int_bias          = -16.f * scale;
+                    spdlog::info("ICC cicp tag declares narrow video range; dequantizing 16..235 accordingly.");
+                }
 
             // Helper function to unpack bits (handles both byte-aligned and bit-packed data)
             auto unpack_bits =

--- a/tests/test_cicp_video_range.cpp
+++ b/tests/test_cicp_video_range.cpp
@@ -1,0 +1,189 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "colorspace.h"
+#include "image.h"
+#include "imageio/icc.h"
+#include "imageio/image_loader.h"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+void put_be32(std::vector<uint8_t> &v, size_t o, uint32_t x)
+{
+    v[o]     = uint8_t(x >> 24);
+    v[o + 1] = uint8_t(x >> 16);
+    v[o + 2] = uint8_t(x >> 8);
+    v[o + 3] = uint8_t(x);
+}
+
+// An ICC profile carrying nothing but a `cicp` tag (ICC.1:2022). Only the tag is read here, so the rest of
+// the profile is left as a bare header -- TIFF stores the blob opaquely and never parses it.
+std::vector<uint8_t> icc_with_cicp(uint8_t cp, uint8_t tc, uint8_t mc, uint8_t fr)
+{
+    std::vector<uint8_t> v(128 + 4 + 12 + 12, 0);
+    put_be32(v, 0, (uint32_t)v.size());
+    put_be32(v, 128, 1);           // one tag
+    put_be32(v, 132, 0x63696370u); // 'cicp'
+    put_be32(v, 136, 144);         // offset
+    put_be32(v, 140, 12);          // size
+    put_be32(v, 144, 0x63696370u); // type signature
+    v[152] = cp;
+    v[153] = tc;
+    v[154] = mc;
+    v[155] = fr;
+    return v;
+}
+
+// 16-bit narrow ("video") range puts black at 16 and white at 235, scaled by the sample depth.
+constexpr uint16_t k_narrow_black = 16 * 256;  // 4096
+constexpr uint16_t k_narrow_white = 235 * 256; // 60160
+constexpr uint16_t k_mid          = 128 * 256; // 32768
+
+// Builds a 3x1, 16-bit, single-sample uncompressed little-endian TIFF holding `codes`, with an embedded
+// ICC profile. Hand-assembled in the style of tests/test_tiff_io.cpp so the tags under test are explicit.
+std::string make_gray16_tiff(const std::vector<uint16_t> &codes, const std::vector<uint8_t> &icc)
+{
+    struct Entry
+    {
+        uint16_t tag, type;
+        uint32_t count, value;
+    };
+    const uint32_t width = (uint32_t)codes.size();
+
+    // Header (8) + entry count (2) + 11 entries (12 each) + next-IFD (4), then the out-of-line ICC blob,
+    // then the pixel data.
+    const uint32_t ifd_off   = 8;
+    const uint32_t n_entries = 11;
+    const uint32_t after_ifd = ifd_off + 2 + n_entries * 12 + 4;
+    const uint32_t icc_off   = after_ifd;
+    const uint32_t data_off  = icc_off + (uint32_t)icc.size();
+    const uint32_t data_len  = width * 2;
+
+    const Entry entries[n_entries] = {
+        {256, 4, 1, width},                        // ImageWidth
+        {257, 4, 1, 1},                            // ImageLength
+        {258, 3, 1, 16},                           // BitsPerSample
+        {259, 3, 1, 1},                            // Compression = none
+        {262, 3, 1, 1},                            // Photometric = min-is-black
+        {273, 4, 1, data_off},                     // StripOffsets
+        {277, 3, 1, 1},                            // SamplesPerPixel
+        {278, 4, 1, 1},                            // RowsPerStrip
+        {279, 4, 1, data_len},                     // StripByteCounts
+        {339, 3, 1, 1},                            // SampleFormat = unsigned int
+        {34675, 7, (uint32_t)icc.size(), icc_off}, // ICCProfile
+    };
+
+    std::string out;
+    auto        u16 = [&out](uint16_t x)
+    {
+        out += char(x & 0xFF);
+        out += char(x >> 8);
+    };
+    auto u32 = [&out](uint32_t x)
+    {
+        out += char(x & 0xFF);
+        out += char((x >> 8) & 0xFF);
+        out += char((x >> 16) & 0xFF);
+        out += char((x >> 24) & 0xFF);
+    };
+
+    out += "II";
+    u16(42);
+    u32(ifd_off);
+    u16((uint16_t)n_entries);
+    for (const auto &e : entries)
+    {
+        u16(e.tag);
+        u16(e.type);
+        u32(e.count);
+        // A SHORT that fits in the value field is stored in its low half, left-justified in the four bytes.
+        if (e.type == 3 && e.count == 1)
+        {
+            u16((uint16_t)e.value);
+            u16(0);
+        }
+        else
+            u32(e.value);
+    }
+    u32(0); // no next IFD
+    out.append(reinterpret_cast<const char *>(icc.data()), icc.size());
+    for (uint16_t c : codes) u16(c);
+    return out;
+}
+
+ImagePtr load(const std::string &bytes, const char *name)
+{
+    std::istringstream in(bytes, std::ios::binary);
+    auto               loaded = load_image(in, name);
+    REQUIRE(loaded.size() == 1);
+    return loaded.front();
+}
+
+} // namespace
+
+// The range flag lives only in the cicp tag: TIFF has no field of its own for it, and a PNG carrying its
+// code points this way has no cICP chunk either. Transfer characteristic 8 is Linear, so what these
+// assertions see is the dequantization alone, with no curve on top of it.
+TEST_CASE("A cicp tag declaring narrow video range is dequantized 16..235")
+{
+    const std::vector<uint16_t> codes{k_narrow_black, k_narrow_white, k_mid};
+
+    SUBCASE("narrow range")
+    {
+        auto img = load(make_gray16_tiff(codes, icc_with_cicp(1, 8, 0, /*full_range*/ 0)), "narrow.tif");
+        REQUIRE(img->channels.size() >= 1);
+        const auto &ch = img->channels[0];
+        REQUIRE(ch.size().x == 3);
+
+        CHECK(ch(0, 0) == doctest::Approx(0.f).epsilon(1e-5));
+        CHECK(ch(1, 0) == doctest::Approx(1.f).epsilon(1e-5));
+        CHECK(ch(2, 0) == doctest::Approx((128.f - 16.f) / 219.f).epsilon(1e-5));
+    }
+
+    SUBCASE("full range, same samples")
+    {
+        auto img = load(make_gray16_tiff(codes, icc_with_cicp(1, 8, 0, /*full_range*/ 1)), "full.tif");
+        REQUIRE(img->channels.size() >= 1);
+        const auto &ch = img->channels[0];
+        REQUIRE(ch.size().x == 3);
+
+        // Black and white sit inside the full range rather than at its ends, which is exactly the error
+        // the narrow flag exists to prevent.
+        CHECK(ch(0, 0) == doctest::Approx(k_narrow_black / 65535.f).epsilon(1e-5));
+        CHECK(ch(1, 0) == doctest::Approx(k_narrow_white / 65535.f).epsilon(1e-5));
+        CHECK(ch(2, 0) == doctest::Approx(k_mid / 65535.f).epsilon(1e-5));
+    }
+
+    SUBCASE("narrow range keeps excursions beyond black and white")
+    {
+        // A narrow-range image may carry codes outside 16..235; those must survive as values outside
+        // [0,1] rather than being clamped, since HDR test patterns rely on the headroom.
+        auto        img = load(make_gray16_tiff({0, 65535}, icc_with_cicp(1, 8, 0, 0)), "excursions.tif");
+        const auto &ch  = img->channels[0];
+        CHECK(ch(0, 0) < 0.f);
+        CHECK(ch(1, 0) > 1.f);
+    }
+}
+
+// The flag has to survive the trip through the tag reader, since that is what both loaders consult.
+TEST_CASE("icc_cicp_tag reports the video range flag")
+{
+    auto narrow = icc_with_cicp(9, 18, 0, 0);
+    auto full   = icc_with_cicp(9, 18, 0, 1);
+
+    CHECK(icc_cicp_tag(narrow.data(), narrow.size()).fr() == 0);
+    CHECK(icc_cicp_tag(full.data(), full.size()).fr() == 1);
+    CHECK(icc_cicp_tag(narrow.data(), narrow.size()).valid());
+    CHECK(!icc_cicp_tag(nullptr, 0).valid());
+}

--- a/tests/test_dds_io.cpp
+++ b/tests/test_dds_io.cpp
@@ -1,0 +1,131 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "colorspace.h"
+#include "image.h"
+#include "imageio/dds.h"
+#include "imageio/image_loader.h"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+void put_le32(std::vector<uint8_t> &v, uint32_t value)
+{
+    v.insert(v.end(), {uint8_t(value), uint8_t(value >> 8), uint8_t(value >> 16), uint8_t(value >> 24)});
+}
+
+// The alpha nibble every texel of the synthetic block carries, and the value it decodes to.
+constexpr uint8_t k_alpha_nibble = 8;
+constexpr float   k_alpha        = float(k_alpha_nibble) / 15.f;
+
+// Builds a 4x4 single-block DX9 DDS under the given FourCC. DXT2 and DXT3 (like DXT4 and DXT5) are the same
+// bits with the same layout; the FourCC alone says whether the colors are already multiplied by alpha, which
+// is exactly what this needs to vary while holding the payload fixed.
+std::string make_one_block_dds(const char fourcc[4])
+{
+    std::vector<uint8_t> v{'D', 'D', 'S', ' '};
+
+    put_le32(v, 124);                                // dwSize
+    put_le32(v, 0x1 | 0x2 | 0x4 | 0x1000 | 0x80000); // caps|height|width|pixelformat|linearsize
+    put_le32(v, 4);                                  // height
+    put_le32(v, 4);                                  // width
+    put_le32(v, 16);                                 // linear size: one 16-byte block
+    put_le32(v, 0);                                  // depth
+    put_le32(v, 0);                                  // mipmap count
+    for (int i = 0; i < 11; ++i) put_le32(v, 0);     // reserved
+
+    // DDS_PIXELFORMAT: FourCC only, no DDPF_ALPHAPREMULT -- the format tag has to carry it on its own.
+    put_le32(v, 32);  // dwSize
+    put_le32(v, 0x4); // DDPF_FOURCC
+    v.insert(v.end(), {uint8_t(fourcc[0]), uint8_t(fourcc[1]), uint8_t(fourcc[2]), uint8_t(fourcc[3])});
+    for (int i = 0; i < 5; ++i) put_le32(v, 0); // bit count and masks
+
+    put_le32(v, 0x1000); // dwCaps = TEXTURE
+    for (int i = 0; i < 4; ++i) put_le32(v, 0);
+
+    // BC2 block: eight bytes of 4-bit alpha, then a DXT1-style color block.
+    const uint8_t packed_alpha = uint8_t(k_alpha_nibble | (k_alpha_nibble << 4));
+    for (int i = 0; i < 8; ++i) v.push_back(packed_alpha);
+
+    // Both endpoints the same mid-gray, so all sixteen texels decode to one color whatever the
+    // interpolation does, and every index selects endpoint 0.
+    const uint16_t rgb565 = uint16_t((16u << 11) | (32u << 5) | 16u);
+    v.insert(v.end(), {uint8_t(rgb565), uint8_t(rgb565 >> 8), uint8_t(rgb565), uint8_t(rgb565 >> 8)});
+    for (int i = 0; i < 4; ++i) v.push_back(0); // all indices 0
+
+    return std::string(v.begin(), v.end());
+}
+
+ImagePtr load_dds(const std::string &bytes, const char *name)
+{
+    // Through load_image() rather than load_dds_image() directly: Image::finalize(), which is where
+    // straight alpha gets premultiplied, runs there and not in the loader.
+    std::istringstream in(bytes, std::ios::binary);
+    auto               loaded = load_image(in, name);
+    REQUIRE(loaded.size() == 1);
+    return loaded.front();
+}
+
+} // namespace
+
+// DXT2 and DXT4 store colors already multiplied by alpha; DXT3 and DXT5 store them straight. Nothing but the
+// FourCC records that in a DX9 file, so a loader that misses it hands premultiplied values to finalize() as
+// though they were straight, and they come back multiplied by alpha a second time.
+TEST_CASE("DDS premultiplied-alpha formats are not premultiplied a second time")
+{
+    auto straight_bytes     = make_one_block_dds("DXT3");
+    auto premultiplied_byte = make_one_block_dds("DXT2");
+
+    // Same payload under both tags, so any difference in the result is the alpha handling alone.
+    REQUIRE(straight_bytes.size() == premultiplied_byte.size());
+    REQUIRE(straight_bytes.substr(128) == premultiplied_byte.substr(128));
+
+    auto straight      = load_dds(straight_bytes, "straight.dds");
+    auto premultiplied = load_dds(premultiplied_byte, "premultiplied.dds");
+
+    REQUIRE(straight->channels.size() == 4);
+    REQUIRE(premultiplied->channels.size() == 4);
+
+    CHECK(straight->alpha_type == AlphaType_Straight);
+    CHECK(premultiplied->alpha_type == AlphaType_PremultipliedLinear);
+
+    // Both files decode to the same alpha, and it has to be well away from 0 and 1 for the rest to mean
+    // anything -- premultiplying by 1 is not observable.
+    for (auto *img : {straight.get(), premultiplied.get()})
+        CHECK(img->channels[3](0, 0) == doctest::Approx(k_alpha).epsilon(1e-4));
+    REQUIRE(k_alpha > 0.1f);
+    REQUIRE(k_alpha < 0.9f);
+
+    for (int c = 0; c < 3; ++c)
+    {
+        const float straight_value      = straight->channels[c](0, 0);
+        const float premultiplied_value = premultiplied->channels[c](0, 0);
+
+        REQUIRE(premultiplied_value > 0.f);
+
+        // HDRView stores premultiplied values, so the straight file is the one finalize() scales by alpha.
+        // The already-premultiplied file must come through untouched -- the two differ by exactly alpha.
+        CHECK(straight_value == doctest::Approx(premultiplied_value * k_alpha).epsilon(1e-4));
+        CHECK(premultiplied_value != doctest::Approx(straight_value).epsilon(1e-4));
+    }
+}
+
+// DXT4/DXT5 are the same distinction one block format along, and are read through the same tag.
+TEST_CASE("DDS DXT4 is premultiplied and DXT5 is straight")
+{
+    auto dxt5 = load_dds(make_one_block_dds("DXT5"), "dxt5.dds");
+    auto dxt4 = load_dds(make_one_block_dds("DXT4"), "dxt4.dds");
+
+    CHECK(dxt5->alpha_type == AlphaType_Straight);
+    CHECK(dxt4->alpha_type == AlphaType_PremultipliedLinear);
+}

--- a/tests/test_icc_cicp.cpp
+++ b/tests/test_icc_cicp.cpp
@@ -1,0 +1,164 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "colorspace.h"
+#include "imageio/icc.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+void put_be32(std::vector<uint8_t> &v, size_t offset, uint32_t value)
+{
+    v[offset + 0] = uint8_t(value >> 24);
+    v[offset + 1] = uint8_t(value >> 16);
+    v[offset + 2] = uint8_t(value >> 8);
+    v[offset + 3] = uint8_t(value);
+}
+
+// Builds the smallest byte sequence that carries an ICC `cicp` tag: a 128-byte header, a one-entry tag
+// table, and the tag itself. LCMS will refuse to open it as a profile, which is deliberate -- the code
+// points have to be readable from the bytes alone, independent of what LCMS makes of the rest.
+std::vector<uint8_t> icc_bytes_with_cicp(uint8_t cp, uint8_t tc, uint8_t mc, uint8_t fr)
+{
+    std::vector<uint8_t> v(128 + 4 + 12 + 12, 0);
+    put_be32(v, 0, (uint32_t)v.size()); // profile size
+    put_be32(v, 128, 1);                // one tag
+    put_be32(v, 132, 0x63696370u);      // 'cicp'
+    put_be32(v, 136, 144);              // tag offset
+    put_be32(v, 140, 12);               // tag size
+    put_be32(v, 144, 0x63696370u);      // tag type signature, repeated
+    v[152] = cp;
+    v[153] = tc;
+    v[154] = mc;
+    v[155] = fr;
+    return v;
+}
+
+} // namespace
+
+// ICC.1:2022 lets a profile declare CICP code points directly. HDRView reads them out of the profile bytes
+// rather than through LCMS, which only gained the tag in 2.16 -- so a build linking an older LCMS (libjxl
+// vendors 2.10) would otherwise see nothing here.
+TEST_CASE("ICC cicp tag is read from the profile bytes")
+{
+    SUBCASE("PQ at BT.2020 primaries")
+    {
+        auto bytes = icc_bytes_with_cicp(9, 16, 0, 1);
+        auto codes = ICCProfile(bytes.data(), bytes.size()).cicp();
+        CHECK(codes.valid());
+        CHECK(codes.cp() == 9);
+        CHECK(codes.tc() == 16);
+        CHECK(codes.is_HDR());
+        CHECK(codes.transfer_function().type == TransferFunction::BT2100_PQ);
+    }
+
+    SUBCASE("HLG at BT.2020 primaries")
+    {
+        auto bytes = icc_bytes_with_cicp(9, 18, 0, 1);
+        auto codes = ICCProfile(bytes.data(), bytes.size()).cicp();
+        CHECK(codes.valid());
+        CHECK(codes.tc() == 18);
+        CHECK(codes.is_HDR());
+        CHECK(codes.transfer_function().type == TransferFunction::BT2100_HLG);
+    }
+
+    SUBCASE("an SDR tag is read but is not HDR")
+    {
+        auto bytes = icc_bytes_with_cicp(1, 13, 0, 1);
+        auto codes = ICCProfile(bytes.data(), bytes.size()).cicp();
+        CHECK(codes.valid());
+        CHECK(!codes.is_HDR());
+    }
+
+    SUBCASE("a profile without the tag reports no code points")
+    {
+        std::vector<uint8_t> v(132, 0);
+        put_be32(v, 0, (uint32_t)v.size());
+        put_be32(v, 128, 0); // no tags
+        CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+    }
+}
+
+// The defect this guards: an HDR image whose transfer function is declared only by the profile's cicp tag
+// used to be linearized by transforming through the profile itself, and the ICC PCS is normalized to media
+// white -- so everything above diffuse white was clamped away. PQ's 1.0 is 10000 nits, which against a
+// 203-nit reference white is a little over 49, and that is what has to survive.
+TEST_CASE("An ICC profile whose cicp tag declares PQ keeps its HDR range")
+{
+    auto       bytes = icc_bytes_with_cicp(9, 16, 0, 1);
+    ICCProfile profile(bytes.data(), bytes.size());
+
+    std::vector<float> pixels{1.f, 1.f, 1.f, 0.5f, 0.5f, 0.5f};
+    std::string        description;
+    Chromaticities     chr;
+
+    REQUIRE(profile.linearize_pixels(pixels.data(), int3{2, 1, 3}, /*keep_primaries*/ true, &description, &chr));
+
+    // Fully-encoded PQ is far above SDR white; the pre-fix path could not return anything above it.
+    CHECK(pixels[0] > 40.f);
+    CHECK(pixels[0] == doctest::Approx(49.2611f).epsilon(1e-3));
+    // Mid-code PQ is a much dimmer absolute level, so the curve is being applied rather than a scale factor.
+    CHECK(pixels[3] < 1.f);
+    CHECK(pixels[3] > 0.f);
+}
+
+// The tag is parsed straight from untrusted bytes, so a truncated or self-inconsistent profile has to fall
+// out as "no code points" rather than reading past the buffer.
+TEST_CASE("ICC cicp parsing rejects malformed profiles")
+{
+    auto good = icc_bytes_with_cicp(9, 16, 0, 1);
+
+    SUBCASE("truncated before the tag table")
+    {
+        for (size_t n : {size_t(0), size_t(4), size_t(127), size_t(131)})
+        {
+            std::vector<uint8_t> v(good.begin(), good.begin() + (ptrdiff_t)n);
+            CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+        }
+    }
+
+    SUBCASE("tag count larger than the buffer can hold")
+    {
+        auto v = good;
+        put_be32(v, 128, 0xFFFFFFFFu);
+        CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+    }
+
+    SUBCASE("tag offset and size point past the end")
+    {
+        auto v = good;
+        put_be32(v, 136, 0xFFFFFF00u);
+        CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+
+        v = good;
+        put_be32(v, 140, 0xFFFFFFFFu);
+        CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+    }
+
+    SUBCASE("tag size too small to hold the code points")
+    {
+        auto v = good;
+        put_be32(v, 140, 11);
+        CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+    }
+
+    SUBCASE("tag type signature does not match the table entry")
+    {
+        auto v = good;
+        put_be32(v, 144, 0x64656164u);
+        CHECK(!ICCProfile(v.data(), v.size()).cicp().valid());
+    }
+
+    SUBCASE("a null buffer is handled") { CHECK(!ICCProfile(nullptr, 0).cicp().valid()); }
+}

--- a/tests/test_line_helpers.cpp
+++ b/tests/test_line_helpers.cpp
@@ -8,6 +8,9 @@
 
 #include "common.h"
 
+// doctest only forward-declares std::basic_ostream, and MSVC's operator<<(ostream&, string_view) needs the
+// complete type -- so asserting on a string_view below does not compile there without this.
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/tests/test_line_helpers.cpp
+++ b/tests/test_line_helpers.cpp
@@ -1,0 +1,64 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "common.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+using std::string;
+using std::string_view;
+using std::vector;
+
+// A string_view carries its own length and need not be null-terminated. These three helpers take one, so a
+// view over the front of a larger buffer has to stop at the view's end -- reading through data() instead
+// runs on to whatever follows, which for a view into a std::string is the rest of that string.
+TEST_CASE("line helpers respect the length of a non-terminated string_view")
+{
+    // Everything from the newline on is outside the view, and must not be seen.
+    const string      backing = "first\nsecond\nthird";
+    const string_view view(backing.data(), 5); // exactly "first"
+    REQUIRE(view == "first");
+
+    SUBCASE("process_lines visits only the lines inside the view")
+    {
+        vector<string> lines;
+        process_lines(view, [&lines](string_view l) { lines.emplace_back(l); });
+        REQUIRE(lines.size() == 1);
+        CHECK(lines[0] == "first");
+    }
+
+    SUBCASE("add_line_numbers numbers only the lines inside the view")
+    {
+        const auto numbered = add_line_numbers(view);
+        CHECK(numbered.find("second") == string::npos);
+        CHECK(numbered.find("third") == string::npos);
+        CHECK(numbered.find("first") != string::npos);
+    }
+
+    SUBCASE("indent indents only the lines inside the view")
+    {
+        const auto indented = indent(view, true, 2);
+        CHECK(indented == "  first");
+    }
+}
+
+// The ordinary null-terminated case has to keep working unchanged.
+TEST_CASE("line helpers still handle multi-line input")
+{
+    const string input = "alpha\nbeta";
+
+    vector<string> lines;
+    process_lines(input, [&lines](string_view l) { lines.emplace_back(l); });
+    REQUIRE(lines.size() == 2);
+    CHECK(lines[0] == "alpha");
+    CHECK(lines[1] == "beta");
+
+    CHECK(indent(input, true, 2) == "  alpha\n  beta");
+}

--- a/tests/test_orientation_windows.cpp
+++ b/tests/test_orientation_windows.cpp
@@ -1,0 +1,111 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "image.h"
+
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// Marks the samples that lie outside the display window, so that after an orientation is applied the
+// question "did the window follow the pixels?" can be asked of the pixels themselves.
+constexpr float k_outside = 999.f;
+constexpr float k_inside  = 1.f;
+
+// A 6x4 image whose display window covers only the left 4 columns; the two columns beyond it hold the
+// sentinel. This is the shape a raw CFA part has: the whole sensor frame as data, the part LibRaw
+// decodes as the display window.
+ImagePtr make_marked_image(int orientation)
+{
+    const int2 size{6, 4};
+    auto       img = std::make_shared<Image>(size, 1);
+
+    img->data_window    = Box2i{{0, 0}, size};
+    img->display_window = Box2i{{0, 0}, {4, 4}};
+
+    auto &ch = img->channels[0];
+    for (int y = 0; y < size.y; ++y)
+        for (int x = 0; x < size.x; ++x) ch(x, y) = (x < 4) ? k_inside : k_outside;
+
+    img->metadata["exif"]["IFD0"]["Orientation"] = {{"value", orientation}};
+    return img;
+}
+
+// Every sample the display window covers, and every sample it does not.
+void check_partition(const ImagePtr &img, int orientation)
+{
+    const auto &ch  = img->channels[0];
+    const auto  dsw = img->display_window;
+
+    CAPTURE(orientation);
+    REQUIRE(ch.size().x * ch.size().y == 24);
+    // The display window keeps its area through any rotation or reflection.
+    REQUIRE(dsw.size().x * dsw.size().y == 16);
+
+    size_t inside = 0, outside = 0;
+    for (int y = 0; y < ch.size().y; ++y)
+        for (int x = 0; x < ch.size().x; ++x)
+        {
+            const bool in_window = x >= dsw.min.x && x < dsw.max.x && y >= dsw.min.y && y < dsw.max.y;
+            const bool is_marked = ch(x, y) == k_outside;
+            CAPTURE(x);
+            CAPTURE(y);
+            // A marked sample inside the window, or an unmarked one outside it, means the window did not
+            // move with the pixels.
+            CHECK(in_window != is_marked);
+            in_window ? ++inside : ++outside;
+        }
+    CHECK(inside == 16);
+    CHECK(outside == 8);
+}
+
+} // namespace
+
+// An EXIF orientation moves the samples, so both windows have to move with them. While the display window
+// is the whole frame this is unobservable; once it is a sub-rectangle -- as it is for a raw CFA part, whose
+// display window marks the region LibRaw actually decodes -- a flip leaves it on the wrong edge.
+TEST_CASE("EXIF orientation carries the display window with the pixels")
+{
+    // 1 is a no-op; 2-8 are the reflections and rotations, and 4, 7 and 8 are the ones a flip moves.
+    for (int orientation : {1, 2, 3, 4, 5, 6, 7, 8})
+    {
+        auto img = make_marked_image(orientation);
+        img->apply_exif_orientation();
+        check_partition(img, orientation);
+    }
+}
+
+// The transposing orientations must also swap the frame's extent, not just reflect within it.
+TEST_CASE("EXIF orientation transposes both windows")
+{
+    for (int orientation : {5, 6, 7, 8})
+    {
+        auto img = make_marked_image(orientation);
+        img->apply_exif_orientation();
+
+        CAPTURE(orientation);
+        CHECK(img->data_window.size().x == 4);
+        CHECK(img->data_window.size().y == 6);
+        CHECK(img->display_window.size().x == 4);
+        CHECK(img->display_window.size().y == 4);
+    }
+
+    for (int orientation : {1, 2, 3, 4})
+    {
+        auto img = make_marked_image(orientation);
+        img->apply_exif_orientation();
+
+        CAPTURE(orientation);
+        CHECK(img->data_window.size().x == 6);
+        CHECK(img->data_window.size().y == 4);
+        CHECK(img->display_window.size().x == 4);
+        CHECK(img->display_window.size().y == 4);
+    }
+}

--- a/tests/test_qoi_io.cpp
+++ b/tests/test_qoi_io.cpp
@@ -1,0 +1,88 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "colorspace.h"
+#include "image.h"
+#include "imageio/qoi.h"
+
+#include <qoi.h>
+
+#include <cstdlib>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// Encodes a single-pixel-per-value RGB QOI file holding `values` verbatim, tagged with `colorspace`
+// (QOI_SRGB or QOI_LINEAR). Going through qoi_encode() rather than save_qoi_image() keeps the stored
+// bytes exactly what the test asks for, independent of the save path's own gain/dither/transfer handling.
+std::string encode_qoi_rgb(const std::vector<unsigned char> &values, unsigned char colorspace)
+{
+    const int      w = (int)values.size();
+    const qoi_desc desc{(unsigned int)w, 1u, 3, colorspace};
+
+    std::vector<unsigned char> interleaved;
+    interleaved.reserve(values.size() * 3);
+    for (auto v : values) interleaved.insert(interleaved.end(), {v, v, v});
+
+    int                                          size = 0;
+    std::unique_ptr<void, decltype(std::free) *> encoded{qoi_encode(interleaved.data(), &desc, &size), std::free};
+    REQUIRE(encoded != nullptr);
+    return std::string((const char *)encoded.get(), (size_t)size);
+}
+
+} // namespace
+
+// A QOI file tagged QOI_SRGB stores sRGB-encoded samples, so the loader has to linearize them the way every
+// other 8-bit loader does. The values below are the ones that separate "linearized" from "left encoded":
+// mid-gray 128 lands at 0.216 linear but 0.502 if the transfer function is skipped.
+TEST_CASE("QOI tagged sRGB is linearized on load")
+{
+    const std::vector<unsigned char> values{0, 64, 128, 192, 255};
+
+    auto               bytes = encode_qoi_rgb(values, QOI_SRGB);
+    std::istringstream in(bytes, std::ios::binary);
+
+    auto loaded = load_qoi_image(in, "srgb.qoi");
+    REQUIRE(loaded.size() == 1);
+    const auto &img = loaded.front();
+    REQUIRE(img->channels.size() == 3);
+
+    for (int c = 0; c < 3; ++c)
+        for (int x = 0; x < (int)values.size(); ++x)
+        {
+            const float encoded  = values[x] / 255.f;
+            const float expected = sRGB_to_linear(encoded);
+            CHECK(img->channels[c](x, 0) == doctest::Approx(expected).epsilon(1e-5));
+        }
+
+    // The distinction the guard turns on: mid-gray must not still be its encoded value.
+    CHECK(img->channels[0](2, 0) == doctest::Approx(0.21586f).epsilon(1e-4));
+    CHECK(img->channels[0](2, 0) != doctest::Approx(128.f / 255.f).epsilon(1e-4));
+}
+
+// The other half of the same guard: a file that declares its samples already linear must be left alone.
+TEST_CASE("QOI tagged linear is not linearized on load")
+{
+    const std::vector<unsigned char> values{0, 64, 128, 192, 255};
+
+    auto               bytes = encode_qoi_rgb(values, QOI_LINEAR);
+    std::istringstream in(bytes, std::ios::binary);
+
+    auto loaded = load_qoi_image(in, "linear.qoi");
+    REQUIRE(loaded.size() == 1);
+    const auto &img = loaded.front();
+    REQUIRE(img->channels.size() == 3);
+
+    for (int c = 0; c < 3; ++c)
+        for (int x = 0; x < (int)values.size(); ++x)
+            CHECK(img->channels[c](x, 0) == doctest::Approx(values[x] / 255.f).epsilon(1e-5));
+}


### PR DESCRIPTION
A third bug hunt, aimed where the first two didn't look. [#187](https://github.com/wkjarosz/hdrview/pull/187)
fuzzed `load_image()` and put the suites under sanitizers; [#189](https://github.com/wkjarosz/hdrview/pull/189)
read the save path, the session and settings loaders, and the shared containers. Both hunt for code that
*crashes or misbehaves*. This one hunts for code that **returns the wrong number quietly** — decodes that
produce no error, no sanitizer report, and a wrong image.

The method was to decode the whole test corpus (2769 files) and compare formats against each other. Several
sets ship the same picture twice — `.qoi` beside `.png`, `.dds` beside a reference `.png`, one PQ pattern as
AVIF, JPEG, JXL and PNG, and a colour chart signalled three different ways in both PNG and TIFF. Where two
independent encodings of one image disagree, one of them is being decoded wrong. That found five of the nine
bugs below; a sanitizer would not have flagged any of them.

## Wrong pixels

**Every QOI file was displayed far too bright.** The guard before `to_linear()` tested
`ImageLoadOptions::tf_override` rather than the transfer function actually chosen for the file.
`tf_override` is `Linear` unless the user explicitly overrides the profile, so in the normal case the
condition was false and the file kept its sRGB-encoded values — no linearization at all. The QOI test suite
ships each image as both `.qoi` and `.png`; `qoi_logo`'s blue channel peaked at 0.356863 from the QOI and
0.10462 from the PNG, and `sRGB_to_linear(0.356863)` is 0.10462 exactly. All fourteen pairs now agree to
within the two loaders' rounding. Shipped in v3.0.0-beta.01.

**HDR images signalling PQ or HLG through an ICC profile lost their entire HDR range.** ICC.1:2022 lets a
profile carry CICP code points in a `cicp` tag, and for an HDR image that tag is the *only* part of the
profile that can describe the encoding — the ICC PCS is normalized to media white, so transforming an image
through the profile clamps everything above diffuse white and the extra range is gone. `test_pattern-PQ.avif`
decoded to a maximum of 1.008 where the same pattern as PNG, JXL, and as an AVIF signalling through an nclx
box all decode to 49.2611 (10000 nits against a 203-nit reference white). A factor of about fifty, in an HDR
viewer, on files whose whole purpose is the HDR range.

The tag is read out of the profile bytes rather than through LCMS, which only learned `cmsSigcicpTag` in
2.16. libjxl vendors 2.10 and the system LCMS here is 2.17, so going through LCMS would have made this work
or not depending on which one a given build linked. Parsing is bounds-checked against the profile length and
covered by tests for truncated, oversized and self-inconsistent tag tables, since it runs on bytes straight
out of a file. A tag whose code points are not fully specified is rejected and the profile is used as before.

**A file's video range was ignored when only its ICC profile stated it.** That tag carries four code points
and only two were being used. PNG chooses narrow- or full-range dequantization from the cICP *chunk* and
defaults to full when there is none, so a file declaring its range only in the tag was stretched as though it
were full range: `PNG-HLG-FancyColorBars-16bit-ICC-cICP-Tag-NR.png` read a mean of 0.447 where its
chunk-signalled twin gives 0.657. TIFF had no notion of video range at all. Narrow range is the same
normalization with a different divisor and offset, so it is expressed that way rather than as a second code
path, and deliberately not clamped — these patterns carry excursions past both black and white on purpose.

The tag is also not restricted to PQ and HLG. ICC.1:2022 requires the encoding a `cicp` tag describes to be
*equivalent* to the one the rest of the profile represents, which makes preferring the tag safe where they
agree and right where they do not — the case the tag exists for. Restricting it to HDR left the two SDR files
in that set on a different path from their chunk-signalled twins, disagreeing by 1.4% at full range and 11%
at narrow. All five PNG pairs in the CICP set — HLG and SDR at both ranges, and PQ — now agree with their
twins to four significant figures, as does the TIFF.

**DXT2 and DXT4 images were premultiplied by alpha twice, and rendered too dark.** `alpha_mode` is only set
from the `DDPF_ALPHAPREMULT` flag or a DX10 header's `misc_flags2`, but DXT2 and DXT4 *are* the
premultiplied-alpha spellings of DXT3 and DXT5 — a DX9 file records it in the FourCC and nowhere else. Those
files were tagged straight, and `Image::finalize()` multiplied colors that already carried alpha by it again.
The tell was that a DXT2 file decoded byte-identically to its DXT3 twin, when the two hold the same payload
under different tags and so must differ by exactly alpha. This also covers the files `image-dds` writes as
`BC2_UNORM_PREMULTIPLIED_ALPHA.dds` and `BC3_UNORM_PREMULTIPLIED_ALPHA.dds`, which use the legacy FourCC to
say exactly this.

**A raw frame's masked border was uninitialized memory.** LibRaw sizes `rawdata.raw_image` from
`raw_width x raw_height` but its unpackers fill only the active area, so on a sensor whose frame carries
masked columns the rest holds whatever the allocation contained — and the CFA part copied the whole frame
out. `RAW_OLYMPUS_EPL3.ORF` reported a maximum of 0.0581369 on one run and 0.999756 on the next; six others
sat at ~65519 of 65535, which 12-bit sensor data cannot produce. Every impossible sample was in the masked
columns: for `RAW_OLYMPUS_E30.ORF`, `over_limit(active=0, margin=153)` at columns 4096..4099, against an
active area that never exceeded its ceiling.

The border is worth keeping — the E-330 writes optical black there and the E-300 writes image data, while the
E-30, TG-4 and E-PL3 never touch it, and nothing in LibRaw tells the two apart. So the whole frame stays as
the data window and the **display window** marks what LibRaw actually decodes. LibRaw is additionally built
with `LIBRAW_CALLOC_RAWSTORE` so the photosites it never writes read as zero rather than as the previous
allocation; both of LibRaw-cmake's targets need it, since they compile the same sources under the same symbol
names and both reach the link line.

Worth knowing for anyone reading the earlier investigation: an ASan build over the whole raw corpus is
*clean*, because the read is in bounds of LibRaw's allocation and merely uninitialized within it — which ASan
cannot see and macOS has no MSan for. What localised it was counting samples above the sensor's bit depth and
reporting their column range.

**An EXIF orientation moved the pixels but not the windows.** `apply_exif_orientation()` swapped a transpose's
`.max` and did nothing at all on a flip. That is unobservable while the display window is the whole frame and
wrong the moment it is not — which the raw CFA part made it. The E-30 is the one oriented file in that set,
and its masked columns landed *inside* the display window: `max_disp` read 0.877 where the correct value is
0.0613565. Both windows now reflect and transpose with the samples. This one is general, not raw-specific:
any image with a display window smaller than its data window was affected.

**The line helpers in `common.cpp` read past the end of a `string_view`.** `process_lines()`,
`add_line_numbers()` and `indent()` each built an `istringstream` from `input.data()`, which for a
`string_view` is not null-terminated — a view over the front of a larger buffer ran on into whatever followed
it. The same class as the shortened-name overread fixed in #189. Both current callers pass whole
null-terminated strings, so this is latent rather than live; it is fixed because these are public helpers that
take a `string_view` and must honour one. While there: the declaration of `process_lines()` took a
`std::function<void(std::string_view &)>` the definition never matched, so the declared overload had no
definition to link against.

## Two crashes

Found while checking the fixes above by hand, in code this branch does not otherwise touch.

**A session passed on the command line dereferenced a null singleton.** `load_images()` ran inside
`HDRViewApp`'s constructor, but the singleton `hdrview()` returns is only assigned once that constructor
returns. A session is what gets far enough to notice: it resolves its entries and refreshes the textures on
the spot, and `set_null_texture()` reads `hdrview()->shader()`. Logging the pointer showed two calls with a
null singleton before the window ever opened. Loading now follows the assignment, and `set_image_textures()`
returns early until the shader exists, since images can arrive before `setup_rendering()` has made one.

**An unresolved session entry walked off the end of the image list.** `finish_pending_session()` rebuilt
`m_images` from the entries it resolved without rebuilding `m_visible_images`, which indexes into it. The file
list reads one through the other while drawing, so a session resolving fewer images than are loaded left
indices pointing past the end (`app-windows.cpp:859`). Every other path that touches `m_images` ends in
`update_visibility()`; this one now does too.

## What changed across the corpus

Several of these touch code that a great many files go through, so the corpus was decoded before and after
and the results diffed.

The QOI, ICC and DDS fixes change **85 files of 2769**, every one accounted for:

| Files | Why |
|---|---|
| 14 QOI | the linearization fix |
| 4 AVIF/JPEG | the ICC `cicp` fix |
| 6 PNG and TIFF | the ICC `cicp` fix — these carry PQ/HLG in an ICC `cicp` tag too, so it reaches two more formats than it was aimed at |
| 6 DDS | the DXT2/DXT4 fix |
| 51 JXL | the video-range commit, by ~1e-4 each: these carry a `cicp` tag, so the analytic CICP curve replaces LCMS's sampled one. Where a reference exists they move toward it — `test_pattern-sRGB.jxl` now reaches exactly 1.0, like its AVIF twin |
| 4 camera raws | run-to-run variation, since fixed — see below |

The raw work was measured separately, across all **336 CFA parts** in the raw corpus: the display window and
everything inside it are identical over three runs, and nothing inside exceeds full scale. 236 of them retain
a masked margin outside that window. The whole-frame maximum still varies for 12 files, which is the honest
cost of keeping those photosites: they are the ones LibRaw leaves alone, and nothing distinguishes them from
the ones it fills.

That 51-file JXL group is the broadest change here and the one judgement call I would flag: it is the direct
consequence of honouring the `cicp` tag for SDR as well as HDR. Narrowing it back to
`codes.valid() && codes.is_HDR()` is a one-line revert, at the price of the two SDR files disagreeing with
their chunk-signalled twins again.

## Found, reproduced, and deliberately not fixed

**`gdal-tiff-sample-formats/int24.tif` decodes to garbage, and I do not think that is ours.** Its 24-bit
signed samples span 0.0001–0.96 where its 16- and 32-bit siblings — the same image — sit in a narrow band
near 0.218. All 400 samples match the 16-bit file exactly when read big-endian and are garbage read
little-endian, in a file whose header says `II`. But libtiff's own model is unambiguous: `_TIFFSwab24BitData`
swaps triples only when the file's byte order differs from the host, which means an `II` file should store
them little-endian and HDRView's current reading is right. The only other 24-bit file in the corpus, libtiff's
own `flower-minisblack-24.tif`, stores byte-palindromic values (0x565656) and cannot discriminate. On one
hand-crafted autotest input against libtiff's documented behaviour, I left it alone.

**16-bit CMYK TIFFs do not load** (`flower-separated-{contig,planar}-16.tif`), where their 8-bit siblings do.
libtiff's RGBA interface declines them. This is reported honestly — an error in the log and "not a supported
image file" — rather than decoded wrongly, so it is a missing feature, not a correctness bug.

## Testing

138 tests pass, up from 125. Each new test synthesizes its input in memory: a one-block DXT2/DXT3 pair
differing only in FourCC; a QOI encoded through `qoi_encode` so the stored bytes are exactly what the test
asks for; a minimal ICC profile carrying just a `cicp` tag, and a 16-bit TIFF hand-assembled around one to
check the 16..235 mapping end to end; a 6x4 image whose display window covers four columns, run through all
eight EXIF orientations to check that no masked sample lands inside the window (64 of those assertions fail
against the old code). Each was confirmed to fail with its fix reverted and pass with it restored.

Three changes ship without a test, each for a reason:

- **the raw display window** — the repo vendors no raw fixture and the smallest candidate is about 10 MB, so
  it is verified against the corpus instead, as described above;
- **the two session crashes** — the GUI harness will not reach the state. I wrote a test for it, found it
  passed with and without the fix, and deleted it rather than let it look like coverage. Both are verified by
  direct reproduction with a session whose entries load but do not match: it segfaults before and runs
  cleanly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
