### PR TITLE
Fifth bug hunt: a flip that moved everything one pixel, and six more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1830,6 +1830,7 @@ if(HDRVIEW_BUILD_GUI_TESTS AND NOT EMSCRIPTEN)
     tests/gui/test_gui_dialogs.cpp
     tests/gui/test_gui_image_io.cpp
     tests/gui/test_gui_view.cpp
+    tests/gui/test_gui_viewport.cpp
     tests/gui/test_gui_tools.cpp
     tests/gui/test_gui_stats.cpp
     tests/gui/test_gui_filtering.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1831,6 +1831,7 @@ if(HDRVIEW_BUILD_GUI_TESTS AND NOT EMSCRIPTEN)
     tests/gui/test_gui_image_io.cpp
     tests/gui/test_gui_view.cpp
     tests/gui/test_gui_viewport.cpp
+    tests/gui/test_gui_display.cpp
     tests/gui/test_gui_tools.cpp
     tests/gui/test_gui_stats.cpp
     tests/gui/test_gui_filtering.cpp

--- a/assets/shaders/colorspaces.sglsl
+++ b/assets/shaders/colorspaces.sglsl
@@ -50,6 +50,11 @@ vec4 sRGBToLinear(vec4 color) { return vec4(sRGBToLinear(color.rgb), color.a); }
 // returns the luminance of a linear rgb color
 float RGBToY(vec3 rgb, vec3 weights) { return dot(weights, rgb); }
 
+// Luminance weights for linear sRGB/BT.709 primaries: the middle row of RGB2XYZ below, and what
+// colorspace.h's sRGB_Yw() computes. Any value already converted into those primaries is weighed by
+// these, whatever gamut it arrived in.
+const vec3 sRGB_Yw = vec3(0.212671, 0.715160, 0.072169);
+
 // Converts a color from linear RGB to XYZ space
 vec3 RGBToXYZ(vec3 rgb)
 {

--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -186,7 +186,11 @@ vec4 isolate(vec4 rgba, int straight_alpha)
 // Applied to each image separately, before any blending: an isolated channel is then undone with its own
 // file's alpha rather than a composite's, and comparison blend modes operate on the values being compared
 // instead of on premultiplied ones.
-vec4 choose_channel(vec4 rgba, int straight_alpha, vec3 yw)
+//
+// Runs after the gamut conversion, so Channels_Y weighs with sRGB's luminance weights, not the source
+// gamut's: those belong to the YC decode above, which is the one step that still sees the file's own
+// primaries.
+vec4 choose_channel(vec4 rgba, int straight_alpha)
 {
     switch (fsp.channel)
     {
@@ -196,7 +200,7 @@ vec4 choose_channel(vec4 rgba, int straight_alpha, vec3 yw)
     case Channels_Green: return isolate(rgba.ggga, straight_alpha);
     case Channels_Blue: return isolate(rgba.bbba, straight_alpha);
     case Channels_Alpha: return vec4(rgba.aaa, 1.0);
-    case Channels_Y: return vec4(vec3(dot(rgba.rgb, yw)), rgba.a);
+    case Channels_Y: return vec4(vec3(RGBToY(rgba.rgb, sRGB_Yw)), rgba.a);
     }
     return rgba;
 }
@@ -265,7 +269,7 @@ void main()
         value.xyz = YC_to_RGB(value.xyz, fsp.primary_yw);
 
     value = fsp.primary_M_to_sRGB * value;
-    value = choose_channel(value, fsp.primary_straight_alpha, fsp.primary_yw);
+    value = choose_channel(value, fsp.primary_straight_alpha);
 
     if (fsp.has_reference != 0)
     {
@@ -278,7 +282,7 @@ void main()
             reference_val.xyz = YC_to_RGB(reference_val.xyz, fsp.secondary_yw);
 
         reference_val = fsp.secondary_M_to_sRGB * reference_val;
-        reference_val = choose_channel(reference_val, fsp.secondary_straight_alpha, fsp.secondary_yw);
+        reference_val = choose_channel(reference_val, fsp.secondary_straight_alpha);
 
         value = blend(value, reference_val);
     }

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -11,20 +11,28 @@
 using namespace std;
 using namespace HelloImGui;
 
+/*!
+    Mirrors a pixel coordinate about the current image's display window, along whichever axes are flipped.
+
+    Pixel coordinates are continuous, with pixel \c i covering <tt>[i, i+1)</tt>, so the mirror of the
+    whole window <tt>[0, max)</tt> is <tt>max - p</tt> -- the same convention image_position() hands the
+    shader. The involution makes pixel_at_vp_pos() and vp_pos_at_pixel() inverses whether flipped or not.
+*/
+float2 HDRViewApp::flip_pixel(float2 pixel) const
+{
+    if (auto img = current_image())
+        return select(m_flip, float2{img->display_window.max} - pixel, pixel);
+    return pixel;
+}
+
 float2 HDRViewApp::pixel_at_vp_pos(float2 vp_pos) const
 {
-    float2 pixel = (vp_pos - (m_translate + center_offset())) / m_zoom;
-    if (auto img = current_image())
-        pixel = select(m_flip, img->display_window.max - pixel - 1, pixel);
-    return pixel;
+    return flip_pixel((vp_pos - (m_translate + center_offset())) / m_zoom);
 }
 
 float2 HDRViewApp::vp_pos_at_pixel(float2 pixel) const
 {
-    if (auto img = current_image())
-        pixel = select(m_flip, img->display_window.max - pixel - 1, pixel);
-
-    return m_zoom * pixel + (m_translate + center_offset());
+    return m_zoom * flip_pixel(pixel) + (m_translate + center_offset());
 }
 
 void HDRViewApp::set_zoom(float zoom)
@@ -80,10 +88,7 @@ void HDRViewApp::auto_fit_viewport()
 
 float HDRViewApp::zoom_level() const { return log(m_zoom * pixel_ratio()) / log(m_zoom_sensitivity); }
 
-void HDRViewApp::set_zoom_level(float level)
-{
-    set_zoom(std::pow(m_zoom_sensitivity, level) / pixel_ratio());
-}
+void HDRViewApp::set_zoom_level(float level) { set_zoom(std::pow(m_zoom_sensitivity, level) / pixel_ratio()); }
 
 void HDRViewApp::zoom_at_vp_pos(float amount, float2 focus_vp_pos)
 {
@@ -125,11 +130,8 @@ void HDRViewApp::zoom_out()
 
 void HDRViewApp::reposition_pixel_to_vp_pos(float2 position, float2 pixel)
 {
-    if (auto img = current_image())
-        pixel = select(m_flip, img->display_window.max - pixel - 1, pixel);
-
     // Calculate where the new offset must be in order to satisfy the image position equation.
-    m_translate = position - (pixel * m_zoom) - center_offset();
+    m_translate = position - (flip_pixel(pixel) * m_zoom) - center_offset();
 }
 
 Box2f HDRViewApp::scaled_display_window(ConstImagePtr img) const
@@ -140,63 +142,31 @@ Box2f HDRViewApp::scaled_display_window(ConstImagePtr img) const
     return dw;
 }
 
-Box2f HDRViewApp::scaled_data_window(ConstImagePtr img) const
-{
-    Box2f dw = img ? Box2f{img->data_window} : Box2f{{0, 0}, {0, 0}};
-    dw.min *= m_zoom;
-    dw.max *= m_zoom;
-    return dw;
-}
-
 float HDRViewApp::pixel_ratio() const { return ImGui::GetIO().DisplayFramebufferScale.x; }
 
 float2 HDRViewApp::center_offset() const
 {
-    auto   dw     = scaled_display_window(current_image());
-    float2 offset = (viewport_size() - dw.size()) / 2.f - dw.min;
-
-    // Adjust for flipping: if flipped, offset from the opposite side
-    // if (current_image())
-    {
-        if (m_flip.x)
-            offset.x += dw.min.x;
-        if (m_flip.y)
-            offset.y += dw.min.y;
-    }
-    return offset;
+    const Box2f dw = scaled_display_window(current_image());
+    // Center the display window in the viewport. Unflipped, the mapping is zoom*pixel + offset, so the
+    // window's min corner still has to be pulled back to the viewport's margin; flipped, it is
+    // zoom*(display_window.max - pixel) + offset, which already puts that corner at zero.
+    return (viewport_size() - dw.size()) / 2.f - select(m_flip, float2{0.f}, dw.min);
 }
 
+// The quad the image shader samples an image over spans its data window, uv 0 at the min corner and uv 1
+// at the max one. Both ends come from vp_pos_at_pixel(), so the drawn image, the overlays and the pixel
+// readouts share one transform -- including which display window a flip mirrors about, which is always the
+// current image's, never the reference's own.
 float2 HDRViewApp::image_position(ConstImagePtr img) const
 {
-    auto   dw  = scaled_data_window(img);
-    auto   dsw = scaled_display_window(img);
-    float2 pos = m_translate + center_offset() + select(m_flip, dsw.max - dw.min, dw.min);
-
-    // Adjust for flipping: move the image to the opposite side if flipped
-    // if (img)
-    // {
-    //     if (m_flip.x)
-    //         pos.x += m_offset.x + center_offset().x + (dsw.max.x - dw.min.x);
-    //     if (m_flip.y)
-    //         pos.y += m_offset.y + center_offset().y + (dsw.max.y - dw.min.y);
-    // }
-    return pos / viewport_size();
+    const Box2f dw = img ? Box2f{img->data_window} : Box2f{{0, 0}, {0, 0}};
+    return vp_pos_at_pixel(dw.min) / viewport_size();
 }
 
 float2 HDRViewApp::image_scale(ConstImagePtr img) const
 {
-    auto   dw    = scaled_data_window(img);
-    float2 scale = dw.size() / viewport_size();
-
-    // Negate scale for flipped axes
-    // if (img)
-    {
-        if (m_flip.x)
-            scale.x = -scale.x;
-        if (m_flip.y)
-            scale.y = -scale.y;
-    }
-    return scale;
+    const Box2f dw = img ? Box2f{img->data_window} : Box2f{{0, 0}, {0, 0}};
+    return (vp_pos_at_pixel(dw.max) - vp_pos_at_pixel(dw.min)) / viewport_size();
 }
 
 int HDRViewApp::next_visible_image_index(int index, Direction_ direction) const

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -212,8 +212,12 @@ float4 HDRViewApp::pixel_value(int2 p, bool raw, int which_image) const
 
 float4 HDRViewApp::tonemap_value(float4 value) const
 {
-    return ::tonemap(float4{powf(2.f, m_exposure_live) * value.xyz() + m_offset_live, value.w}, m_gamma_live, m_tonemap,
-                     m_colormaps[m_colormap_index], m_reverse_colormap);
+    // The exposure/offset step the image shader applies, on the same premultiplied values: the offset is
+    // a straight-color quantity, so it enters scaled by alpha (see main() in image-shader.sglsl). Readouts
+    // built on this therefore report what the viewport shows, translucent pixels included.
+    float3 exposed = powf(2.f, m_exposure_live) * value.xyz() + m_offset_live * value.w;
+    return ::tonemap(float4{exposed, value.w}, m_gamma_live, m_tonemap, m_colormaps[m_colormap_index],
+                     m_reverse_colormap);
 }
 
 void HDRViewApp::calculate_viewport()

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -102,16 +102,18 @@ void HDRViewApp::zoom_at_vp_pos(float amount, float2 focus_vp_pos)
     reposition_pixel_to_vp_pos(focus_vp_pos, focused_pixel);
 }
 
