### PR TITLE
Sixth bug hunt: a watched folder that stopped being watched, duplicated reloads, and three more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1839,6 +1839,7 @@ if(HDRVIEW_BUILD_GUI_TESTS AND NOT EMSCRIPTEN)
     tests/gui/test_gui_multipart.cpp
     tests/gui/test_gui_session.cpp
     tests/gui/test_gui_session_bundle.cpp tests/gui/test_gui_lifetime.cpp
+    tests/gui/test_gui_loader.cpp
   )
   target_include_directories(hdrview_gui_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_gui_tests PROPERTIES CXX_STANDARD 17)

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -1,4 +1,5 @@
 #include "app.h"
+#include "common.h"
 
 #include "image.h"
 #include "version.h"
@@ -564,15 +565,6 @@ void HDRViewApp::load_image(const string filename, std::optional<string_view> bu
                             const ImageLoadOptions &opts)
 {
     m_image_loader.background_load(filename, buffer, should_select, nullptr, opts);
-}
-
-int HDRViewApp::download_percent_remaining(int64_t bytes_loaded, int64_t total_bytes)
-{
-    if (total_bytes <= 0)
-        return 100; // nothing to measure against yet; leave the bar where it started
-
-    const int64_t remaining = std::max<int64_t>(0, total_bytes - bytes_loaded);
-    return (int)std::min<int64_t>(100, (100 * remaining + total_bytes - 1) / total_bytes);
 }
 
 void HDRViewApp::load_url(const string_view url)

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -705,7 +705,7 @@ void HDRViewApp::close_image(int index)
         }
 
         spdlog::debug("Watched directories after closing image:");
-        m_image_loader.remove_watched_directories(
+        m_image_loader.remove_implicitly_watched_directories(
             [this](const fs::path &path)
             {
                 spdlog::debug("{} watched directory: {}",
@@ -754,7 +754,9 @@ void HDRViewApp::close_all_images()
     m_current   = -1;
     m_reference = -1;
     m_active_directories.clear();
-    m_image_loader.remove_watched_directories([](const fs::path &) { return true; });
+    // Only the folders opened alongside these images; one the user asked to watch stays watched, since
+    // what it is for -- files that do not exist yet -- has nothing to do with what is currently loaded.
+    m_image_loader.remove_implicitly_watched_directories([](const fs::path &) { return true; });
     update_visibility(); // this also calls set_image_textures();
 }
 
@@ -1054,7 +1056,7 @@ void HDRViewApp::begin_session_load(const json &j, const fs::path &dir)
             continue;
 
         PendingSession::Entry e;
-        e.path             = resolve(rel);
+        e.path                  = resolve(rel);
         e.channel_selector      = entry.value<string>("channel_selector", "");
         e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
         e.selected_group        = entry.value<int>("selected_group", 0);
@@ -1096,7 +1098,7 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
         // images (image_loader.cpp's extract_and_schedule) -- this is also why "reveal in file manager" and
         // reload_image() already handle these correctly with no session-specific work.
         PendingSession::Entry e;
-        e.path             = fs::path(zip_name) / fs::u8path(rel);
+        e.path                  = fs::path(zip_name) / fs::u8path(rel);
         e.channel_selector      = entry.value<string>("channel_selector", "");
         e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
         e.selected_group        = entry.value<int>("selected_group", 0);
@@ -1176,17 +1178,17 @@ void HDRViewApp::finish_pending_session()
     m_exposure_live = m_exposure = view.value<float>("exposure", m_exposure);
     // Only the floor; see MIN_GAMMA. Exposure and offset have no unsafe values, and a session has to be
     // able to carry back whatever the sliders' Ctrl+click entry and keyboard shortcuts can set.
-    m_gamma_live = m_gamma   = std::max(MIN_GAMMA, view.value<float>("gamma", m_gamma));
+    m_gamma_live = m_gamma = std::max(MIN_GAMMA, view.value<float>("gamma", m_gamma));
     m_offset_live = m_offset = view.value<float>("offset", m_offset);
     m_tonemap                = id_to_enum(view, "tonemap", g_tonemap_ids, m_tonemap);
     m_channel                = id_to_enum(view, "channel", g_channel_ids, m_channel);
     m_colormap_index =
         clamp<int>(view.value<int>("colormap_index", m_colormap_index), 0, (int)std::size(m_colormaps) - 1);
-    m_reverse_colormap   = view.value<bool>("reverse_colormap", m_reverse_colormap);
-    m_clamp_to_LDR       = view.value<bool>("clamp_to_LDR", m_clamp_to_LDR);
-    m_dither             = view.value<bool>("dither", m_dither);
-    m_bg_mode            = id_to_enum(view, "bg_mode", g_bg_mode_ids, m_bg_mode);
-    m_bg_color.xyz()     = view.value<float3>("bg_color", m_bg_color.xyz());
+    m_reverse_colormap = view.value<bool>("reverse_colormap", m_reverse_colormap);
+    m_clamp_to_LDR     = view.value<bool>("clamp_to_LDR", m_clamp_to_LDR);
+    m_dither           = view.value<bool>("dither", m_dither);
+    m_bg_mode          = id_to_enum(view, "bg_mode", g_bg_mode_ids, m_bg_mode);
+    m_bg_color.xyz()   = view.value<float3>("bg_color", m_bg_color.xyz());
     set_zoom(view.value<float>("zoom", m_zoom));
     m_translate          = view.value<float2>("translate", m_translate);
     m_flip               = view.value<bool2>("flip", m_flip);

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -490,7 +490,7 @@ void HDRViewApp::load_images(const vector<string> &filenames)
 
         // A .zip might be a session bundle -- see zip_bundle_hook (wired in the constructor), checked inside
         // background_load() once it has the zip's bytes in hand.
-        load_image(filenames[i], {}, i == 0, opts);
+        load_image(filenames[i], std::nullopt, i == 0, opts);
     }
 }
 
@@ -560,10 +560,19 @@ void HDRViewApp::open_session_bundle()
 }
 
 // Note: the filename is passed by value in case its an element of m_recent_files, which we modify
-void HDRViewApp::load_image(const string filename, const string_view buffer, bool should_select,
+void HDRViewApp::load_image(const string filename, std::optional<string_view> buffer, bool should_select,
                             const ImageLoadOptions &opts)
 {
     m_image_loader.background_load(filename, buffer, should_select, nullptr, opts);
+}
+
+int HDRViewApp::download_percent_remaining(int64_t bytes_loaded, int64_t total_bytes)
+{
+    if (total_bytes <= 0)
+        return 100; // nothing to measure against yet; leave the bar where it started
+
+    const int64_t remaining = std::max<int64_t>(0, total_bytes - bytes_loaded);
+    return (int)std::min<int64_t>(100, (100 * remaining + total_bytes - 1) / total_bytes);
 }
 
 void HDRViewApp::load_url(const string_view url)
@@ -594,7 +603,8 @@ void HDRViewApp::load_url(const string_view url)
             auto filename    = get_filename(url);
             auto char_buffer = reinterpret_cast<const char *>(buffer);
             spdlog::info("Downloaded file '{}' with size {} from url '{}'", filename, buffer_size, url);
-            hdrview()->load_image(url, {char_buffer, (size_t)buffer_size}, true, load_image_options());
+            hdrview()->m_remaining_download = 0; // the last progress callback need not have reported it
+            hdrview()->load_image(url, string_view{char_buffer, (size_t)buffer_size}, true, load_image_options());
         },
         (em_async_wget2_data_onerror_func)[](unsigned, void *data, int err, const char *desc) {
             auto   payload                         = reinterpret_cast<Payload *>(data);
@@ -607,7 +617,7 @@ void HDRViewApp::load_url(const string_view url)
         (em_async_wget2_data_onprogress_func)[](unsigned, void *data, int bytes_loaded, int total_bytes) {
             auto payload = reinterpret_cast<Payload *>(data);
 
-            payload->hdrview->m_remaining_download = (total_bytes - bytes_loaded) / total_bytes;
+            payload->hdrview->m_remaining_download = download_percent_remaining(bytes_loaded, total_bytes);
         });
 
     // emscripten_async_wget_data(
@@ -644,7 +654,7 @@ void HDRViewApp::reload_image(ImagePtr image, bool should_select)
     auto opts                  = load_image_options();
     opts.channel_selector      = image->channel_selector;
     opts.alpha_is_transparency = image->alpha_is_transparency;
-    m_image_loader.background_load(image->filename, {}, should_select, image, opts);
+    m_image_loader.background_load(image->filename, std::nullopt, should_select, image, opts);
 }
 
 void HDRViewApp::close_image(int index)

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -103,7 +103,7 @@ void HDRViewApp::zoom_at_vp_pos(float amount, float2 focus_vp_pos)
 }
 
 //! The nudge that keeps a zoom already sitting on a power of two from being rounded to the wrong side of
-//! it by float error in log2(), while being far too small to reach the neighbouring stop.
+//! it by float error in log2(), while being far too small to reach the neighboring stop.
 static constexpr float k_zoom_step_epsilon = 1e-4f;
 
 void HDRViewApp::zoom_in()

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -431,29 +431,26 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
                 m_draw_grid           = j.value<bool>("draw pixel grid", m_draw_grid);
                 m_exposure_live = m_exposure = j.value<float>("exposure", m_exposure);
                 m_gamma_live = m_gamma = std::max(MIN_GAMMA, j.value<float>("gamma", m_gamma));
-                m_tonemap = (Tonemap_)clamp<int>(j.value<Tonemap_>("tonemap", m_tonemap), 0, Tonemap_COUNT - 1);
-                m_clamp_to_LDR         = j.value<bool>("clamp to LDR", m_clamp_to_LDR);
-                m_dither               = j.value<bool>("dither", m_dither);
+                m_tonemap        = (Tonemap_)clamp<int>(j.value<Tonemap_>("tonemap", m_tonemap), 0, Tonemap_COUNT - 1);
+                m_clamp_to_LDR   = j.value<bool>("clamp to LDR", m_clamp_to_LDR);
+                m_dither         = j.value<bool>("dither", m_dither);
                 m_file_list_mode = clamp<int>(j.value<int>("file list mode", m_file_list_mode), 0, 2);
