### PR TITLE
Use American spelling throughout the source

### DIFF
--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -105,7 +105,7 @@ void HDRViewApp::draw_tool_palette()
     // ImGui renders the title bar inside Begin() and sizes its collapse arrow from the current font, which
     // has no style var of its own, so shrink the font to shrink the arrow. Padding makes up the difference,
     // keeping the bar a standard frame tall and - since ImGui insets the arrow by that same padding - the
-    // arrow centred within it.
+    // arrow centered within it.
     const float bar_height = ImGui::GetFrameHeight();
     ImGui::PushFont(nullptr, 0.75f * ImGui::GetStyle().FontSizeBase);
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding,

--- a/src/colormap.cpp
+++ b/src/colormap.cpp
@@ -387,7 +387,7 @@ void Colormap::initialize()
 
     cmap           = Colormap_AbsGreys;
     s_values[cmap] = {IM_COL32(255, 255, 255, 255), IM_COL32(0, 0, 0, 255), IM_COL32(255, 255, 255, 255)};
-    ImPlot::AddColormap("Abs Grey", (const ImU32 *)s_values[cmap].data(), (int)s_values[cmap].size(), false);
+    ImPlot::AddColormap("Abs Gray", (const ImU32 *)s_values[cmap].data(), (int)s_values[cmap].size(), false);
 
     for (cmap = 0; cmap < Colormap_COUNT; ++cmap)
     {

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -588,7 +588,7 @@ TransferFunction transfer_function_from_CICP(int tc)
     case 2: return TransferFunction::Unspecified;
     case 1: [[fallthrough]];
     case 6: [[fallthrough]];
-    // 12 is BT.1361 extended colour gamut, which shares this curve for 1.33 > L >= -0.0045 and departs from it
+    // 12 is BT.1361 extended color gamut, which shares this curve for 1.33 > L >= -0.0045 and departs from it
     // only for more negative values. Mapping it to ITU is therefore exact except deep into negative linear.
     case 12: [[fallthrough]];
     case 14: [[fallthrough]];

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -322,7 +322,7 @@ static void draw_display_range_extents(const Box1d &sdr_x, double ceiling_x, boo
     const float near_tol = 0.02f * (x_hi - x_lo);
 
     // A leg stops short of the boundary it marks, and short of the axis line it turns towards. The first
-    // keeps neighbouring brackets apart where they meet -- one band's upper boundary is the next one's
+    // keeps neighboring brackets apart where they meet -- one band's upper boundary is the next one's
     // lower -- so the two read as separate spans rather than one fused rail. The second keeps the bracket
     // sitting above the plot instead of welded to its edge.
     const float leg_inset = 2.f;
@@ -782,7 +782,7 @@ void Image::draw_histogram()
         {
             ceiling_x = display_to_plot(headroom);
             draw_display_ceiling_line(ceiling_x, hdr_dimmed);
-            // Grey rather than white: this is the display telling us where it stops, not a control the
+            // Gray rather than white: this is the display telling us where it stops, not a control the
             // user set, and it should not read as a third handle alongside the black and white points.
             ImPlot::TagX(ceiling_x, ImVec4(0.6f, 0.6f, 0.6f, hdr_dimmed ? unreachable_alpha : 1.f), "%.3gx", headroom);
         }

--- a/src/imageio/gainmap.cpp
+++ b/src/imageio/gainmap.cpp
@@ -184,14 +184,14 @@ void append_base_rendition(Image &image, int num_base)
 
     const int2 size = image.channels.front().size();
 
-    // The colour channels only. Alpha is not part of the rendition the gain map converts, and
+    // The color channels only. Alpha is not part of the rendition the gain map converts, and
     // duplicating it would just cost memory.
-    std::vector<int> colour;
+    std::vector<int> color;
     for (int c = 0; c < num_base && c < (int)image.channels.size(); ++c)
         if (image.channels[c].name != "A")
-            colour.push_back(c);
+            color.push_back(c);
 
-    if (colour.empty())
+    if (color.empty())
         return;
 
     // "base", not "sdr": which rendition is stored is the file's choice, and a base-HDR JPEG XL
@@ -200,14 +200,14 @@ void append_base_rendition(Image &image, int num_base)
     static const char *rgb[]  = {"base.R", "base.G", "base.B"};
 
     const int first = (int)image.channels.size();
-    for (size_t c = 0; c < colour.size(); ++c) image.channels.emplace_back(colour.size() < 3 ? mono[c] : rgb[c], size);
+    for (size_t c = 0; c < color.size(); ++c) image.channels.emplace_back(color.size() < 3 ? mono[c] : rgb[c], size);
 
     parallel_for(blocked_range<int>(0, size.y, 128),
                  [&, first](int begin_y, int end_y, int, int)
                  {
-                     for (size_t c = 0; c < colour.size(); ++c)
+                     for (size_t c = 0; c < color.size(); ++c)
                      {
-                         const auto &from = image.channels[colour[c]];
+                         const auto &from = image.channels[color[c]];
                          auto       &to   = image.channels[first + (int)c];
                          for (int y = begin_y; y < end_y; ++y)
                              for (int x = 0; x < size.x; ++x) to(x, y) = from(x, y);

--- a/src/imageio/gainmap.h
+++ b/src/imageio/gainmap.h
@@ -84,7 +84,7 @@ GainmapImage resample_gainmap(const GainmapImage &gainmap, int2 size, bool linea
 //! Append \p gainmap to \p image as a `gainmap.*` channel group. It must already be \p image's size.
 void append_gainmap_channels(Image &image, const GainmapImage &gainmap);
 
-//! Copy \p image's colour channels into a `base.*` group, before a gain map is applied to them.
+//! Copy \p image's color channels into a `base.*` group, before a gain map is applied to them.
 /*!
     Called "base" rather than "sdr" because which rendition a file stores is the file's choice: a
     base-HDR JPEG XL keeps its HDR rendition here and derives an SDR one from the map. Alpha is not

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -926,7 +926,7 @@ void draw_load_image_options_dialog(bool &open)
             ImGui::Tooltip("A gain-mapped file holds a base rendition plus a map, and the image above is the two "
                            "combined. With this on, both are kept as their own \"base\" and \"gainmap\" channel "
                            "groups, so everything in the file is loaded rather than only the result.\n\nCosts "
-                           "roughly 75% more memory for a colour image with a single-channel map.");
+                           "roughly 75% more memory for a color image with a single-channel map.");
         }
 
         ImGui::Spacing();

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -823,7 +823,7 @@ struct TransferSignalling
     bool   srgb_chunk     = false; ///< the sRGB chunk describes it, if the primaries are sRGB's too
 };
 
-TransferSignalling transfer_signalling(TransferFunction tf)
+TransferSignalling transfer_signaling(TransferFunction tf)
 {
     switch (tf.type)
     {
@@ -949,17 +949,17 @@ void save_png_image(const Image &img, ostream &os, string_view /*filename*/, flo
     // and a reader assumes sRGB), or unrecognized (< 0, where the pixels were converted to sRGB above). A
     // genuinely wide gamut -- BT.2020, Display P3 -- gets cHRM and gAMA instead.
     const bool primaries_are_srgb = cicp_primaries < 0 || cicp_primaries == 1 || cicp_primaries == 2;
-    const auto signalling         = transfer_signalling(tf);
+    const auto signaling          = transfer_signaling(tf);
 
-    if (signalling.srgb_chunk && primaries_are_srgb)
+    if (signaling.srgb_chunk && primaries_are_srgb)
         png_set_sRGB(png_ptr, info_ptr.get(), PNG_sRGB_INTENT_PERCEPTUAL);
 
-    if (signalling.file_gamma > 0.0)
+    if (signaling.file_gamma > 0.0)
     {
-        png_set_gAMA(png_ptr, info_ptr.get(), signalling.file_gamma);
-        if (!signalling.gamma_is_exact)
+        png_set_gAMA(png_ptr, info_ptr.get(), signaling.file_gamma);
+        if (!signaling.gamma_is_exact)
             spdlog::debug("PNG: approximating the {} curve as gAMA {:.5f} for readers that ignore cICP",
-                          transfer_function_name(tf), signalling.file_gamma);
+                          transfer_function_name(tf), signaling.file_gamma);
     }
     else if (!k_can_write_cicp)
         // Writing the file regardless would encode the pixels with this curve while recording no curve at
@@ -1055,7 +1055,7 @@ PNGSaveOptions *png_parameters_gui()
     // How faithfully the chosen curve can be recorded, said here rather than only in the log after the fact:
     // this is the moment the user can still pick a different curve or a different format. The classification
     // is the writer's own, so the two cannot disagree.
-    if (const auto signalling = transfer_signalling(s_opts.tf); signalling.file_gamma <= 0.0)
+    if (const auto signaling = transfer_signaling(s_opts.tf); signaling.file_gamma <= 0.0)
     {
         const string name = transfer_function_name(s_opts.tf);
         const string note =

--- a/tests/gui/test_gui_tools.cpp
+++ b/tests/gui/test_gui_tools.cpp
@@ -61,7 +61,7 @@ static void show_and_expand_palette(ImGuiTestContext *ctx)
 }
 
 //! A point on the palette's title bar clear of its collapse arrow. Not GetWindowTitlebarPoint(), which
-//! returns the bar's centre - on a palette only as wide as its buttons, that is the arrow itself.
+//! returns the bar's center - on a palette only as wide as its buttons, that is the arrow itself.
 static float2 palette_grab_point(ImGuiTestContext *ctx)
 {
     ImGuiWindow *w = ctx->WindowInfo(palette_window_ref).Window;
@@ -138,7 +138,7 @@ void RegisterTests_Tools(ImGuiTestEngine *engine)
         ImGuiWindow *w = ctx->WindowInfo(palette_window_ref).Window;
         IM_CHECK(w != nullptr);
 
-        // The buttons sit centred in the window's padding. ImGui truncates the layout cursor to whole
+        // The buttons sit centered in the window's padding. ImGui truncates the layout cursor to whole
         // pixels as it stacks items, so fractional padding or spacing shows up here as a bottom edge
         // tighter than the top one.
         {

--- a/tests/test_gainmap.cpp
+++ b/tests/test_gainmap.cpp
@@ -187,7 +187,7 @@ TEST_CASE("What the file stores is kept alongside what is built from it")
         REQUIRE(g >= 0);
         REQUIRE(b >= 0);
 
-        // The colour channels were brightened; base.* still reads what the file held.
+        // The color channels were brightened; base.* still reads what the file held.
         CHECK(img->channels[0](0, 0) == doctest::Approx(0.25f * std::exp2(1.8f)));
         CHECK(img->channels[r](0, 0) == doctest::Approx(0.25f));
         CHECK(img->channels[g](3, 2) == doctest::Approx(0.25f));

--- a/tests/test_index_helpers.cpp
+++ b/tests/test_index_helpers.cpp
@@ -92,7 +92,7 @@ TEST_CASE("nth_matching_index finds the nth match or reports past-the-end")
 
 TEST_CASE("next_matching_index holds its invariants over every small vector and starting index")
 {
-    // The hand-picked cases above name the behaviours worth reading; this pins them over the whole
+    // The hand-picked cases above name the behaviors worth reading; this pins them over the whole
     // small-input space, where the interesting starting indices are the ones outside the vector -- -1
     // for "nothing selected", and anything a stale session file might name.
     auto is_set = [](size_t, const bool &b) { return b; };


### PR DESCRIPTION
A spelling-only sweep, split out of [#193](https://github.com/wkjarosz/hdrview/pull/193) so that PR stays
about export bugs. No behaviour beyond one label changes; the diff is 26 lines, all of them one word.

HDRView's API is American English and bakes it into its identifiers — `colorspace.h`,
`color_conversion_matrix()`, `ColorGamut_`, `colormap.cpp` — so a comment saying "colour" beside them
reads as a different codebase and, more practically, hides from a `grep` for `color`.

## What changed

Comments in ten files, plus two identifiers:

- `gainmap.cpp`'s local `std::vector<int> colour`
- `png.cpp`'s `transfer_signalling()` and its `signalling` locals

Both are confined to their own file, so neither rename reaches an API.

## The one user-visible change

The **"Abs Grey" colormap is now "Abs Gray"**, and it is the only thing here anyone can see. It is safe:
`Colormap::name()` reads the name back from ImPlot by index, and both sessions and settings store the
*index*, not the name, so nothing already saved refers to the old spelling. Called out separately because
it is a label rather than a comment — easy to drop if you would rather keep it.

## What deliberately stays

- **`colour-science`** (4 places) — the library is named that; it is a proper noun, not prose.
- **`greyhounds-looking-for-a-table.heic`** — a real fixture's filename in `test_gainmap.cpp`.

## Checks

142/142 ctest, including the GUI suite, and `HDRView --help` still runs. The convention itself is recorded
in CLAUDE.md by #193, so this is the one-off catch-up behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