+//! The nudge that keeps a zoom already sitting on a power of two from being rounded to the wrong side of
+//! it by float error in log2(), while being far too small to reach the neighbouring stop.
+static constexpr float k_zoom_step_epsilon = 1e-4f;
+
 void HDRViewApp::zoom_in()
 {
     // keep position at center of window fixed while zooming
     auto center_pos   = float2(viewport_size() / 2.f);
     auto center_pixel = pixel_at_vp_pos(center_pos);
 
-    // determine next higher power of 2 zoom level
-    float level_for_sensitivity = ceil(log(m_zoom) / log(2.f) + 0.5f);
-    float new_scale             = std::pow(2.f, level_for_sensitivity);
-    set_zoom(new_scale);
+    // the next power of two strictly above the current zoom, whether or not the zoom is one itself
+    set_zoom(std::pow(2.f, std::floor(std::log2(m_zoom) + k_zoom_step_epsilon) + 1.f));
     reposition_pixel_to_vp_pos(center_pos, center_pixel);
 }
 
@@ -121,10 +123,8 @@ void HDRViewApp::zoom_out()
     auto center_pos   = float2(viewport_size() / 2.f);
     auto center_pixel = pixel_at_vp_pos(center_pos);
 
-    // determine next lower power of 2 zoom level
-    float level_for_sensitivity = std::floor(log(m_zoom) / log(2.f) - 0.5f);
-    float new_scale             = std::pow(2.f, level_for_sensitivity);
-    set_zoom(new_scale);
+    // the next power of two strictly below the current zoom, whether or not the zoom is one itself
+    set_zoom(std::pow(2.f, std::ceil(std::log2(m_zoom) - k_zoom_step_epsilon) - 1.f));
     reposition_pixel_to_vp_pos(center_pos, center_pixel);
 }
 

--- a/src/app.h
+++ b/src/app.h
@@ -261,6 +261,7 @@ public:
     float      &offset() { return m_offset; }
     Tonemap_   &tonemap() { return m_tonemap; }
     Colormap_   colormap() { return m_colormaps[m_colormap_index]; }