-                m_short_names          = j.value<bool>("short names", m_short_names);
+                m_short_names    = j.value<bool>("short names", m_short_names);
                 // "draw clip warnings" is the older key, a single toggle covering both ends; fall back to it
                 // so settings written by an earlier version still take effect
-                bool both             = j.value<bool>("draw clip warnings", false);
-                m_clip_warnings       = j.value<bool2>("clip warnings", bool2{both, both});
-                m_show_FPS            = j.value<bool>("show FPS", m_show_FPS);
-                m_clip_range          = j.value<float2>("clip range", m_clip_range);
-                m_histogram_height    = j.value<float>("histogram height", m_histogram_height);
+                bool both          = j.value<bool>("draw clip warnings", false);
+                m_clip_warnings    = j.value<bool2>("clip warnings", bool2{both, both});
+                m_show_FPS         = j.value<bool>("show FPS", m_show_FPS);
+                m_clip_range       = j.value<float2>("clip range", m_clip_range);
+                m_histogram_height = j.value<float>("histogram height", m_histogram_height);
                 // Clamped: it indexes pixel_color_widget()'s current/reference/composite choices, and the
                 // settings file is ordinary user-editable text.
                 m_status_pixel_target = clamp<int>(j.value<int>("status pixel target", m_status_pixel_target), 0, 2);
-                m_x_scale =
-                    clamp<int>(j.value<int>("histogram x scale", m_x_scale), 0, AxisScale_COUNT - 1);
-                m_y_scale =
-                    clamp<int>(j.value<int>("histogram y scale", m_y_scale), 0, AxisScale_COUNT - 1);
-                m_playback_speed      = j.value<float>("playback speed", m_playback_speed);
-                m_colormap_index =
-                    clamp<int>(j.value<int>("colormap index", 0), 0, (int)std::size(m_colormaps) - 1);
-                m_show_developer_menu = j.value<bool>("show developer menu", m_show_developer_menu);
+                m_x_scale        = clamp<int>(j.value<int>("histogram x scale", m_x_scale), 0, AxisScale_COUNT - 1);
+                m_y_scale        = clamp<int>(j.value<int>("histogram y scale", m_y_scale), 0, AxisScale_COUNT - 1);
+                m_playback_speed = j.value<float>("playback speed", m_playback_speed);
+                m_colormap_index = clamp<int>(j.value<int>("colormap index", 0), 0, (int)std::size(m_colormaps) - 1);
+                m_show_developer_menu    = j.value<bool>("show developer menu", m_show_developer_menu);
                 m_show_tool_palette      = j.value<bool>("show tool palette", m_show_tool_palette);
                 m_tool_palette_collapsed = j.value<bool>("tool palette collapsed", m_tool_palette_collapsed);
                 m_tool_palette_vertical  = j.value<bool>("tool palette vertical", m_tool_palette_vertical);
@@ -602,6 +599,15 @@ void HDRViewApp::setup_frame_callbacks()
         m_image_loader.get_loaded_images(
             [this](ImagePtr new_image, ImagePtr to_replace, bool should_select)
             {
+                // A replacement whose target has gone was a reload of an image closed while it was still
+                // loading. Appending it would put back the image that was just closed, so let it go.
+                const int idx = to_replace ? image_index(to_replace) : -1;
+                if (to_replace && !is_valid(idx))
+                {
+                    spdlog::debug("Discarding reload of '{}': it was closed while loading.", new_image->filename);
+                    return;
+                }
+
 #if !defined(__EMSCRIPTEN__)
                 std::error_code ec;
                 auto            path = fs::weakly_canonical(new_image->filename, ec);
@@ -611,7 +617,6 @@ void HDRViewApp::setup_frame_callbacks()
                 m_active_directories.insert(path.parent_path());
 #endif
 
-                int idx = (to_replace) ? image_index(to_replace) : -1;
                 if (is_valid(idx))
                     m_images[idx] = new_image;
                 else
@@ -844,22 +849,16 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
         auto add = [this](const Action &a) { m_actions[a.names[0]] = a; };
         add(Action{{"Open image..."}, ICON_MY_OPEN_IMAGE, ImGuiMod_Ctrl | ImGuiKey_O, 0, [this]() { open_image(); }});
 
-        add(Action{{"Create gradient image..."},
-                   ICON_MY_DITHER,
-                   ImGuiKey_None,
-                   0,
-                   [this]() { dialog("Create gradient image...").open = true; }});
-        add(Action{{"Create dither image..."},
-                   ICON_MY_DITHER,
-                   ImGuiKey_None,
-                   0,
-                   [this]() { dialog("Create dither image...").open = true; }});
+        add(Action{{"Create gradient image..."}, ICON_MY_DITHER, ImGuiKey_None, 0, [this]() {
+                       dialog("Create gradient image...").open = true;
+                   }});
+        add(Action{{"Create dither image..."}, ICON_MY_DITHER, ImGuiKey_None, 0, [this]() {
+                       dialog("Create dither image...").open = true;
+                   }});
 
-        add(Action{{"Image loading options..."},
-                   ICON_MY_SETTINGS_WINDOW,
-                   ImGuiKey_None,
-                   0,
-                   [this]() { dialog("Image loading options...").open = true; }});
+        add(Action{{"Image loading options..."}, ICON_MY_SETTINGS_WINDOW, ImGuiKey_None, 0, [this]() {
+                       dialog("Image loading options...").open = true;
+                   }});
 
 #if !defined(__EMSCRIPTEN__)
         add(Action{{"Open folder..."}, ICON_MY_OPEN_FOLDER, ImGuiKey_None, 0, [this]() { open_folder(); }});
@@ -1092,11 +1091,9 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                        &w.isVisible});
         }
 
-        add(Action{{"Decrease exposure"},
-                   ICON_MY_DECREASE_EXPOSURE,
-                   ImGuiKey_E,
-                   ImGuiInputFlags_Repeat,
-                   [this]() { m_exposure_live = m_exposure -= 0.25f; }});
+        add(Action{{"Decrease exposure"}, ICON_MY_DECREASE_EXPOSURE, ImGuiKey_E, ImGuiInputFlags_Repeat, [this]() {
+                       m_exposure_live = m_exposure -= 0.25f;
+                   }});
         add(Action{{"Increase exposure"},
                    ICON_MY_INCREASE_EXPOSURE,
                    ImGuiMod_Shift | ImGuiKey_E,
@@ -1232,7 +1229,7 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                        false,
                        &m_mouse_mode_enabled[i]});
 