+    bool       &reverse_colormap() { return m_reverse_colormap; }
     BlendMode_ &blend_mode() { return m_blend_mode; }
     bool       &clamp_to_LDR() { return m_clamp_to_LDR; }
     bool       &dithering_on() { return m_dither; }

--- a/src/app.h
+++ b/src/app.h
@@ -148,6 +148,17 @@ public:
     /// Reposition the image so that the specified image pixel coordinate lies under the provided viewport position
     void reposition_pixel_to_vp_pos(float2 vp_pos, float2 pixel);
 
+    /// Mirrors a pixel coordinate about the current image's display window along the flipped axes; an
+    /// involution, and the only place the flip enters the pixel <-> viewport transforms.
+    float2 flip_pixel(float2 pixel) const;
+
+    /// Where the quad the image shader samples \p img over starts, as a fraction of the viewport: the
+    /// viewport position of the image's data-window min corner. Derived from vp_pos_at_pixel(), so what is
+    /// drawn and what the overlays and pixel readouts report can never describe different places.
+    float2 image_position(ConstImagePtr img) const;
+    /// The extent of that same quad, as a fraction of the viewport. Negative along a flipped axis.
+    float2 image_scale(ConstImagePtr img) const;
+
     float  pixel_ratio() const;
     float2 viewport_size() const { return m_viewport_size; }
     bool   vp_pos_in_viewport(float2 vp_pos) const
@@ -306,9 +317,6 @@ private:
     void   calculate_viewport();
     float2 center_offset() const;
     Box2f  scaled_display_window(ConstImagePtr img) const;
-    Box2f  scaled_data_window(ConstImagePtr img) const;
-    float2 image_position(ConstImagePtr img) const;
-    float2 image_scale(ConstImagePtr img) const;
 
     void draw_background();
     void draw_statistics_window();