-        // below actions are only available if there is an image
+            // below actions are only available if there is an image
 
 #if !defined(__EMSCRIPTEN__)
         add(Action{{"Reload image"},

--- a/src/app.h
+++ b/src/app.h
@@ -79,6 +79,9 @@ public:
     void close_image(int index = -1);
     void close_all_images();
     void reload_image(ImagePtr image, bool shall_select = false);
+    /// The background loader, which also owns the watched-directory and recent-file lists.
+    BackgroundImageLoader       &image_loader() { return m_image_loader; }
+    const BackgroundImageLoader &image_loader() const { return m_image_loader; }
 
     //-----------------------------------------------------------------------------
     // saving/loading an entire session (loaded images, current/reference selection, blend mode,

--- a/src/app.h
+++ b/src/app.h
@@ -73,7 +73,7 @@ public:
     void open_image();
     void open_folder();
     void load_images(const vector<string> &filenames);
-    void load_image(const string filename, const string_view buffer = string_view{}, bool should_select = true,
+    void load_image(const string filename, std::optional<string_view> buffer = std::nullopt, bool should_select = true,
                     const ImageLoadOptions &opts = {});
     void load_url(const string_view url);
     void close_image(int index = -1);
@@ -400,6 +400,18 @@ private:
 
     int m_remaining_download = 0;
 
+public:
+    /// Percent of a download still outstanding, for the status bar's progress readout.
+    /*!
+        Split out from the Emscripten download callbacks so the arithmetic is exercised on every platform.
+        It guards the two things the raw byte counts do not: a total of zero, which a server that sends no
+        content length reports and which the callbacks can also see before the headers arrive; and integer
+        division, which sends every partial fraction to zero. Rounds what is left up, so the bar stays
+        visible until the download is genuinely finished rather than vanishing on the last few bytes.
+    */
+    static int download_percent_remaining(int64_t bytes_loaded, int64_t total_bytes);
+
+private:
     ImGuiTextFilter m_file_filter, m_channel_filter;
     vector<size_t>  m_visible_images;
 

--- a/src/app.h
+++ b/src/app.h
@@ -400,18 +400,6 @@ private:
 
     int m_remaining_download = 0;
 
-public:
-    /// Percent of a download still outstanding, for the status bar's progress readout.
-    /*!
-        Split out from the Emscripten download callbacks so the arithmetic is exercised on every platform.
-        It guards the two things the raw byte counts do not: a total of zero, which a server that sends no
-        content length reports and which the callbacks can also see before the headers arrive; and integer
-        division, which sends every partial fraction to zero. Rounds what is left up, so the bar stays
-        visible until the download is genuinely finished rather than vanishing on the last few bytes.
-    */
-    static int download_percent_remaining(int64_t bytes_loaded, int64_t total_bytes);
-
-private:
     ImGuiTextFilter m_file_filter, m_channel_filter;
     vector<size_t>  m_visible_images;
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -363,3 +363,12 @@ bool natural_less(const string_view a, const string_view b)
     }
     return a.size() < b.size();
 }
+
+int download_percent_remaining(int64_t bytes_loaded, int64_t total_bytes)
+{
+    if (total_bytes <= 0)
+        return 100; // nothing to measure against yet; leave the bar where it started
+
+    const int64_t remaining = std::max<int64_t>(0, total_bytes - bytes_loaded);
+    return (int)std::min<int64_t>(100, (100 * remaining + total_bytes - 1) / total_bytes);
+}

--- a/src/common.h
+++ b/src/common.h
@@ -14,6 +14,7 @@
 
 #include "fwd.h"
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -506,6 +507,16 @@ std::pair<int, int> find_common_prefix_suffix(const std::vector<std::string> &na
     \returns One short name per input, in the same order.
 */
 std::vector<std::string> shorten_names(const std::vector<std::string> &names);
+
+/// Percent of a download still outstanding, for the status bar's progress readout.
+/*!
+    Kept apart from the Emscripten download callbacks so the arithmetic is exercised on every platform.
+    It guards the two things the raw byte counts do not: a total of zero, which a server that sends no
+    content length reports and which the callbacks can also see before the headers arrive; and integer
+    division, which sends every partial fraction to zero. Rounds what is left up, so the bar stays
+    visible until the download is genuinely finished rather than vanishing on the last few bytes.
+*/
+int download_percent_remaining(int64_t bytes_loaded, int64_t total_bytes);
 
 // Compare two strings in "natural" order (e.g. file2 < file10)
 bool natural_less(const std::string_view a, const std::string_view b);

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <hello_imgui/dpi_aware.h>
 #include <miniz.h>
+#include <optional>
 #include <sstream>
 
 #include "imageio/dds.h"
@@ -221,17 +222,17 @@ struct BackgroundImageLoader::PendingImages
     bool                    add_to_recent;         ///< Whether to add the loaded images to the recent files list
     bool                    should_select = false; ///< Whether to select the first loaded image
     ImagePtr                to_replace = nullptr;  ///< If not null, this image will be replaced with the loaded images
-    PendingImages(const string &f, const string_view buffer, const fs::path &path, ImageLoadOptions opts,
+    PendingImages(const string &f, std::optional<string_view> buffer, const fs::path &path, ImageLoadOptions opts,
                   bool recent = true, bool should_select = false, ImagePtr to_replace = nullptr) :
         filename(f), add_to_recent(recent), should_select(should_select), to_replace(to_replace)
     {
         computation = do_async(
-            // convert the buffer (if any) to a string so the async thread has its own copy,
-            // then load from the string or filename depending on whether the buffer is empty
-            [this, buffer_str = string(buffer), path, opts]()
+            // give the async thread its own copy of the buffer, if there is one; whether there is decides
+            // where the bytes come from, which an empty buffer must not be mistaken for
+            [this, buffer_str = buffer ? std::optional<string>{string(*buffer)} : std::nullopt, path, opts]()
             {
                 fs::file_time_type last_modified = fs::file_time_type::clock::now();
-                if (buffer_str.empty())
+                if (!buffer_str)
                 {
                     std::error_code ec;
                     if (!fs::exists(path, ec) || ec)
@@ -256,9 +257,17 @@ struct BackgroundImageLoader::PendingImages
                         return;
                     }
                 }
+                else if (buffer_str->empty())
+                {
+                    // A zero-byte zip entry, or a download that returned nothing. The path here is a
+                    // display name rather than something on disk, so falling through to the branch above
+                    // would blame the filesystem for a file that was never meant to be there.
+                    spdlog::error("'{}' is empty.", path.u8string());
+                    return;
+                }
                 else
                 {
-                    std::istringstream is{buffer_str};
+                    std::istringstream is{*buffer_str};
                     images = load_image(is, path.u8string(), opts);
                 }
 
@@ -383,14 +392,14 @@ std::optional<string> zip_extract_entry(string_view zip_bytes, const string &ent
     return string(buffer.begin(), buffer.end());
 }
 
-void BackgroundImageLoader::background_load(const string filename, const string_view buffer, bool should_select,
-                                            ImagePtr to_replace, const ImageLoadOptions &opts)
+void BackgroundImageLoader::background_load(const string filename, std::optional<string_view> buffer,
+                                            bool should_select, ImagePtr to_replace, const ImageLoadOptions &opts)
 {
     if (should_select)
         spdlog::debug("will select image '{}'", filename);
 
-    auto load_one = [this](const fs::path &path, const string_view buffer, bool add_to_recent, bool should_select,
-                           ImagePtr to_replace, const ImageLoadOptions &opts)
+    auto load_one = [this](const fs::path &path, std::optional<string_view> buffer, bool add_to_recent,
+                           bool should_select, ImagePtr to_replace, const ImageLoadOptions &opts)
     {
         try
         {
@@ -480,19 +489,18 @@ void BackgroundImageLoader::background_load(const string filename, const string_
     auto path = fs::u8path(filename);
 
     std::error_code path_ec;
-    if (!buffer.empty())
+    if (buffer)
     {
-        // if we have a buffer, we assume it is a file that has been downloaded
-        // and we load it directly from the buffer
-        spdlog::info("Loading image '{}' from {:.0h} buffer.", filename, human_readible{buffer.size()});
+        // a buffer was supplied, so the bytes are in hand and `filename` is only a name
+        spdlog::info("Loading image '{}' from {:.0h} buffer.", filename, human_readible{buffer->size()});
 
         if (to_lower(get_extension(filename)) == ".zip")
         {
-            if (zip_bundle_hook && zip_bundle_hook(buffer, filename))
+            if (zip_bundle_hook && zip_bundle_hook(*buffer, filename))
                 return;
 
             remove_recent_file(filename);
-            if (extract_and_schedule(buffer, filename, should_select, to_replace))
+            if (extract_and_schedule(*buffer, filename, should_select, to_replace))
                 add_recent_file(filename);
         }
         else

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -663,45 +663,69 @@ void BackgroundImageLoader::remove_watched_directories_if(const std::function<bo
 
 void BackgroundImageLoader::get_loaded_images(function<void(ImagePtr, ImagePtr, bool)> callback)
 {
-    // move elements matching the criterion to the end of the vector, and then erase all matching elements
-    pending_images.erase(
-        std::remove_if(pending_images.begin(), pending_images.end(),
-                       [this, &callback](shared_ptr<PendingImages> p)
-                       {
-                           // if the computation isn't ready, we return false to indicate that we can't
-                           // yet remove this entry
-                           if (!p->computation.ready())
-                               return false;
+    // Take the finished loads out of the pending list before running any callbacks: the callback reaches
+    // back into the app, which is free to schedule further loads, and nothing should be walking
+    // pending_images while that happens.
+    vector<shared_ptr<PendingImages>> finished;
+    for (auto it = pending_images.begin(); it != pending_images.end();)
+    {
+        if ((*it)->computation.ready())
+        {
+            finished.push_back(std::move(*it));
+            it = pending_images.erase(it);
+        }
+        else
+            ++it;
+    }
 
-                           // finalize the computation
-                           try
-                           {
-                               p->computation.wait();
-                           }
-                           catch (const std::exception &e)
-                           {
-                               spdlog::error("Could not load image \"{}\": {}.", p->filename, e.what());
-                               return true;
-                           }
+    for (auto &p : finished)
+    {
+        // finalize the computation
+        try
+        {
+            p->computation.wait();
+        }
+        catch (const std::exception &e)
+        {
+            spdlog::error("Could not load image \"{}\": {}.", p->filename, e.what());
+            continue;
+        }
 
-                           // once the async computation is ready, we can access the resulting
-                           // images and return true to report that we can remove this entry from
-                           // pending_images
-                           if (p->images.empty())
-                               return true;
+        if (p->images.empty())
+            continue;
 
-                           for (size_t i = 0; i < p->images.size(); ++i)
-                               callback(p->images[i], p->to_replace,
-                                        p->should_select && i == 0); // i == 0 to always select the first of the
-                                                                     // possibly multiple 'should_select' images
+        // i == 0 both selects the first of possibly several images and claims the slot being replaced.
+        // Exactly one arrival can take a replaced image's place; any others are ordinary additions. That
+        // matters because the app reads "asked to replace, but the target is gone" as "the image was
+        // closed while loading" and drops the arrival -- a reading only this split makes safe. A reload
+        // happens to yield a single image today, since it carries the replaced image's channel selector
+        // and so re-reads only that part of a multi-part file, but nothing here should depend on that.
+        for (size_t i = 0; i < p->images.size(); ++i)
+            callback(p->images[i], i == 0 ? p->to_replace : ImagePtr{}, p->should_select && i == 0);
 
-                           // if loading was successful, add the filename to the recent list
-                           if (p->add_to_recent)
-                               add_recent_file(p->filename);
+        // if loading was successful, add the filename to the recent list
+        if (p->add_to_recent)
+            add_recent_file(p->filename);
 
-                           return true;
-                       }),
-        pending_images.end());
+        // Another reload of the same image can still be in flight: the watch loop polls four times a
+        // second and schedules one on every timestamp change, so a file being written repeatedly -- a
+        // watched render folder, say -- outruns the load, and "Reload all images" pressed twice does the
+        // same. Each was told to replace an image that has now been replaced itself, and the arrival is
+        // matched to its slot by identity, so without this the later one finds nothing to replace and
+        // arrives as a second copy of the same file. Point it at whatever took that image's place.
+        if (p->to_replace)
+        {
+            auto replacement = p->images.front();
+            auto retarget    = [&](vector<shared_ptr<PendingImages>> &v)
+            {
+                for (auto &q : v)
+                    if (q && q != p && q->to_replace == p->to_replace)
+                        q->to_replace = replacement;
+            };
+            retarget(finished);
+            retarget(pending_images);
+        }
+    }
 }
 
 void BackgroundImageLoader::load_new_and_modified_files()

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -595,6 +595,7 @@ bool BackgroundImageLoader::add_watched_directory(const std::filesystem::path &d
         return false;
     }
     m_directories.emplace(canon_p);
+    m_explicit_directories.emplace(canon_p);
 
     if (!ignore_existing)
         return true;
@@ -614,11 +615,25 @@ bool BackgroundImageLoader::add_watched_directory(const std::filesystem::path &d
 
 void BackgroundImageLoader::remove_watched_directories(std::function<bool(const fs::path &)> criterion)
 {
+    remove_watched_directories_if(criterion, /* keep_explicit */ false);
+}
+
+void BackgroundImageLoader::remove_implicitly_watched_directories(std::function<bool(const fs::path &)> criterion)
+{
+    remove_watched_directories_if(criterion, /* keep_explicit */ true);
+}
+
+void BackgroundImageLoader::remove_watched_directories_if(const std::function<bool(const fs::path &)> &criterion,
+                                                          bool                                         keep_explicit)
+{
     // Remove directories that match the criterion
     for (auto it = m_directories.begin(); it != m_directories.end();)
     {
-        if (criterion(*it))
+        if (criterion(*it) && !(keep_explicit && m_explicit_directories.count(*it)))
+        {
+            m_explicit_directories.erase(*it);
             it = m_directories.erase(it);
+        }
         else
             ++it;
     }

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -534,6 +534,9 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
             }
         }
 
+        if (ec)
+            spdlog::error("Could not list directory '{}': {}.", filename, ec.message());
+
         sort(begin(entries), end(entries),
              [](const auto &a, const auto &b) { return natural_less(a.path().string(), b.path().string()); });
 
@@ -543,8 +546,12 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
             load_one(entries[i].path(), buffer, false, i == 0 ? should_select : false, to_replace, opts);
         }
 
-        // this moves the file to the top of the recent files list
-        add_recent_file(filename);
+        // Only somewhere that opened something belongs in the recent list, the same rule the file and zip
+        // paths follow; picking a folder that held no images does nothing at all.
+        if (entries.empty())
+            spdlog::warn("No loadable images found in '{}'.", filename);
+        else
+            add_recent_file(filename); // this moves the folder to the top of the recent files list
     }
 #endif
     else // a regular file

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -331,6 +331,9 @@ vector<std::pair<string, string>> zip_root_entries_with_suffix(string_view zip_b
             to_lower(name.substr(name.size() - suffix_lower.size())) != suffix_lower)
             continue;
 
+        if (!zip_entry_size_is_plausible(stat.m_uncomp_size, stat.m_comp_size, name))
+            continue;
+
         std::vector<char> buffer(stat.m_uncomp_size);
         if (!mz_zip_reader_extract_to_mem(&zip, i, buffer.data(), buffer.size(), 0))
         {
@@ -360,6 +363,12 @@ std::optional<string> zip_extract_entry(string_view zip_bytes, const string &ent
 
     mz_zip_archive_file_stat stat;
     if (!mz_zip_reader_file_stat(&zip, index, &stat))
+    {
+        mz_zip_reader_end(&zip);
+        return std::nullopt;
+    }
+
+    if (!zip_entry_size_is_plausible(stat.m_uncomp_size, stat.m_comp_size, entry_path))
     {
         mz_zip_reader_end(&zip);
         return std::nullopt;
@@ -434,6 +443,9 @@ void BackgroundImageLoader::background_load(const string filename, const string_
 
             // If entry_pattern is set, skip entries that don't match
             if (!entry_pattern.empty() && entry_path.u8string() != entry_pattern)
+                continue;
+
+            if (!zip_entry_size_is_plausible(stat.m_uncomp_size, stat.m_comp_size, entry_path.u8string()))
                 continue;
 
             buffer.resize(stat.m_uncomp_size);
@@ -808,6 +820,37 @@ void check_image_dimensions(int64_t width, int64_t height, string_view format)
     if (width > k_max_image_dimension || height > k_max_image_dimension || width * height > k_max_image_pixels)
         throw std::invalid_argument{
             fmt::format("{}: image dimensions {}x{} are implausibly large.", format, width, height)};
+}
+
+// DEFLATE cannot expand data by more than 1032:1, so a larger ratio is a claim the archive's own bytes
+// cannot back, whatever wrote it. Stored (uncompressed) entries are covered by the same test, since their
+// ratio is 1.
+static constexpr uint64_t k_max_zip_expansion_ratio = 1032;
+// And a bound on the honest case, which the ratio test cannot catch: an archive really can hold gigabytes
+// of compressible data, and HDRView would read the entry whole into memory before finding out it is not an
+// image. No file it can load is anywhere near this large.
+static constexpr uint64_t k_max_zip_entry_bytes = 2ull << 30;
+
+bool zip_entry_size_is_plausible(uint64_t uncompressed_size, uint64_t compressed_size, string_view entry_name)
+{
+    if (uncompressed_size > k_max_zip_entry_bytes)
+    {
+        spdlog::warn("Skipping zip entry '{}': it declares {:.0h}, more than any image HDRView can load.", entry_name,
+                     human_readible{(size_t)uncompressed_size});
+        return false;
+    }
+
+    // An empty entry compresses to a non-empty stream, so only guard the ratio once there is something to
+    // expand; a zero compressed size cannot back anything anyway.
+    if (uncompressed_size > k_max_zip_expansion_ratio * std::max<uint64_t>(compressed_size, 1))
+    {
+        spdlog::warn("Skipping zip entry '{}': it declares {:.0h} stored in {:.0h}, which no deflate stream "
+                     "could expand to.",
+                     entry_name, human_readible{(size_t)uncompressed_size}, human_readible{(size_t)compressed_size});
+        return false;
+    }
+
+    return true;
 }
 
 const ImageLoadOptions &load_image_options() { return s_opts; }

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -110,8 +110,14 @@ std::optional<string> zip_extract_entry(string_view zip_bytes, const string &ent
 
 struct BackgroundImageLoader
 {
-    void background_load(const string filename, const string_view = string_view{}, bool should_select = false,
-                         ImagePtr to_replace = nullptr, const ImageLoadOptions &opts = {});
+    //! Load `filename`, from `buffer` when one is supplied and from disk otherwise.
+    /*!
+        An absent buffer and an empty one are different things: a zip can hold a zero-byte entry, and a
+        download can return nothing, neither of which means "go and read this path". The path in those
+        cases is a name built for display (`archive.zip/entry.png`), which nothing can open.
+    */
+    void background_load(const string filename, std::optional<string_view> buffer = std::nullopt,
+                         bool should_select = false, ImagePtr to_replace = nullptr, const ImageLoadOptions &opts = {});
     void get_loaded_images(function<void(ImagePtr, ImagePtr, bool)> callback);
     int  num_pending_images() const { return (int)pending_images.size(); }
 

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -3,6 +3,7 @@
 #include "colorspace.h"
 #include "fwd.h"
 #include "imageio/gainmap.h"
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <optional>
@@ -71,6 +72,19 @@ struct ImageLoadOptions
 */
 void check_image_dimensions(int64_t width, int64_t height, string_view format);
 
+/**
+    Whether a zip entry's declared uncompressed size is one the archive could actually be holding.
+
+    Every entry is read whole into memory before anything looks at it, sized from what the archive's
+    directory claims rather than from the bytes present -- so a declared size costs that much memory, and
+    the time to decompress into it, whether or not the data is there. The same reasoning as
+    check_image_dimensions(), one layer further out.
+
+    \param [] uncompressed_size  Size the archive's directory declares for the entry
+    \param [] compressed_size    Size the archive's directory says it stores it in
+    \param [] entry_name         Entry name, for the warning
+*/
+bool zip_entry_size_is_plausible(uint64_t uncompressed_size, uint64_t compressed_size, string_view entry_name);
 
 const ImageLoadOptions &load_image_options();
 void                    draw_load_image_options_dialog(bool &open);

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -71,6 +71,7 @@ struct ImageLoadOptions
 */
 void check_image_dimensions(int64_t width, int64_t height, string_view format);
 
+
 const ImageLoadOptions &load_image_options();
 void                    draw_load_image_options_dialog(bool &open);
 
@@ -101,9 +102,17 @@ struct BackgroundImageLoader
     int  num_pending_images() const { return (int)pending_images.size(); }
 
     const set<fs::path> &watched_directories() const { return m_directories; }
-    bool                 add_watched_directory(const fs::path &dir, bool ignore_existing);
-    //! Remove all watched directories that match the criterion.
+    //! Watch `dir` in its own right, whether or not anything has been loaded from it.
+    bool add_watched_directory(const fs::path &dir, bool ignore_existing);
+    //! Remove all watched directories that match the criterion, however they came to be watched.
     void remove_watched_directories(function<bool(const fs::path &)> remove_criterion);
+    //! Same, but keeps the ones add_watched_directory() was asked for.
+    /*!
+        Callers prune by "no loaded image came from here", which is the right rule for a directory that is
+        only watched because its images were opened. A directory the user asked for holds no loaded images
+        of its own -- that is the point of it -- so that rule would always throw it away.
+    */
+    void remove_implicitly_watched_directories(function<bool(const fs::path &)> remove_criterion);
 
     void load_new_and_modified_files();
 
@@ -136,6 +145,12 @@ private:
     void remove_recent_file(const string &f);
 
     set<fs::path> m_directories;
+
+    // The subset of m_directories that add_watched_directory() was asked for, rather than ones picked up
+    // from the folder an image was opened from.
+    set<fs::path> m_explicit_directories;
+
+    void remove_watched_directories_if(const function<bool(const fs::path &)> &criterion, bool keep_explicit);
 
     // don't treat these files as new (they are either currently loaded, or we've previously loaded them from a watched
     // directory and manually closed them, so don't want to automatically reload them)

--- a/src/platform_utils.cpp
+++ b/src/platform_utils.cpp
@@ -142,7 +142,7 @@ extern "C"
         }
         else
         {
-            hdrview()->load_image(filename, {buffer, buffer_size}, should_select);
+            hdrview()->load_image(filename, string_view{buffer, buffer_size}, should_select);
             return 0;
         }
     }

--- a/tests/gui/test_gui_loader.cpp
+++ b/tests/gui/test_gui_loader.cpp
@@ -281,6 +281,36 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
     };
 
     /*
+        An entry with no bytes in it. A zip can hold one, and the loader decided where to read from by
+        asking whether the buffer it was handed was empty -- so a zero-byte entry fell through to "open
+        this path", against a name assembled for display (archive.zip/inside.png) that no filesystem has.
+        The complaint was that the file did not exist, about a file that was never supposed to.
+    */
+    t           = IM_REGISTER_TEST(engine, "loader", "an_empty_zip_entry_is_reported_as_empty");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        const fs::path dir   = make_temp_dir("empty_entry");
+        const fs::path empty = write_zip(dir, "empty.zip", 0, std::string{});
+        IM_CHECK(!empty.empty());
+
+        reset_images(ctx);
+        {
+            LogCapture log;
+            hdrview()->load_images({empty.u8string()});
+            for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+            IM_CHECK_EQ(hdrview()->num_images(), 0);
+            IM_CHECK(log.saw("is empty"));
+            // Whatever it says, it must not claim something is missing from the filesystem: the name it
+            // would be talking about was assembled for display and was never a path.
+            IM_CHECK(!log.saw("doesn't exist"));
+        }
+
+        reset_images(ctx);
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+    };
+
+    /*
         The same identity matching, in the other direction: an image closed while its reload was still in
         flight. The arrival has a slot to fill that no longer exists, and appending it puts the image the
         user just closed back in the list.

--- a/tests/gui/test_gui_loader.cpp
+++ b/tests/gui/test_gui_loader.cpp
@@ -281,6 +281,58 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
     };
 
     /*
+        Open Recent should list places that opened. The file path is careful about this -- it drops the name
+        first and only puts it back once a load has actually succeeded -- and so is the zip path, but a
+        folder was recorded the moment it was looked at, whether or not it turned out to hold anything or
+        could even be read. Picking it from the menu then does nothing at all.
+    */
+    t           = IM_REGISTER_TEST(engine, "loader", "only_folders_that_opened_something_become_recent");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        const fs::path empty_dir = make_temp_dir("recent_empty");
+        const fs::path junk_dir  = make_temp_dir("recent_junk");
+        const fs::path full_dir  = make_temp_dir("recent_full");
+        place_fixture(full_dir, "a.png");
+        {
+            // A file no loader claims, so the folder is non-empty but yields nothing.
+            std::ofstream junk{junk_dir / "notes.txt"};
+            junk << "not an image";
+        }
+
+        auto is_recent = [](const fs::path &p)
+        {
+            const auto &recents = hdrview()->image_loader().recent_files();
+            return std::find(recents.begin(), recents.end(), p.u8string()) != recents.end();
+        };
+
+        reset_images(ctx);
+        hdrview()->image_loader().clear_recent_files();
+
+        hdrview()->load_images({empty_dir.u8string()});
+        for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 0);
+        IM_CHECK(!is_recent(empty_dir));
+
+        hdrview()->load_images({junk_dir.u8string()});
+        for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 0);
+        IM_CHECK(!is_recent(junk_dir));
+
+        // And a folder that does hold an image is still recorded.
+        hdrview()->load_images({full_dir.u8string()});
+        for (int frame = 0; frame < 240 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+        IM_CHECK(is_recent(full_dir));
+
+        reset_images(ctx);
+        hdrview()->image_loader().clear_recent_files();
+        std::error_code ec;
+        fs::remove_all(empty_dir, ec);
+        fs::remove_all(junk_dir, ec);
+        fs::remove_all(full_dir, ec);
+    };
+
+    /*
         An entry with no bytes in it. A zip can hold one, and the loader decided where to read from by
         asking whether the buffer it was handed was empty -- so a zero-byte entry fell through to "open
         this path", against a name assembled for display (archive.zip/inside.png) that no filesystem has.

--- a/tests/gui/test_gui_loader.cpp
+++ b/tests/gui/test_gui_loader.cpp
@@ -1,0 +1,119 @@
+/** \file test_gui_loader.cpp
+    \author Wojciech Jarosz
+
+    BackgroundImageLoader driven through a running app: which directories it watches, and what stops it
+    watching them.
+
+    Distinct from test_gui_image_io.cpp, which loads a file the caller named. Here the loader is the one
+    deciding what to open, so the tests are about the decisions rather than the decode.
+*/
+
+#include "app.h"
+#include "image.h"
+#include "test_gui_registry.h"
+
+#include "imgui_test_engine/imgui_te_context.h"
+#include "imgui_test_engine/imgui_te_engine.h"
+
+#include <filesystem>
+#include <fstream>
+
+#ifndef HDRVIEW_GUI_TEST_IMAGE
+#error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
+#endif
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+//! A fresh, empty directory under the system temp dir, canonicalized the way the loader stores paths.
+fs::path make_temp_dir(const char *stem)
+{
+    std::error_code ec;
+    fs::path        d = fs::temp_directory_path(ec) / fmt::format("hdrview_watch_test_{}", stem);
+    fs::remove_all(d, ec);
+    fs::create_directories(d, ec);
+    return fs::weakly_canonical(d, ec);
+}
+
+//! Copies the fixture into `dir` under `name`, returning its path.
+fs::path place_fixture(const fs::path &dir, const char *name)
+{
+    std::error_code ec;
+    fs::path        dst = dir / name;
+    fs::copy_file(HDRVIEW_GUI_TEST_IMAGE, dst, fs::copy_options::overwrite_existing, ec);
+    return dst;
+}
+
+bool is_watched(const fs::path &dir) { return hdrview()->image_loader().watched_directories().count(dir) != 0; }
+
+void reset_images(ImGuiTestContext *ctx)
+{
+    hdrview()->close_all_images();
+    for (int frame = 0; frame < 60 && hdrview()->num_images() != 0; ++frame) ctx->Yield();
+}
+
+void load_and_wait(ImGuiTestContext *ctx, const fs::path &file)
+{
+    const int before = hdrview()->num_images();
+    hdrview()->load_images({file.u8string()});
+    for (int frame = 0; frame < 240 && hdrview()->num_images() <= before; ++frame) ctx->Yield();
+}
+
+} // namespace
+
+void RegisterTests_Loader(ImGuiTestEngine *engine)
+{
+    /*
+        "Add watched folder..." exists to watch a folder you have *not* opened -- its whole point is to pick
+        up files that do not exist yet. So no loaded image ever lives in it, and any rule phrased as "drop
+        the directories no loaded image came from" throws it away. Closing an unrelated image must not.
+    */
+    ImGuiTest *t = IM_REGISTER_TEST(engine, "loader", "explicit_watch_outlives_the_images");
+    t->TestFunc  = [](ImGuiTestContext *ctx)
+    {
+        const fs::path watch_dir = make_temp_dir("explicit");
+        const fs::path image_dir = make_temp_dir("images");
+        const fs::path image     = place_fixture(image_dir, "a.png");
+        IM_CHECK(fs::exists(image));
+
+        reset_images(ctx);
+        hdrview()->image_loader().remove_watched_directories([](const fs::path &) { return true; });
+
+        IM_CHECK(hdrview()->image_loader().add_watched_directory(watch_dir, true));
+        IM_CHECK(is_watched(watch_dir));
+
+        // An image from somewhere else entirely; the watched folder stays empty throughout.
+        load_and_wait(ctx, image);
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+        IM_CHECK(is_watched(watch_dir));
+
+        hdrview()->close_image(0);
+        IM_CHECK_EQ(hdrview()->num_images(), 0);
+        IM_CHECK(is_watched(watch_dir));
+
+        // Nor may closing everything, for the same reason: the folder was asked for in its own right.
+        load_and_wait(ctx, image);
+        hdrview()->close_all_images();
+        IM_CHECK(is_watched(watch_dir));
+
+        // The X button beside it in the watched-folders table is what removes it, and must still work.
+        hdrview()->image_loader().remove_watched_directories([&](const fs::path &p) { return p == watch_dir; });
+        IM_CHECK(!is_watched(watch_dir));
+
+        // The other half of the rule, so this does not simply pin every directory forever: a folder watched
+        // only because its images were opened is still dropped once none of them is loaded.
+        reset_images(ctx);
+        hdrview()->load_images({image_dir.u8string()});
+        for (int frame = 0; frame < 240 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+        IM_CHECK(is_watched(image_dir));
+        hdrview()->close_image(0);
+        IM_CHECK(!is_watched(image_dir));
+
+        std::error_code ec;
+        fs::remove_all(watch_dir, ec);
+        fs::remove_all(image_dir, ec);
+    };
+}

--- a/tests/gui/test_gui_loader.cpp
+++ b/tests/gui/test_gui_loader.cpp
@@ -236,4 +236,78 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         std::error_code ec;
         fs::remove_all(dir, ec);
     };
+
+    /*
+        Two reloads in flight for one image. The watch loop schedules a reload whenever a file's timestamp
+        moves, and it polls four times a second, so a file being written repeatedly -- which is exactly what
+        a watched render folder is -- outruns the load. "Reload all images" pressed twice does the same.
+
+        The arrival is matched to its slot by pointer identity, so once the first reload has replaced the
+        image, the second no longer finds the object it was told to replace.
+    */
+    t           = IM_REGISTER_TEST(engine, "loader", "overlapping_reloads_replace_rather_than_accumulate");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        const fs::path dir  = make_temp_dir("reload");
+        const fs::path file = place_fixture(dir, "a.png");
+
+        reset_images(ctx);
+        load_and_wait(ctx, file);
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+
+        auto original = hdrview()->image(0);
+        IM_CHECK(original != nullptr);
+
+        // Both scheduled before either can finish, the way the watch loop schedules them.
+        hdrview()->reload_image(original);
+        hdrview()->reload_image(original);
+        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+
+        // One file, one entry -- whichever reload landed last.
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+        IM_CHECK(hdrview()->image(0) != original);
+        IM_CHECK(hdrview()->image(0)->path == fs::path(file));
+
+        // However many pile up, not just two.
+        auto current = hdrview()->image(0);
+        for (int i = 0; i < 4; ++i) hdrview()->reload_image(current);
+        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+        IM_CHECK(hdrview()->image(0)->path == fs::path(file));
+
+        reset_images(ctx);
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+    };
+
+    /*
+        The same identity matching, in the other direction: an image closed while its reload was still in
+        flight. The arrival has a slot to fill that no longer exists, and appending it puts the image the
+        user just closed back in the list.
+    */
+    t           = IM_REGISTER_TEST(engine, "loader", "closing_an_image_mid_reload_does_not_resurrect_it");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        const fs::path dir  = make_temp_dir("closed_reload");
+        const fs::path file = place_fixture(dir, "a.png");
+
+        reset_images(ctx);
+        load_and_wait(ctx, file);
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+
+        hdrview()->reload_image(hdrview()->image(0));
+        hdrview()->close_image(0);
+        IM_CHECK_EQ(hdrview()->num_images(), 0);
+
+        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 0);
+
+        // An ordinary load still adds, so this is not refusing arrivals in general.
+        load_and_wait(ctx, file);
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+
+        reset_images(ctx);
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+    };
 }

--- a/tests/gui/test_gui_loader.cpp
+++ b/tests/gui/test_gui_loader.cpp
@@ -1,8 +1,8 @@
 /** \file test_gui_loader.cpp
     \author Wojciech Jarosz
 
-    BackgroundImageLoader driven through a running app: which directories it watches, and what stops it
-    watching them.
+    BackgroundImageLoader driven through a running app: which directories it watches and what stops it
+    watching them, and what it does with an archive whose contents it has to discover for itself.
 
     Distinct from test_gui_image_io.cpp, which loads a file the caller named. Here the loader is the one
     deciding what to open, so the tests are about the decisions rather than the decode.
@@ -15,8 +15,15 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include <miniz.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <mutex>
 
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
@@ -47,6 +54,75 @@ fs::path place_fixture(const fs::path &dir, const char *name)
 }
 
 bool is_watched(const fs::path &dir) { return hdrview()->image_loader().watched_directories().count(dir) != 0; }
+
+//! Collects everything logged while it is in scope. See the same helper in tests/test_loader_limits.cpp:
+//! refusing an entry up front and failing to extract it look identical from outside, so the warning is the
+//! only thing that tells them apart.
+struct LogCapture
+{
+    struct Sink : spdlog::sinks::base_sink<std::mutex>
+    {
+        std::vector<std::string> messages;
+        void                     sink_it_(const spdlog::details::log_msg &msg) override
+        {
+            messages.emplace_back(msg.payload.data(), msg.payload.size());
+        }
+        void flush_() override {}
+    };
+
+    std::shared_ptr<Sink> sink = std::make_shared<Sink>();
+
+    LogCapture() { spdlog::default_logger()->sinks().push_back(sink); }
+    ~LogCapture()
+    {
+        auto &sinks = spdlog::default_logger()->sinks();
+        sinks.erase(std::remove(sinks.begin(), sinks.end(), sink), sinks.end());
+    }
+
+    bool saw(const std::string &substring) const
+    {
+        return std::any_of(sink->messages.begin(), sink->messages.end(),
+                           [&](const std::string &m) { return m.find(substring) != std::string::npos; });
+    }
+};
+
+//! Writes a zip holding `contents` under "inside.png". A non-zero `declared` overwrites the entry's
+//! uncompressed size in both of its headers, so the archive claims more than it stores; zero leaves the
+//! real archive alone. See the equivalent fixture in tests/test_loader_limits.cpp for the header offsets.
+fs::path write_zip(const fs::path &dir, const char *name, uint32_t declared, const std::string &contents)
+{
+    mz_zip_archive zip;
+    memset(&zip, 0, sizeof(zip));
+    void  *buf  = nullptr;
+    size_t size = 0;
+    if (!mz_zip_writer_init_heap(&zip, 0, 0) ||
+        !mz_zip_writer_add_mem(&zip, "inside.png", contents.data(), contents.size(), MZ_BEST_COMPRESSION) ||
+        !mz_zip_writer_finalize_heap_archive(&zip, &buf, &size))
+    {
+        mz_zip_writer_end(&zip);
+        return {}; // the caller checks for this
+    }
+    std::string bytes(reinterpret_cast<char *>(buf), size);
+    mz_zip_writer_end(&zip);
+
+    if (declared)
+    {
+        auto patch_at = [&](const char *sig, size_t field_offset)
+        {
+            size_t pos = bytes.find(sig, 0, 4);
+            if (pos == std::string::npos)
+                return;
+            for (int b = 0; b < 4; ++b) bytes[pos + field_offset + b] = char((declared >> (8 * b)) & 0xff);
+        };
+        patch_at("PK\x03\x04", 22);
+        patch_at("PK\x01\x02", 24);
+    }
+
+    fs::path      out = dir / name;
+    std::ofstream os{out, std::ios::binary};
+    os.write(bytes.data(), (std::streamsize)bytes.size());
+    return out;
+}
 
 void reset_images(ImGuiTestContext *ctx)
 {
@@ -115,5 +191,49 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         std::error_code ec;
         fs::remove_all(watch_dir, ec);
         fs::remove_all(image_dir, ec);
+    };
+
+    /*
+        Opening a zip is the path where the loader discovers the entries itself, so the sizes it allocates
+        from are whatever the archive claims. A claim its own stored bytes cannot back has to be refused
+        before the allocation, not after the extraction fails -- the buffer is value-initialized, so the
+        pages are really touched and overcommit does not soften it. tests/test_loader_limits.cpp covers the
+        same guard on the two session-manifest paths; this is the one a user reaches by opening a file.
+    */
+    t           = IM_REGISTER_TEST(engine, "loader", "an_archive_lying_about_an_entry_is_refused_up_front");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        const fs::path dir = make_temp_dir("zip");
+        // Well past deflate's 1032:1 ceiling, but small enough that a build without the guard merely wastes
+        // the allocation rather than exhausting the machine.
+        // A small, highly compressible payload: the claim has to exceed what deflate could have expanded
+        // the *stored* bytes to, and an already-compressed entry (a PNG, say) barely shrinks, so the same
+        // declared size against one would be a ratio deflate can legitimately reach.
+        const fs::path lying = write_zip(dir, "lying.zip", 64u << 20, std::string(64, 'x'));
+        IM_CHECK(!lying.empty());
+
+        reset_images(ctx);
+        {
+            LogCapture log;
+            hdrview()->load_images({lying.u8string()});
+            for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+            IM_CHECK_EQ(hdrview()->num_images(), 0);
+            IM_CHECK(log.saw("Skipping zip entry 'inside.png'"));
+        }
+
+        // The same image in an honest archive still opens, so the guard is refusing the claim rather than
+        // the format.
+        std::ifstream     in{HDRVIEW_GUI_TEST_IMAGE, std::ios::binary};
+        const std::string fixture{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+        const fs::path    honest = write_zip(dir, "honest.zip", 0, fixture);
+        IM_CHECK(!honest.empty());
+        reset_images(ctx);
+        hdrview()->load_images({honest.u8string()});
+        for (int frame = 0; frame < 240 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), 1);
+
+        reset_images(ctx);
+        std::error_code ec;
+        fs::remove_all(dir, ec);
     };
 }

--- a/tests/gui/test_gui_multipart.cpp
+++ b/tests/gui/test_gui_multipart.cpp
@@ -64,6 +64,36 @@ void RegisterTests_Multipart(ImGuiTestEngine *engine)
         }
     };
 
+    /*
+        Reloading one part of a multi-part file has to leave the image list the same length: the part
+        replaces itself, and none of its siblings is disturbed. The watch loop reloads on every timestamp
+        change, so a multi-part file being rewritten reaches this constantly, and it does so on a list where
+        ten images share one path -- the case most likely to confuse a replacement for an addition.
+
+        (Reloading a part re-reads only that part, since it carries the part's own channel selector, so
+        each of these arrivals is a single image.)
+    */
+    t           = IM_REGISTER_TEST(engine, "multipart", "reloading_keeps_one_image_per_part");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        load_multipart(ctx);
+        const int parts = hdrview()->num_images();
+        IM_CHECK(parts > 1);
+
+        hdrview()->reload_image(hdrview()->image(0));
+        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), parts);
+
+        // And with a second reload already queued behind the first, which is what a file being written
+        // repeatedly produces.
+        hdrview()->reload_image(hdrview()->image(0));
+        hdrview()->reload_image(hdrview()->image(0));
+        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        IM_CHECK_EQ(hdrview()->num_images(), parts);
+
+        for (int i = 0; i < hdrview()->num_images(); ++i) IM_CHECK(hdrview()->image(i) != nullptr);
+    };
+
     t           = IM_REGISTER_TEST(engine, "multipart", "each_part_computes_valid_stats");
     t->TestFunc = [](ImGuiTestContext *ctx)
     {

--- a/tests/gui/test_gui_registry.h
+++ b/tests/gui/test_gui_registry.h
@@ -20,6 +20,7 @@ void RegisterTests_Multipart(ImGuiTestEngine *engine);
 void RegisterTests_Session(ImGuiTestEngine *engine);
 void RegisterTests_SessionBundle(ImGuiTestEngine *engine);
 void RegisterTests_Lifetime(ImGuiTestEngine *engine);
+void RegisterTests_Loader(ImGuiTestEngine *engine);
 
 inline void RegisterAllGuiTests(ImGuiTestEngine *engine)
 {
@@ -37,4 +38,5 @@ inline void RegisterAllGuiTests(ImGuiTestEngine *engine)
     RegisterTests_Session(engine);
     RegisterTests_SessionBundle(engine);
     RegisterTests_Lifetime(engine);
+    RegisterTests_Loader(engine);
 }

--- a/tests/gui/test_gui_viewport.cpp
+++ b/tests/gui/test_gui_viewport.cpp
@@ -197,7 +197,7 @@ void RegisterTests_Viewport(ImGuiTestEngine *engine)
 
                     // The same thing in the terms a user would check it in: the pixel reported half a pixel
                     // inside the leading corner of the drawn image. Flipped horizontally, the leftmost
-                    // column on screen is the image's rightmost, not its neighbour.
+                    // column on screen is the image's rightmost, not its neighbor.
                     const Box2i  dw = img->data_window;
                     const Box2f  drawn{expected_vp_pos(float2{dw.min}), expected_vp_pos(float2{dw.max})};
                     const Box2f  rect = Box2f{drawn}.make_valid();

--- a/tests/test_index_helpers.cpp
+++ b/tests/test_index_helpers.cpp
@@ -4,12 +4,21 @@
 // be found in the LICENSE.txt file.
 //
 
+/** \file test_index_helpers.cpp
+    \author Wojciech Jarosz
+
+    Small pure helpers the app leans on, checked exhaustively over their input range rather than at a few
+    sampled points: the index arithmetic that walks the image list, and the download-progress arithmetic the
+    status bar reads.
+*/
+
 #include <doctest/doctest.h>
 
+#include "app.h"
 #include "common.h"
 
-#include <initializer_list>
 #include <algorithm>
+#include <initializer_list>
 #include <numeric>
 #include <vector>
 
@@ -169,4 +178,66 @@ TEST_CASE("nth_matching_index agrees with a direct scan for every small vector")
                 CHECK(nth_matching_index(v, n, is_set) == expected);
             }
         }