--- a/src/colormap.cpp
+++ b/src/colormap.cpp
@@ -420,6 +420,8 @@ const std::vector<ImU32> &Colormap::values(Colormap_ idx)
 
 ImVec4 Colormap::sample(Colormap_ idx, float t)
 {
-    float cmap_size = (float)Colormap::values(idx).size();
-    return ImPlot::SampleColormap(saturate(lerp(0.5f / cmap_size, (cmap_size - 0.5f) / cmap_size, t)), idx);
+    // t runs edge to edge: 0 is the colormap's first color and 1 its last, matching what the shader gets
+    // out of texture(). That shader has to shift t to the first and last texel *centers* to land there;
+    // ImPlot's own lookup is already parameterized over the colors themselves, so it must not.
+    return ImPlot::SampleColormap(saturate(t), idx);
 }

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -830,7 +830,13 @@ void convert_primaries(float *pixels, int3 size, const Chromaticities &src, cons
 Color3 tonemap(const Color3 color, float gamma, Tonemap_ tonemap_mode, Colormap_ colormap, bool reverse_colormap);
 inline Color4 tonemap(const Color4 color, float gamma, Tonemap_ tonemap_mode, Colormap_ colormap, bool reverse_colormap)
 {
-    return Color4(tonemap(color.xyz(), gamma, tonemap_mode, colormap, reverse_colormap), color.w);
+    Color3 rgb = tonemap(color.xyz(), gamma, tonemap_mode, colormap, reverse_colormap);
+    // A colormap lookup answers with a straight color, while everything around it is premultiplied, so the
+    // two false-color modes premultiply their result -- the gamma curve, applied to values that already
+    // are, does not. Mirrors tonemap() in assets/shaders/image-shader.sglsl.
+    if (tonemap_mode == Tonemap_FalseColor || tonemap_mode == Tonemap_PositiveNegative)
+        rgb *= color.w;
+    return Color4(rgb, color.w);
 }
 
 float2 blend(float2 top, float2 bottom, BlendMode_ blend_mode);

--- a/tests/gui/test_gui_display.cpp
+++ b/tests/gui/test_gui_display.cpp
@@ -1,0 +1,169 @@
+/** \file test_gui_display.cpp
+    \author Wojciech Jarosz
+
+    The display pipeline as the readouts reproduce it. HDRViewApp::tonemap_value() and the colormap lookup
+    under it are a CPU re-implementation of what assets/shaders/image-shader.sglsl puts on screen; the pixel
+    inspector, the pixel-value overlay and the statistics swatches are all built on them. Where the two
+    drift, HDRView reports a color it is not showing.
+
+    Both tests below transcribe the shader's own arithmetic and compare against it across a sweep, the same
+    way "colorpass GLSL PQ constants match colorspace.h's inverse_EOTF_BT2100_PQ" does in
+    tests/test_colorspace.cpp. If you edit either side, edit both.
+*/
+
+#include "app.h"
+#include "colormap.h"
+#include "test_gui_registry.h"
+
+#include "imgui_test_engine/imgui_te_context.h"
+#include "imgui_test_engine/imgui_te_engine.h"
+
+#include <cmath>
+
+namespace
+{
+
+bool approx(float a, float b, float eps = 2e-3f) { return std::fabs(a - b) < eps; }
+bool approx(float3 a, float3 b, float eps = 2e-3f) { return la::maxelem(la::abs(a - b)) < eps; }
+
+//! Colormap::initialize()'s rule for which colormaps get a filtered texture; the qualitative ones are
+//! sampled Nearest, and none of them is offered as a false-color map.
+bool is_continuous(Colormap_ cmap) { return cmap > ImPlotColormap_Paired; }
+
+/*!
+    The colormap fetch as the fragment shader performs it: tonemap()'s texel-center remap of \p t, followed
+    by a bilinear lookup into the N-texel, ClampToEdge texture Colormap::initialize() uploads. Returns the
+    stored (sRGB-encoded) color, exactly what the shader hands to sRGBToLinear().
+*/
+float3 glsl_colormap_fetch(Colormap_ cmap, float t, bool reverse)
+{
+    if (reverse)
+        t = 1.f - t;
+
+    const auto &values = Colormap::values(cmap);
+    const float n      = (float)values.size();
+    // mix(0.5 / n, (n - 0.5) / n, t), converted from a uv to a texel coordinate, is just t * (n - 1); the
+    // sampler's ClampToEdge is what bounds it once t leaves [0, 1].
+    const float coord = std::min(std::max(t * (n - 1.f), 0.f), n - 1.f);
+    const int   i0    = (int)std::floor(coord);
+    const int   i1    = std::min(i0 + 1, (int)values.size() - 1);
+
+    auto texel = [&values](int i)
+    {
+        ImVec4 c = ImGui::ColorConvertU32ToFloat4(values[i]);
+        return float3{c.x, c.y, c.z};
+    };
+    return la::lerp(texel(i0), texel(i1), coord - (float)i0);
+}
+
+//! Restores the tonemap controls the tests below drive directly, whatever the rest of the suite left set.
+struct TonemapState
+{
+    Tonemap_ tonemap  = hdrview()->tonemap();
+    float    gamma    = hdrview()->gamma_live();
+    float    exposure = hdrview()->exposure_live();
+    float    offset   = hdrview()->offset_live();
+    bool     reverse  = hdrview()->reverse_colormap();
+
+    ~TonemapState()
+    {
+        hdrview()->tonemap()          = tonemap;
+        hdrview()->gamma_live()       = gamma;
+        hdrview()->exposure_live()    = exposure;
+        hdrview()->offset_live()      = offset;
+        hdrview()->reverse_colormap() = reverse;
+    }
+};
+
+} // namespace
+
+void RegisterTests_Display(ImGuiTestEngine *engine)
+{
+    // Colormap::sample() is the readouts' half of the shader's colormap texture fetch. It has to agree with
+    // it over the whole of t, not just where the two parameterizations happen to cross.
+    ImGuiTest *t = IM_REGISTER_TEST(engine, "display", "colormap_sample_matches_the_shaders_texture_fetch");
+    t->TestFunc  = [](ImGuiTestContext *)
+    {
+        for (Colormap_ cmap = 0; cmap < Colormap_COUNT; ++cmap)
+        {
+            const auto &values = Colormap::values(cmap);
+            IM_CHECK(!values.empty());
+
+            // Both ends, for every colormap: t 0 is its first color and t 1 its last. This much holds
+            // whether the texture is filtered or not, so the qualitative maps are included.
+            const ImVec4 first = ImGui::ColorConvertU32ToFloat4(values.front());
+            const ImVec4 last  = ImGui::ColorConvertU32ToFloat4(values.back());
+            const ImVec4 lo    = Colormap::sample(cmap, 0.f);
+            const ImVec4 hi    = Colormap::sample(cmap, 1.f);
+            IM_CHECK(approx(float3{lo.x, lo.y, lo.z}, float3{first.x, first.y, first.z}, 1.f / 255.f));
+            IM_CHECK(approx(float3{hi.x, hi.y, hi.z}, float3{last.x, last.y, last.z}, 1.f / 255.f));
+
+            if (!is_continuous(cmap))
+                continue;
+
+            // And the interior, against the filtered fetch itself. ImPlot's table quantizes each step
+            // between two colors into 255 of its own, so allow a couple of those.
+            for (float x : {0.f, 0.01f, 0.1f, 0.25f, 1.f / 3.f, 0.5f, 0.625f, 0.75f, 0.9f, 0.99f, 1.f})
+            {
+                const ImVec4 got = Colormap::sample(cmap, x);
+                IM_CHECK(approx(float3{got.x, got.y, got.z}, glsl_colormap_fetch(cmap, x, false), 3.f / 255.f));
+            }
+
+            // Out of range clamps rather than wrapping or extrapolating, as ClampToEdge does.
+            const ImVec4 under = Colormap::sample(cmap, -0.5f);
+            const ImVec4 over  = Colormap::sample(cmap, 1.5f);
+            IM_CHECK(approx(float3{under.x, under.y, under.z}, float3{first.x, first.y, first.z}, 1.f / 255.f));
+            IM_CHECK(approx(float3{over.x, over.y, over.z}, float3{last.x, last.y, last.z}, 1.f / 255.f));
+        }
+    };
+
+    // tonemap_value() is the readouts' half of the shader's exposure/offset step and tonemap(). Swept over
+    // both, every tonemap mode, and the translucent pixels where the premultiplied convention is the only
+    // thing that distinguishes a right answer from a plausible one.
+    t           = IM_REGISTER_TEST(engine, "display", "tonemap_value_matches_the_shader");
+    t->TestFunc = [](ImGuiTestContext *)
+    {
+        TonemapState restore;
+
+        // Transcribed from main() and tonemap() in assets/shaders/image-shader.sglsl.
+        auto glsl_tonemap =
+            [](float4 value, float exposure, float offset, float gamma, Tonemap_ mode, Colormap_ cmap, bool reverse)
+        {
+            const float3 rgb = std::pow(2.f, exposure) * value.xyz() + offset * value.w;
+            if (mode == Tonemap_Gamma)
+            {
+                auto sign_pow = [](float a, float p) {
+                    return (a > 0.f ? 1.f : a < 0.f ? -1.f : 0.f) * std::pow(std::fabs(a), p);
+                };
+                return float4{la::apply(sign_pow, rgb, float3{1.f / gamma}), value.w};
+            }
+
+            const float avg = la::dot(rgb, float3{1.f / 3.f});
+            const float t   = (mode == Tonemap_FalseColor) ? avg : 0.5f * avg + 0.5f;
+            return float4{sRGB_to_linear(glsl_colormap_fetch(cmap, t, reverse)) * value.w, value.w};
+        };
+
+        const float4 samples[] = {{0.4f, 0.4f, 0.4f, 1.f},   {0.4f, 0.4f, 0.4f, 0.5f}, {0.f, 0.f, 0.f, 0.f},
+                                  {0.9f, 0.2f, 0.05f, 0.7f}, {1.5f, 0.3f, 2.75f, 1.f}, {-0.2f, 0.6f, -0.05f, 0.25f}};
+
+        for (Tonemap_ mode : {Tonemap_Gamma, Tonemap_FalseColor, Tonemap_PositiveNegative})
+            for (bool reverse : {false, true})
+                for (float exposure : {-2.f, 0.f, 1.f})
+                    for (float offset : {0.f, 0.25f, -0.3f})
+                        for (float gamma : {1.f, 2.2f})
+                            for (const float4 &value : samples)
+                            {
+                                hdrview()->tonemap()          = mode;
+                                hdrview()->exposure_live()    = exposure;
+                                hdrview()->offset_live()      = offset;
+                                hdrview()->gamma_live()       = gamma;
+                                hdrview()->reverse_colormap() = reverse;
+
+                                const float4 got = hdrview()->tonemap_value(value);
+                                const float4 want =
+                                    glsl_tonemap(value, exposure, offset, gamma, mode, hdrview()->colormap(), reverse);
+                                IM_CHECK(approx(got.xyz(), want.xyz(), 3.f / 255.f));
+                                IM_CHECK(approx(got.w, want.w));
+                            }
+    };
+}

--- a/tests/gui/test_gui_registry.h
+++ b/tests/gui/test_gui_registry.h
@@ -11,6 +11,7 @@ void RegisterTests_Dialogs(ImGuiTestEngine *engine);
 void RegisterTests_ImageIO(ImGuiTestEngine *engine);
 void RegisterTests_View(ImGuiTestEngine *engine);
 void RegisterTests_Viewport(ImGuiTestEngine *engine);
+void RegisterTests_Display(ImGuiTestEngine *engine);
 void RegisterTests_Tools(ImGuiTestEngine *engine);
 void RegisterTests_Stats(ImGuiTestEngine *engine);
 void RegisterTests_Filtering(ImGuiTestEngine *engine);
@@ -27,6 +28,7 @@ inline void RegisterAllGuiTests(ImGuiTestEngine *engine)
     RegisterTests_ImageIO(engine);
     RegisterTests_View(engine);
     RegisterTests_Viewport(engine);
+    RegisterTests_Display(engine);
     RegisterTests_Tools(engine);
     RegisterTests_Stats(engine);
     RegisterTests_Filtering(engine);

--- a/tests/gui/test_gui_registry.h
+++ b/tests/gui/test_gui_registry.h
@@ -10,6 +10,7 @@ void RegisterTests_Smoke(ImGuiTestEngine *engine);
 void RegisterTests_Dialogs(ImGuiTestEngine *engine);
 void RegisterTests_ImageIO(ImGuiTestEngine *engine);
 void RegisterTests_View(ImGuiTestEngine *engine);
+void RegisterTests_Viewport(ImGuiTestEngine *engine);
 void RegisterTests_Tools(ImGuiTestEngine *engine);
 void RegisterTests_Stats(ImGuiTestEngine *engine);
 void RegisterTests_Filtering(ImGuiTestEngine *engine);
@@ -25,6 +26,7 @@ inline void RegisterAllGuiTests(ImGuiTestEngine *engine)
     RegisterTests_Dialogs(engine);
     RegisterTests_ImageIO(engine);
     RegisterTests_View(engine);
+    RegisterTests_Viewport(engine);
     RegisterTests_Tools(engine);
     RegisterTests_Stats(engine);
     RegisterTests_Filtering(engine);

--- a/tests/gui/test_gui_view.cpp
+++ b/tests/gui/test_gui_view.cpp
@@ -8,6 +8,8 @@
 #include "image.h"
 #include "test_gui_registry.h"
 
+#include <cmath>
+
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
@@ -27,7 +29,10 @@ static void ensure_image_loaded(ImGuiTestContext *ctx)
 
 void RegisterTests_View(ImGuiTestEngine *engine)
 {
-    ImGuiTest *t = IM_REGISTER_TEST(engine, "view", "zoom_round_trip");
+    // "Zoom in"/"Zoom out" step between adjacent powers of two, and back. Both directions are checked from
+    // fractional zooms as well as exact ones: fitting to the window and the scroll wheel both leave the zoom
+    // between two stops, and from there neither direction may skip the stop it is standing next to.
+    ImGuiTest *t = IM_REGISTER_TEST(engine, "view", "zoom_steps_between_powers_of_two");
     t->TestFunc  = [](ImGuiTestContext *ctx)
     {
         ensure_image_loaded(ctx);
@@ -35,16 +40,40 @@ void RegisterTests_View(ImGuiTestEngine *engine)
 
         ctx->MenuClick("View/100%");
         IM_CHECK_EQ(hdrview()->zoom_level(), 0.f);
+        const float one_to_one = hdrview()->zoom();
 
+        // The menu round trip, driven the way a user drives it.
         ctx->MenuClick("View/Zoom in");
-        IM_CHECK(hdrview()->zoom_level() > 0.f);
-        float zoomed_in = hdrview()->zoom_level();
-
+        IM_CHECK_EQ(hdrview()->zoom(), 2.f * one_to_one);
         ctx->MenuClick("View/Zoom out");
-        IM_CHECK(hdrview()->zoom_level() < zoomed_in);
-
+        IM_CHECK_EQ(hdrview()->zoom(), one_to_one);
+        ctx->MenuClick("View/Zoom out");
+        IM_CHECK_EQ(hdrview()->zoom(), 0.5f * one_to_one);
         ctx->MenuClick("View/100%");
         IM_CHECK_EQ(hdrview()->zoom_level(), 0.f);
+
+        // Every start, exact or not, lands on the stop next to it -- and one step back returns to the
+        // interval it came from.
+        for (float from : {0.25f, 0.5f, 1.f, 2.f, 4.f, 0.75f, 1.5f, 2.3f, 3.f, 6.9f})
+        {
+            IM_CHECK_SILENT(from >= HDRViewApp::MIN_ZOOM && from <= HDRViewApp::MAX_ZOOM);
+            const float above = std::exp2(std::floor(std::log2(from)) + 1.f);
+            const float below = std::exp2(std::ceil(std::log2(from)) - 1.f);
+
+            hdrview()->set_zoom(from);
+            hdrview()->zoom_in();
+            IM_CHECK_EQ(hdrview()->zoom(), above);
+            hdrview()->zoom_out();
+            IM_CHECK_EQ(hdrview()->zoom(), 0.5f * above);
+
+            hdrview()->set_zoom(from);
+            hdrview()->zoom_out();
+            IM_CHECK_EQ(hdrview()->zoom(), below);
+            hdrview()->zoom_in();
+            IM_CHECK_EQ(hdrview()->zoom(), 2.f * below);
+        }
+
+        ctx->MenuClick("View/100%");
     };
 
     // Flipping mirrors the image inside the rectangle it already occupies, so the two menu items toggle

--- a/tests/gui/test_gui_view.cpp
+++ b/tests/gui/test_gui_view.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "app.h"
+#include "image.h"
 #include "test_gui_registry.h"
 
 #include "imgui_test_engine/imgui_te_context.h"
@@ -46,6 +47,9 @@ void RegisterTests_View(ImGuiTestEngine *engine)
         IM_CHECK_EQ(hdrview()->zoom_level(), 0.f);
     };
 
+    // Flipping mirrors the image inside the rectangle it already occupies, so the two menu items toggle
+    // their state without the image moving or resizing on screen. The transforms behind that rectangle are
+    // exercised in their own right by the "viewport" tests.
     t           = IM_REGISTER_TEST(engine, "view", "flip_toggle");
     t->TestFunc = [](ImGuiTestContext *ctx)
     {
@@ -53,11 +57,23 @@ void RegisterTests_View(ImGuiTestEngine *engine)
         bool orig_h = *hdrview()->action("Flip horizontally").p_selected;
         bool orig_v = *hdrview()->action("Flip vertically").p_selected;
 
+        const Box2i dw        = hdrview()->current_image()->display_window;
+        auto        on_screen = [&dw] {
+            return Box2f{hdrview()->vp_pos_at_pixel(float2{dw.min}), hdrview()->vp_pos_at_pixel(float2{dw.max})}
+                .make_valid();
+        };
+        const Box2f before = on_screen();
+
         ctx->SetRef("##MainMenuBar");
         ctx->MenuClick("View/Flip horizontally");
         IM_CHECK_EQ(*hdrview()->action("Flip horizontally").p_selected, !orig_h);
+        IM_CHECK(la::maxelem(la::abs(on_screen().min - before.min)) < 1e-2f);
+        IM_CHECK(la::maxelem(la::abs(on_screen().max - before.max)) < 1e-2f);
+
         ctx->MenuClick("View/Flip vertically");
         IM_CHECK_EQ(*hdrview()->action("Flip vertically").p_selected, !orig_v);
+        IM_CHECK(la::maxelem(la::abs(on_screen().min - before.min)) < 1e-2f);
+        IM_CHECK(la::maxelem(la::abs(on_screen().max - before.max)) < 1e-2f);
 
         // restore
         ctx->MenuClick("View/Flip horizontally");

--- a/tests/gui/test_gui_viewport.cpp
+++ b/tests/gui/test_gui_viewport.cpp
@@ -1,0 +1,217 @@
+/** \file test_gui_viewport.cpp
+    \author Wojciech Jarosz
+
+    The viewport transforms: pixel <-> viewport <-> app position, and their agreement with the quad the
+    image shader is actually asked to draw. Everything the app says about where a pixel is -- the mouse
+    readout, the pixel-value overlay, the window borders, the watched-pixel crosshairs -- is one of these
+    functions, so they and the shader have to describe the same place.
+*/
+
+#include "app.h"
+#include "image.h"
+#include "test_gui_registry.h"
+
+#include "imgui_test_engine/imgui_te_context.h"
+#include "imgui_test_engine/imgui_te_engine.h"
+
+#include <cmath>
+
+#ifndef HDRVIEW_GUI_TEST_IMAGE
+#error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
+#endif
+#ifndef HDRVIEW_GUI_TEST_IMAGE_2
+#error "HDRVIEW_GUI_TEST_IMAGE_2 must be defined by CMake to a second fixture image path"
+#endif
+
+namespace
+{
+
+//! Loads `paths` and waits for all of them to arrive.
+void load_and_wait(ImGuiTestContext *ctx, const std::vector<std::string> &paths)
+{
+    hdrview()->close_all_images();
+    for (int frame = 0; frame < 60 && hdrview()->num_images() != 0; ++frame) ctx->Yield();
+    hdrview()->load_images(paths);
+    for (int frame = 0; frame < 240 && hdrview()->num_images() < (int)paths.size(); ++frame) ctx->Yield();
+    IM_CHECK_EQ(hdrview()->num_images(), (int)paths.size());
+}
+
+bool approx(float2 a, float2 b, float eps = 1e-2f) { return la::maxelem(la::abs(a - b)) < eps; }
+
+/*!
+    Gives an image the display window an OpenEXR file can carry -- offset from the origin and a different
+    size from the data window -- for as long as it is in scope.
+
+    The fixtures are PNGs, whose two windows always coincide at the origin, which hides every place the two
+    are confused for one another. Restored on destruction, and nothing between here and there yields, so no
+    frame is ever drawn against the substitute.
+*/
+struct ScopedDisplayWindow
+{
+    ImagePtr img;
+    Box2i    saved;
+
+    ScopedDisplayWindow(ImagePtr i, const Box2i &substitute) : img(i), saved(i->display_window)
+    {
+        img->display_window = substitute;
+    }
+    ~ScopedDisplayWindow() { img->display_window = saved; }
+};
+
+//! Every combination of the two flip axes, so no test below checks only the unflipped case.
+struct FlipState
+{
+    bool &h       = *hdrview()->action("Flip horizontally").p_selected;
+    bool &v       = *hdrview()->action("Flip vertically").p_selected;
+    bool  saved_h = h, saved_v = v;
+
+    void set(int f)
+    {
+        h = (f & 1) != 0;
+        v = (f & 2) != 0;
+    }
+    ~FlipState()
+    {
+        h = saved_h;
+        v = saved_v;
+    }
+};
+
+} // namespace
+
+void RegisterTests_Viewport(ImGuiTestEngine *engine)
+{
+    /*
+        The pixel <-> viewport map is an invertible affine one: a pixel step is exactly `zoom` viewport
+        units, positive or negative with the flip, and converting either way and back returns what went in.
+        Swept over zoom, pan and both flip axes, with a display window that neither starts at the origin nor
+        matches the data window, since that is what an EXR carries and what the flip mirrors about.
+    */
+    ImGuiTest *t = IM_REGISTER_TEST(engine, "viewport", "pixel_transform_is_affine_and_invertible");
+    t->TestFunc  = [](ImGuiTestContext *ctx)
+    {
+        load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE});
+
+        auto      img = hdrview()->current_image();
+        FlipState flip;
+
+        for (const Box2i &display_window : {img->display_window, Box2i{{-13, 7}, {img->data_window.max + int2{5, -3}}}})
+        {
+            ScopedDisplayWindow scoped{img, display_window};
+            for (int f = 0; f < 4; ++f)
+            {
+                flip.set(f);
+                for (float zoom : {0.125f, 1.f, 3.f, 64.f})
+                    for (float2 pan : {float2{0.f, 0.f}, float2{37.f, -19.f}})
+                    {
+                        hdrview()->set_zoom(zoom);
+                        hdrview()->center();
+                        hdrview()->reposition_pixel_to_vp_pos(pan, float2{0.f, 0.f});
+
+                        for (float2 pixel : {float2{0.f, 0.f}, float2{0.5f, 0.5f}, float2{-4.25f, 11.75f},
+                                             float2{img->data_window.max}, float2{display_window.min}})
+                        {
+                            // Round trip, in both directions.
+                            IM_CHECK(approx(hdrview()->pixel_at_vp_pos(hdrview()->vp_pos_at_pixel(pixel)), pixel));
+                            IM_CHECK(approx(hdrview()->vp_pos_at_pixel(hdrview()->pixel_at_vp_pos(pixel)), pixel));
+
+                            // One pixel across is exactly `zoom` across, mirrored along the flipped axes.
+                            const float2 step =
+                                hdrview()->vp_pos_at_pixel(pixel + 1.f) - hdrview()->vp_pos_at_pixel(pixel);
+                            IM_CHECK(approx(step, zoom * la::select(bool2{flip.h, flip.v}, float2{-1.f}, float2{1.f}),
+                                            1e-2f * zoom));
+
+                            // And repositioning puts the pixel where it was asked to go.
+                            hdrview()->reposition_pixel_to_vp_pos(float2{31.f, 17.f}, pixel);
+                            IM_CHECK(approx(hdrview()->vp_pos_at_pixel(pixel), float2{31.f, 17.f}));
+                        }
+                    }
+            }
+        }
+    };
+
+    /*
+        Where the image actually lands on screen, against the specification written out below rather than
+        against any other part of the transform.
+
+        This has to be absolute. image_position()/image_scale() are derived from vp_pos_at_pixel(), so the
+        two agree by construction and comparing them cannot detect a change in the transform they share;
+        likewise, asking vp_pos_at_pixel() where the image is and then asking it which pixel is there just
+        has it grade itself. What is *not* free is the placement: the current image's display window is
+        centered in the viewport, and a flipped axis mirrors within it -- and the reference image is placed
+        by that same mapping, so the two stay overlaid whatever their own windows are.
+    */
+    ImGuiTest *t2 = IM_REGISTER_TEST(engine, "viewport", "images_land_where_the_viewport_specifies");
+    t2->TestFunc  = [](ImGuiTestContext *ctx)
+    {
+        // Two images of different sizes, so a reference whose windows differ from the current image's is
+        // exercised rather than the coincidence of them matching.
+        load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
+        hdrview()->set_current_image_index(0);
+        hdrview()->set_reference_image_index(1);
+        auto img = hdrview()->current_image();
+        auto ref = hdrview()->reference_image();
+        IM_CHECK(img && ref);
+        IM_CHECK(img->display_window != ref->display_window);
+
+        FlipState flip;
+
+        // A display window that neither starts at the origin nor matches the data window, since that is
+        // what an OpenEXR file carries and what a flip mirrors about; the fixtures are PNGs, whose two
+        // windows always coincide at the origin and so hide any confusion between them.
+        for (const Box2i &display_window : {img->display_window, Box2i{{-9, 4}, {700, 990}}})
+        {
+            ScopedDisplayWindow scoped{img, display_window};
+            for (int f = 0; f < 4; ++f)
+            {
+                flip.set(f);
+                for (float zoom : {0.3f, 1.f, 2.f, 8.f})
+                {
+                    hdrview()->set_zoom(zoom);
+                    hdrview()->center();
+
+                    // The specification, independent of everything under test.
+                    const float2 span            = zoom * float2{display_window.size()};
+                    const float2 origin          = (hdrview()->viewport_size() - span) / 2.f;
+                    auto         expected_vp_pos = [&](float2 pixel)
+                    {
+                        const float2 within = zoom * (pixel - float2{display_window.min});
+                        return origin + la::select(bool2{flip.h, flip.v}, span - within, within);
+                    };
+
+                    for (float2 pixel : {float2{display_window.min}, float2{display_window.max}, float2{0.f, 0.f},
+                                         float2{-6.5f, 123.25f}})
+                        IM_CHECK(approx(hdrview()->vp_pos_at_pixel(pixel), expected_vp_pos(pixel), 1e-2f * zoom));
+
+                    // The quad the shader samples each image over: uv 0 at its data window's min corner,
+                    // uv 1 at the max one, both placed by that same mapping. The reference included -- it
+                    // is mirrored about the *current* image's display window, not its own.
+                    for (ConstImagePtr which : {ConstImagePtr{img}, ConstImagePtr{ref}})
+                    {
+                        const float2 vp    = hdrview()->viewport_size();
+                        const float2 pos   = hdrview()->image_position(which) * vp;
+                        const float2 scale = hdrview()->image_scale(which) * vp;
+                        IM_CHECK(approx(pos, expected_vp_pos(float2{which->data_window.min}), 1e-2f * zoom));
+                        IM_CHECK(approx(pos + scale, expected_vp_pos(float2{which->data_window.max}), 1e-2f * zoom));
+                    }
+
+                    // The same thing in the terms a user would check it in: the pixel reported half a pixel
+                    // inside the leading corner of the drawn image. Flipped horizontally, the leftmost
+                    // column on screen is the image's rightmost, not its neighbour.
+                    const Box2i  dw = img->data_window;
+                    const Box2f  drawn{expected_vp_pos(float2{dw.min}), expected_vp_pos(float2{dw.max})};
+                    const Box2f  rect = Box2f{drawn}.make_valid();
+                    const float2 half{0.5f * zoom};
+                    const int2   near_pixel = int2{hdrview()->pixel_at_vp_pos(rect.min + half)};
+                    const int2   far_pixel  = int2{hdrview()->pixel_at_vp_pos(rect.max - half)};
+                    IM_CHECK_EQ(near_pixel.x, flip.h ? dw.max.x - 1 : dw.min.x);
+                    IM_CHECK_EQ(near_pixel.y, flip.v ? dw.max.y - 1 : dw.min.y);
+                    IM_CHECK_EQ(far_pixel.x, flip.h ? dw.min.x : dw.max.x - 1);
+                    IM_CHECK_EQ(far_pixel.y, flip.v ? dw.min.y : dw.max.y - 1);
+                }
+            }
+        }
+
+        hdrview()->set_reference_image_index(-1, true);
+    };
+}