+}
+
+TEST_CASE("download_percent_remaining reports a usable percentage for any byte counts")
+{
+    // The status bar draws its progress bar only while this is above zero, and computes the filled
+    // fraction as (100 - remaining) / 100, so the value has to stay inside [0, 100], fall as bytes
+    // arrive, and reach zero only when the transfer is actually complete.
+    using App = HDRViewApp;
+
+    SUBCASE("a total the server has not reported yet cannot divide")
+    {
+        // Emscripten's progress callback can fire before the content length is known, and some servers
+        // never send one. The previous form divided by this directly.
+        CHECK(App::download_percent_remaining(0, 0) == 100);
+        CHECK(App::download_percent_remaining(1234, 0) == 100);
+        CHECK(App::download_percent_remaining(0, -1) == 100);
+    }
+
+    SUBCASE("the endpoints are exact")
+    {
+        CHECK(App::download_percent_remaining(0, 1000) == 100);
+        CHECK(App::download_percent_remaining(1000, 1000) == 0);
+        // Over-reporting (more bytes than the declared total) still reads as finished, not negative.
+        CHECK(App::download_percent_remaining(1500, 1000) == 0);
+    }
+
+    SUBCASE("a partial transfer is neither 0 nor 100")
+    {
+        // Integer division sent all of these to zero, so the bar vanished the moment the first bytes
+        // landed and the download appeared to finish instantly.
+        CHECK(App::download_percent_remaining(500, 1000) == 50);
+        CHECK(App::download_percent_remaining(250, 1000) == 75);
+        CHECK(App::download_percent_remaining(999, 1000) == 1);
+        // Rounded up, so a nearly-finished transfer still shows rather than disappearing early.
+        CHECK(App::download_percent_remaining(999999, 1000000) == 1);
+    }
+
+    SUBCASE("the invariants hold across every small total and byte count")
+    {
+        for (int64_t total = 1; total <= 64; ++total)
+        {
+            int64_t previous = 101;
+            for (int64_t loaded = 0; loaded <= total; ++loaded)
+            {
+                const int r = App::download_percent_remaining(loaded, total);
+                INFO("loaded = ", loaded, " of ", total, " -> ", r);
+                CHECK(r >= 0);
+                CHECK(r <= 100);
+                CHECK(r <= previous); // never goes backwards as bytes arrive
+                CHECK((r == 0) == (loaded == total));
+                previous = r;
+            }
+        }
+    }
+
+    SUBCASE("a transfer larger than 32 bits does not overflow the percentage")
+    {
+        const int64_t huge = 8ll << 30;
+        CHECK(App::download_percent_remaining(0, huge) == 100);
+        CHECK(App::download_percent_remaining(huge / 2, huge) == 50);
+        CHECK(App::download_percent_remaining(huge, huge) == 0);
+    }
 }