--- a/tests/test_colorspace.cpp
+++ b/tests/test_colorspace.cpp
@@ -169,6 +169,47 @@ TEST_CASE("color_conversion_matrix generalizes to the colorpass's other reachabl
                                         gamut_chromaticities(ColorGamut_sRGB_BT709)));
 }
 
+TEST_CASE("the image shader isolates luminance in the primaries it has already converted to")
+{
+    // assets/shaders/image-shader.sglsl converts every image into sRGB/BT.709 primaries before
+    // choose_channel() runs, so the Channels_Y case weighs with sRGB's own luminance weights -- spelled out
+    // in colorspaces.sglsl as sRGB_Yw, since GLSL can't include colorspace.h. If you edit either side, edit
+    // both.
+    // The shader spells them as the middle row of its own RGB2XYZ, the classic rounded sRGB matrix, while
+    // colorspace.h derives them from the BT.709 chromaticities; the two agree to about 3e-5 per weight,
+    // which is well under a code value at any bit depth HDRView displays.
+    const float3 glsl_sRGB_Yw{0.212671f, 0.715160f, 0.072169f};
+    INFO("colorspace.h says ", sRGB_Yw().x, ", ", sRGB_Yw().y, ", ", sRGB_Yw().z);
+    CHECK(approx_equal(sRGB_Yw(), glsl_sRGB_Yw, 1e-4f));
+    CHECK(glsl_sRGB_Yw.x + glsl_sRGB_Yw.y + glsl_sRGB_Yw.z == doctest::Approx(1.f).epsilon(1e-5));
+
+    // What makes those the right weights for a value that arrived in some other gamut: luminance is a
+    // property of the color, not of the primaries it is written in, so converting into sRGB and weighing
+    // with sRGB's weights recovers the luminance the source gamut's own weights describe. Restricted to
+    // gamuts that share sRGB's D65 white, since a chromatic adaptation is free to move Y.
+    for (ColorGamut_ gamut : {ColorGamut_Display_P3_SMPTE432, ColorGamut_BT2020_2100, ColorGamut_AdobeRGB})
+    {
+        const Chromaticities chr = gamut_chromaticities(gamut);
+        INFO("gamut = ", color_gamut_name(gamut));
+        REQUIRE(approx_equal(chr.white, Chromaticities{}.white, 1e-4f));
+
+        float3x3 M;
+        color_conversion_matrix(M, chr, Chromaticities{});
+
+        const float3 native_Yw = computeYw(chr);
+        for (const float3 &rgb :
+             {float3{1, 1, 1}, float3{1, 0, 0}, float3{0, 1, 0}, float3{0, 0, 1}, float3{0.2f, 0.7f, 0.4f}})
+        {
+            INFO("rgb = ", rgb);
+            CHECK(dot(mul(M, rgb), sRGB_Yw()) == doctest::Approx(dot(rgb, native_Yw)).epsilon(1e-4));
+        }
+
+        // And that the weights actually differ, so the check above is not passing on a coincidence: this
+        // is the whole reason using the source gamut's weights after the conversion is wrong.
+        CHECK_FALSE(approx_equal(native_Yw, sRGB_Yw(), 1e-3f));
+    }
+}
+
 TEST_CASE("colorpass GLSL PQ constants match colorspace.h's inverse_EOTF_BT2100_PQ")
 {
     // assets/shaders/colorspaces.sglsl's pq_encode() hand-duplicates the five ST.2084 constants as decimal


### PR DESCRIPTION
The display path: everything between a decoded pixel and what you see or read out. Distinct from the loader and memory-safety territory of hunts 1–3, and from hunt 4's write round-tripping. Every fix has a test that fails without it, verified by reverting each one individually.

## Flipping shifted everything the app knows about the image by one pixel

`pixel_at_vp_pos()`/`vp_pos_at_pixel()` mirrored a pixel coordinate as `display_window.max - p - 1`. Those coordinates are continuous, with pixel `i` covering `[i, i+1)`, so the mirror of `[0, max)` is `max - p` — the `-1` is the discrete form, and it is also the convention the quad handed to the image shader uses.

Everything the app says about where a pixel is therefore pointed one pixel away from what was drawn: the mouse readout, the pixel-value overlay, the watched-pixel crosshairs, and the data window, display window and selection rectangles. One pixel times the zoom on screen — invisible at 1:1, eight logical pixels at 8×.

`center_offset()` settles which side is right: it is written so the display window stays centered under a flip, and only `max - p` comes out centered.

## A reference image of a different size stopped overlaying when flipped

`image_position()` mirrored each image about *its own* display window rather than the current image's — the one `center_offset()` and the pixel transforms use. A reference whose display window differed landed offset by the difference between the two, so every comparison blend mode compared the wrong pixels as soon as either axis was flipped.

`image_position()`/`image_scale()` now derive both ends of the quad from `vp_pos_at_pixel()` instead of rebuilding the mapping, so what is drawn and what the overlays and readouts report cannot describe different places again. That leaves `flip_pixel()` as the single site the flip enters.

## Zoom in/out skipped a stop

`ceil(log2(zoom) + 0.5)` and `floor(log2(zoom) - 0.5)` round to the *nearest* power of two and then step from there. From a zoom that is already one that is correct, but from anywhere in between it skips the stop it is standing next to: 3× zoomed in went to 8× rather than 4×, and 2.3× zoomed out went to 1× rather than 2×. Fitting to the window and the scroll wheel both leave the zoom between stops, so this was the ordinary case, not the corner one.

## Three ways the pixel readouts re-implemented the shader inexactly

All on one path — `pixel_value()` feeds `tonemap_value()`, which the pixel inspector, the pixel-value overlay and the statistics swatches all print — so each made HDRView name a color it was not showing.

- **`Colormap::sample()` applied two parameterizations at once.** The shader shifts `t` to the first and last texel centers because it reads the colormap as an N-texel texture; ImPlot's own lookup is parameterized over the colors themselves and needs `t` as it is. Doing both compresses the range by half a color at each end. Invisible on a 256-color map, but the false-color maps on offer are built from 11 keys, where it is 5% of the map — and on Greys, built from 2, `t = 0` reported a quarter-gray where the screen was white.
- **The offset was added unscaled** where the shader adds `offset * alpha`. Everything the app holds is premultiplied and the offset is a straight-color quantity, so alpha is what carries it into the same convention.
- **The two false-color modes returned a straight color** where the shader premultiplies what the colormap hands back, for the same reason. The gamma curve, applied to values that already are premultiplied, correctly does not.

The last two diverge only on translucent pixels, which is exactly where a readout is worth checking against the screen.

## Isolating the Y channel used the wrong luminance weights

`choose_channel()`'s `Channels_Y` case weighed with the source gamut's weights, but it runs after `M_to_sRGB` has already moved the value into sRGB/BT.709 primaries. Those weights belong to the YC decode a few lines earlier, the one step that still sees the file's own primaries. Wrong for every image carrying chromaticities of its own — Rec.2020, Display-P3 or Adobe RGB, from EXR, HEIF, AVIF or an ICC profile — by around 5% on a saturated Rec.2020 green.

Luminance is a property of the color rather than of the primaries it is written in, so this is not a matter of preferring one set of weights: for gamuts sharing sRGB's white point the two agree exactly, which the new test checks against `color_conversion_matrix()`.

## Tests

Two new GUI files (`test_gui_viewport.cpp`, `test_gui_display.cpp`) and one doctest, plus two existing tests generalized rather than duplicated: `view/zoom_round_trip` only asserted that zooming in raised the zoom and out lowered it, and `view/flip_toggle` only that the menu flipped two booleans.

- `viewport/images_land_where_the_viewport_specifies` states the placement **absolutely** — display window centered in the viewport, a flipped axis mirroring within it — rather than comparing two parts of the transform against each other, which after this refactor they satisfy by construction. It sweeps both flip axes, four zooms, and a display window offset from the origin and differing from the data window, since the PNG fixtures' windows always coincide at the origin and hide any confusion between them.
- The display tests transcribe the shader's own arithmetic and compare against it across a sweep, the way `colorpass GLSL PQ constants match colorspace.h's inverse_EOTF_BT2100_PQ` already does: the colormap fetch over every colormap and eleven values of `t` including out-of-range ones, and `tonemap_value()` over every tonemap mode, both colormap directions, and a range of exposures, offsets, gammas and alphas.

`ctest` 143/143; GUI suite 36 → 40 tests. The shader change was checked to cross-compile to Metal, GLES3 and HLSL5 with `sokol-shdc` directly, since only `glsl410` is generated on this preset.

## Not fixed

The colorpass has no HLG encoder, so an HLG display falls through to the linear fallback while `supports_hdr()` counts HLG as HDR. Doing it properly needs the inverse OOTF, and I have no HLG display to validate against — flagging it rather than shipping an unverifiable guess.