--- a/tests/test_index_helpers.cpp
+++ b/tests/test_index_helpers.cpp
@@ -14,7 +14,6 @@
 
 #include <doctest/doctest.h>
 
-#include "app.h"
 #include "common.h"
 
 #include <algorithm>
@@ -185,34 +184,32 @@ TEST_CASE("download_percent_remaining reports a usable percentage for any byte c
     // The status bar draws its progress bar only while this is above zero, and computes the filled
     // fraction as (100 - remaining) / 100, so the value has to stay inside [0, 100], fall as bytes
     // arrive, and reach zero only when the transfer is actually complete.
-    using App = HDRViewApp;
-
     SUBCASE("a total the server has not reported yet cannot divide")
     {
         // Emscripten's progress callback can fire before the content length is known, and some servers
         // never send one. The previous form divided by this directly.
-        CHECK(App::download_percent_remaining(0, 0) == 100);
-        CHECK(App::download_percent_remaining(1234, 0) == 100);
-        CHECK(App::download_percent_remaining(0, -1) == 100);
+        CHECK(download_percent_remaining(0, 0) == 100);
+        CHECK(download_percent_remaining(1234, 0) == 100);
+        CHECK(download_percent_remaining(0, -1) == 100);
     }
 
     SUBCASE("the endpoints are exact")
     {
-        CHECK(App::download_percent_remaining(0, 1000) == 100);
-        CHECK(App::download_percent_remaining(1000, 1000) == 0);
+        CHECK(download_percent_remaining(0, 1000) == 100);
+        CHECK(download_percent_remaining(1000, 1000) == 0);
         // Over-reporting (more bytes than the declared total) still reads as finished, not negative.
-        CHECK(App::download_percent_remaining(1500, 1000) == 0);
+        CHECK(download_percent_remaining(1500, 1000) == 0);
     }
 
     SUBCASE("a partial transfer is neither 0 nor 100")
     {
         // Integer division sent all of these to zero, so the bar vanished the moment the first bytes
         // landed and the download appeared to finish instantly.
-        CHECK(App::download_percent_remaining(500, 1000) == 50);
-        CHECK(App::download_percent_remaining(250, 1000) == 75);
-        CHECK(App::download_percent_remaining(999, 1000) == 1);
+        CHECK(download_percent_remaining(500, 1000) == 50);
+        CHECK(download_percent_remaining(250, 1000) == 75);
+        CHECK(download_percent_remaining(999, 1000) == 1);
         // Rounded up, so a nearly-finished transfer still shows rather than disappearing early.
-        CHECK(App::download_percent_remaining(999999, 1000000) == 1);
+        CHECK(download_percent_remaining(999999, 1000000) == 1);
     }
 
     SUBCASE("the invariants hold across every small total and byte count")
@@ -222,7 +219,7 @@ TEST_CASE("download_percent_remaining reports a usable percentage for any byte c
             int64_t previous = 101;
             for (int64_t loaded = 0; loaded <= total; ++loaded)
             {
-                const int r = App::download_percent_remaining(loaded, total);
+                const int r = download_percent_remaining(loaded, total);
                 INFO("loaded = ", loaded, " of ", total, " -> ", r);
                 CHECK(r >= 0);
                 CHECK(r <= 100);
@@ -236,8 +233,8 @@ TEST_CASE("download_percent_remaining reports a usable percentage for any byte c
     SUBCASE("a transfer larger than 32 bits does not overflow the percentage")
     {
         const int64_t huge = 8ll << 30;
-        CHECK(App::download_percent_remaining(0, huge) == 100);
-        CHECK(App::download_percent_remaining(huge / 2, huge) == 50);
-        CHECK(App::download_percent_remaining(huge, huge) == 0);
+        CHECK(download_percent_remaining(0, huge) == 100);
+        CHECK(download_percent_remaining(huge / 2, huge) == 50);
+        CHECK(download_percent_remaining(huge, huge) == 0);
     }
 }

--- a/tests/test_loader_limits.cpp
+++ b/tests/test_loader_limits.cpp
@@ -16,7 +16,16 @@
 #include "imageio/raw.h"
 #include "imageio/stb.h"
 
+#include <miniz.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -72,13 +81,13 @@ std::string dds_header(uint32_t w, uint32_t h)
     v[1] = 'D';
     v[2] = 'S';
     v[3] = ' ';
-    put_le32(4, 124);      // dwSize
-    put_le32(8, 0x1007);   // caps | height | width | pixelformat
-    put_le32(12, h);       // dwHeight
-    put_le32(16, w);       // dwWidth
-    put_le32(76, 32);      // ddspf.dwSize
-    put_le32(80, 0x41);    // ddspf.dwFlags: RGB | alpha
-    put_le32(88, 32);      // ddspf.dwRGBBitCount
+    put_le32(4, 124);    // dwSize
+    put_le32(8, 0x1007); // caps | height | width | pixelformat
+    put_le32(12, h);     // dwHeight
+    put_le32(16, w);     // dwWidth
+    put_le32(76, 32);    // ddspf.dwSize
+    put_le32(80, 0x41);  // ddspf.dwFlags: RGB | alpha
+    put_le32(88, 32);    // ddspf.dwRGBBitCount
     put_le32(92, 0x00ff0000);
     put_le32(96, 0x0000ff00);
     put_le32(100, 0x000000ff);
@@ -120,12 +129,141 @@ std::string rejection_reason(Loader &&loader, const std::string &bytes, const ch
 }
 
 //! Whether \p reason is the dimension check's complaint rather than some later decode failure.
-bool blames_dimensions(const std::string &reason)
-{
-    return reason.find("implausibly large") != std::string::npos;
-}
+bool blames_dimensions(const std::string &reason) { return reason.find("implausibly large") != std::string::npos; }
 
 } // namespace
+
+namespace
+{
+
+//! A one-entry deflated zip holding `contents` under `name`.
+std::string make_zip(const std::string &name, const std::string &contents)
+{
+    mz_zip_archive zip;
+    memset(&zip, 0, sizeof(zip));
+    REQUIRE(mz_zip_writer_init_heap(&zip, 0, 0));
+    REQUIRE(mz_zip_writer_add_mem(&zip, name.c_str(), contents.data(), contents.size(), MZ_BEST_COMPRESSION));
+    void  *buf  = nullptr;
+    size_t size = 0;
+    REQUIRE(mz_zip_writer_finalize_heap_archive(&zip, &buf, &size));
+    std::string out(reinterpret_cast<char *>(buf), size);
+    mz_zip_writer_end(&zip);
+    return out;
+}
+
+/*!
+    Overwrites the uncompressed-size field in both of an entry's headers, leaving the stored bytes alone --
+    a zip whose directory claims far more than the archive is holding. Real-world equivalents are a
+    truncated or hand-edited archive and a deliberate decompression bomb; both reach the same code.
+
+    The field sits at offset 22 of a local file header (PK\3\4) and offset 24 of a central directory
+    header (PK\1\2).
+*/
+void declare_uncompressed_size(std::string &zip, uint32_t declared)
+{
+    auto patch_at = [&](const char *sig, size_t field_offset)
+    {
+        size_t pos = zip.find(sig, 0, 4);
+        REQUIRE(pos != std::string::npos);
+        for (int b = 0; b < 4; ++b) zip[pos + field_offset + b] = char((declared >> (8 * b)) & 0xff);
+    };
+    patch_at("PK\x03\x04", 22);
+    patch_at("PK\x01\x02", 24);
+}
+
+//! Collects everything logged while it is in scope, so a test can assert that a call site was reached.
+/*!
+    The guard's only observable effect is that the extraction is not attempted: an archive lying about an
+    entry's size fails to extract either way, just with a large allocation and a decompression first. So the
+    warning is what distinguishes "refused up front" from "tried and failed", and the log is where it shows.
+*/
+struct LogCapture
+{
+    struct Sink : spdlog::sinks::base_sink<std::mutex>
+    {
+        std::vector<std::string> messages;
+        void                     sink_it_(const spdlog::details::log_msg &msg) override
+        {
+            messages.emplace_back(msg.payload.data(), msg.payload.size());
+        }
+        void flush_() override {}
+    };
+
+    std::shared_ptr<Sink> sink = std::make_shared<Sink>();
+
+    LogCapture() { spdlog::default_logger()->sinks().push_back(sink); }
+    ~LogCapture()
+    {
+        auto &sinks = spdlog::default_logger()->sinks();
+        sinks.erase(std::remove(sinks.begin(), sinks.end(), sink), sinks.end());
+    }
+
+    bool saw(const std::string &substring) const
+    {
+        return std::any_of(sink->messages.begin(), sink->messages.end(),
+                           [&](const std::string &m) { return m.find(substring) != std::string::npos; });
+    }
+};
+
+} // namespace
+
+TEST_CASE("A zip entry declaring more than the archive holds is skipped before it is allocated for")
+{
+    // Same reasoning as the image headers above, one layer out: an entry is read whole into memory, sized
+    // from what the archive's directory claims. A claim the stored bytes cannot back costs that memory --
+    // and the decompression time to fill it -- before anything discovers it is not an image.
+    const std::string manifest = R"({"type": "HDRView session"})";
+
+    SUBCASE("an honest archive is untouched")
+    {
+        const std::string zip = make_zip("manifest.json", manifest);
+
+        auto found = zip_root_entries_with_suffix(zip, ".json");
+        REQUIRE(found.size() == 1);
+        CHECK(found[0].first == "manifest.json");
+        CHECK(found[0].second == manifest);
+
+        auto one = zip_extract_entry(zip, "manifest.json");
+        REQUIRE(one.has_value());
+        CHECK(*one == manifest);
+    }
+
+    SUBCASE("a ratio no deflate stream could produce is refused before extraction is attempted")
+    {
+        std::string zip = make_zip("manifest.json", manifest);
+        // Well past deflate's 1032:1 ceiling, but small enough that a build without the guard merely wastes
+        // the allocation instead of exhausting the machine -- vector<char>(n) zero-fills, so the pages are
+        // really touched.
+        declare_uncompressed_size(zip, 64u << 20);
+
+        {
+            LogCapture log;
+            CHECK(zip_root_entries_with_suffix(zip, ".json").empty());
+            CHECK(log.saw("Skipping zip entry 'manifest.json'"));
+        }
+        {
+            LogCapture log;
+            CHECK_FALSE(zip_extract_entry(zip, "manifest.json").has_value());
+            CHECK(log.saw("Skipping zip entry 'manifest.json'"));
+        }
+    }
+
+    SUBCASE("the ratio and the absolute bound are both enforced, and neither rejects a real entry")
+    {
+        // Plausible: an ordinary entry, and one compressed as hard as deflate can manage.
+        CHECK(zip_entry_size_is_plausible(1024, 512, "ordinary"));
+        CHECK(zip_entry_size_is_plausible(1032 * 4096, 4096, "maximally compressible"));
+        // A stored (ratio 1) entry of any workable size, and an empty one.
+        CHECK(zip_entry_size_is_plausible(64 * 1024 * 1024, 64 * 1024 * 1024, "stored"));
+        CHECK(zip_entry_size_is_plausible(0, 2, "empty"));
+
+        // Beyond what deflate can expand to, however large the archive says it is.
+        CHECK_FALSE(zip_entry_size_is_plausible(1033 * 4096, 4096, "past the ratio"));
+        CHECK_FALSE(zip_entry_size_is_plausible(1ull << 40, 8, "wildly past the ratio"));
+        // And an honestly-compressible bomb, which the ratio test alone would let through.
+        CHECK_FALSE(zip_entry_size_is_plausible(8ull << 30, 8ull << 20, "decompression bomb"));
+    }
+}
 
 TEST_CASE("check_image_dimensions accepts real sizes and rejects degenerate ones")
 {


### PR DESCRIPTION
The layer nobody had hunted. Hunts [#187](https://github.com/wkjarosz/hdrview/pull/187) and
[#191](https://github.com/wkjarosz/hdrview/pull/191) hunt what a decoder does with bytes,
[#193](https://github.com/wkjarosz/hdrview/pull/193) what a writer emits, and
[#194](https://github.com/wkjarosz/hdrview/pull/194) what the GPU shows. This is the machinery around all
of them: which files get decoded, when, on what thread, whose lifetime they share, and what happens when
the disk changes underneath. `BackgroundImageLoader` and the `app-file-io.cpp` plumbing had been touched
only at their edges — #187 reordered the loader *table*, never the async part.

Five bugs, each verified by reverting its fix individually and watching a specific assertion fail.

## Watching

**"Add watched folder…" was cancelled by closing any image.** Its documented purpose is watching a folder
you have *not* opened — *"Do not load the selected folder, but monitor it for new files and load those as
they are created."* So no loaded image ever lives in it, and `close_image()` prunes with "drop every
directory that is not the parent of some loaded image", which is always true of one. Point HDRView at a
folder renders are being written to, close an unrelated image, and the watch is silently gone. Closing all
images took it too. Nothing in the loader recorded *how* a directory came to be watched, so nothing could
tell the two apart.

An explicit watch is now removed only by the X button beside it in the watched-folders table. Keeping the
directory in `m_directories` rather than tracking survivors separately is load-bearing: the same pruning
trims `m_existing_files` to files under a still-watched directory, and that set is what stops the watcher
treating already-known files as new — a directory kept without its file list would re-load everything in
it on the next 250 ms poll.

## Reloading

**A reload could duplicate an image, or bring back one you had closed.** An arrival is matched to its slot
by pointer identity, and identity goes stale two ways.

Two reloads in flight at once: the watch loop schedules one on every timestamp change and polls four times
a second, so a file being written repeatedly outruns the load — and "Reload all images" pressed twice does
it too. The first arrival replaces the image, so the second cannot find what it was told to replace and
lands as a second copy. The list then holds an outdated *and* a current version of one path, and every
later reload of either adds another. Queued replacements are now re-pointed at whatever took their
target's place.

The same missing target with the opposite right answer: an image closed while its reload was in flight has
no slot to fill, and appending puts back what was just closed. Those are dropped — which is only safe
because exactly one arrival per load now claims the slot, so a later part of a multi-part file can never
be mistaken for an arrival whose slot has gone.

`get_loaded_images()` also stops running callbacks from inside a `remove_if` over the list it is pruning.

## Zip archives

**Entries were allocated from their declared uncompressed size, unvalidated**, at all three extraction
sites — reachable from opening a `.zip`, dropping one on the window, and scanning one for a session
manifest. #187 closed this for image headers; the zip layer one level out was never covered.
`std::vector<char> buffer(n)` value-initializes, so the pages are really touched: overcommit does not
soften this into reserved address space.

Two bounds, because neither catches the other's case. Deflate cannot expand data by more than 1032:1, so a
larger ratio is a claim the archive's own stored bytes cannot back — sound, in that it never rejects a real
entry, and the same reasoning #187 used to bound the raw loader by pixels per byte. That leaves the honest
bomb, whose ratio is achievable and whose data really is there, so an absolute cap covers what the ratio
cannot.

## Buffers and paths

**An empty buffer was indistinguishable from no buffer.** `background_load()` decided where to read from by
asking whether the buffer was empty, so a zero-byte zip entry fell through to "open this path" — against a
name assembled for display (`archive.zip/inside.png`) that no filesystem has. The complaint was that a file
did not exist, about a file that was never meant to. It is a `std::optional` now.

**The Emscripten download progress could not report a percentage, and could divide by zero doing it.**
`(total_bytes - bytes_loaded) / total_bytes` is integer division, so every partial fraction came out zero
and the bar — drawn only while the value is above zero — vanished as soon as the first bytes arrived. When
the total is zero, which a server sending no content length reports and which the callback can also see
before the headers land, it divided by it. Nothing reset the value on success either; that was hidden only
by the division already forcing it to zero.

**A folder entered Open Recent whether or not it opened anything** — before anything in it had been read,
and even when the directory could not be listed at all, whose `error_code` was passed in and never
examined. Every other path is careful about this: a file is dropped from the list and only put back once a
load succeeds, and a zip is added only if an entry was scheduled.

## Verification

152/152 `ctest`, 48 GUI tests. Every fix was confirmed to fail its test when reverted on its own, which
mattered more than usual here:

- The first zip test was a **tautology** — an archive lying about a size fails to extract either way, just
  with the allocation and a decompression first, so the returned value is identical. Only the resource use
  differs. It now captures the log through a scoped sink, which distinguishes "refused up front" from
  "tried and failed"; unwiring any of the three call sites fails it, while the value-only form passed.
- A multipart test **claimed a regression it could not catch**. Instrumenting the loader showed why: an
  initial multi-part load yields ten images with no replacement, but a reload yields exactly one, since it
  carries the part's own channel selector. The multi-image-plus-replacement case never arises. The split is
  kept — it is what makes the drop rule safe — but described as the contract it is rather than a fix for an
  unreachable bug.

The download arithmetic moved with its test. It took no `this` and touched no member state, and sat on
`HDRViewApp` only so the test could reach it — which is what made it public. It is a free function in
`common.h` now, where `shorten_names()` went for this same reason and where `next_matching_index()`, which
the very same test file exercises, already lived. `tests/test_index_helpers.cpp` drops `app.h` entirely as a
result: that call was the only thing pulling the whole app header into a test of arithmetic.

Tests fold into their existing homes: the zip bounds into `tests/test_loader_limits.cpp`, which #187
created for exactly this class; the download arithmetic into `tests/test_index_helpers.cpp` alongside the
other small pure helpers, checked across every total up to 64 rather than at sampled points; the multi-part
reload case into `tests/gui/test_gui_multipart.cpp`. Only the watching and archive behaviour needed a new
file. Each test is broader than its bug — the watch one also proves an *implicitly* watched folder is still
dropped when its last image closes, so the fix cannot degrade into pinning everything.

The Emscripten toolchain earned its keep: it caught `hdrview_loadfile()` in `platform_utils.cpp`, the
browser drag-and-drop entry point, which the native build never compiles.

## Swept and clean

Recorded because it bounds where the remaining risk is not: the pending-session interaction (already
hardened by #189/#191, and undisturbed by the `get_loaded_images()` restructure — nothing reads
`num_pending_images()` from inside a callback); Open Recent's indexing, consistent across the File menu and
the command palette despite different truncation widths; and `Image::loadable()`, which handles case and
the leading period correctly.

One use-after-free was chased and discarded: `~TaskTracker` unbinds without waiting, and `PendingImages`
destroys `images` before `computation` — the same shape as #187's `~Channel` bug. Unreachable, because
`get_loaded_images()` only erases entries that are `ready()` and the app singleton is never deleted.

