### PR TITLE
Seventh bug hunt: two XMP and EXR files that never reached the screen, and four more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1659,7 +1659,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_xmp.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1659,7 +1659,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_xmp.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_xmp.cpp tests/test_exif.cpp
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -455,8 +455,8 @@ void PixelStats::calculate(const Channel &img, const Channel *alpha, int2 img_da
             Partial total;
             for (const auto &p : partials)
             {
-                summary.minimum = std::min(p.minimum, summary.minimum);
-                summary.maximum = std::max(p.maximum, summary.maximum);
+                summary.minimum         = std::min(p.minimum, summary.minimum);
+                summary.maximum         = std::max(p.maximum, summary.maximum);
                 summary.extreme_minimum = std::min(p.extreme_minimum, summary.extreme_minimum);
                 summary.extreme_maximum = std::max(p.extreme_maximum, summary.extreme_maximum);
                 summary.nan_pixels += p.nan_pixels;
@@ -557,8 +557,7 @@ void PixelStats::calculate(const Channel &img, const Channel *alpha, int2 img_da
                         if (!std::isfinite(val) || is_marker(val)) //< the summary counts these instead
                             continue;
 
-                        for (int s = 0; s < AxisScale_COUNT; ++s)
-                            ++bins[s][clamp_idx(value_to_bin(val, (AxisScale)s))];
+                        for (int s = 0; s < AxisScale_COUNT; ++s) ++bins[s][clamp_idx(value_to_bin(val, (AxisScale)s))];
                     }
                 },
                 (int)num_threads);
@@ -1187,56 +1186,67 @@ void Image::finalize()
 
     // Centralized XMP parsing: if loaders stored raw XMP into image->xmp_data or into exif metadata,
     // parse it once here and populate metadata["xmp"] with structured JSON.
-    if (!metadata.contains("xmp"))
+    // XMP decorates an image; it does not describe its pixels. Anything thrown while deriving it -- by the
+    // parser, or by a JSON value not having the type this code reads it as -- costs the metadata and
+    // nothing else. Without this it left finalize() and the image never arrived.
+    try
     {
-        // spdlog::warn("XMP metadata not yet parsed; attempting to parse from raw data.");
-        if (metadata.contains("exif") && metadata["exif"].is_object())
+        if (!metadata.contains("xmp"))
         {
-            // Check EXIF entries for raw XMP stored by exif parser (tag 700)
-            for (auto &it : metadata["exif"].items())
+            // spdlog::warn("XMP metadata not yet parsed; attempting to parse from raw data.");
+            if (metadata.contains("exif") && metadata["exif"].is_object())
             {
-                auto &v = it.value();
-                if (!v.is_object())
-                    continue;
-
-                if (v.contains("XMP Metadata") && v["XMP Metadata"].is_object() && v["XMP Metadata"].contains("value"))
+                // Check EXIF entries for raw XMP stored by exif parser (tag 700)
+                for (auto &it : metadata["exif"].items())
                 {
-                    std::string s = v["XMP Metadata"]["value"].get<std::string>();
-                    if (s.find("http://ns.adobe.com/xap/1.0/") != std::string::npos ||
-                        s.find("x:xmpmeta") != std::string::npos || s.find("<?xpacket") != std::string::npos)
+                    auto &v = it.value();
+                    if (!v.is_object())
+                        continue;
+
+                    if (v.contains("XMP Metadata") && v["XMP Metadata"].is_object() &&
+                        v["XMP Metadata"]["value"].is_string())
                     {
-                        if (xmp_data.empty())
+                        std::string s = v["XMP Metadata"]["value"].get<std::string>();
+                        if (s.find("http://ns.adobe.com/xap/1.0/") != std::string::npos ||
+                            s.find("x:xmpmeta") != std::string::npos || s.find("<?xpacket") != std::string::npos)
                         {
-                            xmp_data.assign(s.begin(), s.end());
-                            spdlog::debug("Reading XMP data from EXIF XMP Metadata tag.");
+                            if (xmp_data.empty())
+                            {
+                                xmp_data.assign(s.begin(), s.end());
+                                spdlog::debug("Reading XMP data from EXIF XMP Metadata tag.");
+                            }
+                            else
+                            {
+                                spdlog::warn("Image contains both xpacket XMP data ({} bytes) and an XMP EXIF tag; "
+                                             "prioritizing xpacket buffer.",
+                                             xmp_data.size());
+                            }
+                            break;
                         }
-                        else
-                        {
-                            spdlog::warn("Image contains both xpacket XMP data ({} bytes) and an XMP EXIF tag; "
-                                         "prioritizing xpacket buffer.",
-                                         xmp_data.size());
-                        }
-                        break;
                     }
                 }
             }
-        }
 
-        if (!xmp_data.empty())
-        {
-            spdlog::debug("Parsing XMP from {} byte buffer:\n{}", xmp_data.size(),
-                          std::string(reinterpret_cast<const char *>(xmp_data.data()), xmp_data.size()));
-            Xmp xmp(reinterpret_cast<const char *>(xmp_data.data()), xmp_data.size());
-            if (xmp.valid())
+            if (!xmp_data.empty())
             {
-                spdlog::debug("Successfully parsed XMP metadata.");
-                metadata["xmp"] = xmp.to_json();
-            }
-            else
-            {
-                spdlog::warn("Failed to parse XMP metadata from raw xmp_data buffer.");
+                spdlog::debug("Parsing XMP from {} byte buffer:\n{}", xmp_data.size(),
+                              std::string(reinterpret_cast<const char *>(xmp_data.data()), xmp_data.size()));
+                Xmp xmp(reinterpret_cast<const char *>(xmp_data.data()), xmp_data.size());
+                if (xmp.valid())
+                {
+                    spdlog::debug("Successfully parsed XMP metadata.");
+                    metadata["xmp"] = xmp.to_json();
+                }
+                else
+                {
+                    spdlog::warn("Failed to parse XMP metadata from raw xmp_data buffer.");
+                }
             }
         }
+    }
+    catch (const std::exception &e)
+    {
+        spdlog::warn("Could not read this image's XMP metadata: {}. Loading it without.", e.what());
     }
 
     // sanity check all channels have the same size as the data window

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -235,6 +235,12 @@ void           Exif::reset() { m_impl.reset(); }
 size_t         Exif::size() const { return m_impl ? m_impl->data.size() : 0; }
 const uint8_t *Exif::data() const { return m_impl ? m_impl->data.data() : nullptr; }
 
+// Declared in exif.h, where the reasoning behind the subtraction lives.
+bool maker_note_range_within(uint32_t offset, uint32_t size, uint32_t bound)
+{
+    return offset <= bound && size <= bound - offset;
+}
+
 //! Walk the entries of an Apple maker note, which libexif has no decoder for.
 /*!
     The note is a TIFF-style IFD preceded by a 12-byte "Apple iOS" header, with its own byte order and
@@ -247,6 +253,7 @@ const uint8_t *Exif::data() const { return m_impl ? m_impl->data.data() : nullpt
     \return       False when the note is Apple's but too short to hold the entries it claims; true
                   otherwise, including when there is no Apple maker note to walk.
 */
+
 template <typename F>
 static bool for_each_apple_makernote_entry(ExifData *ed, F &&visit)
 {
@@ -327,10 +334,10 @@ static bool for_each_apple_makernote_entry(ExifData *ed, F &&visit)
 
         // if the data fits in 4 bytes, it sits at location 8, otherwise location 8 stores a 32-bit offset
         // to where the data is
-        size_t entry_offset = (entry_size > 4) ? read_as<uint32_t>(mn_data + ofs + 8, endian) : (ofs + 8);
-        if (entry_offset + entry_size > mn_size)
+        uint32_t entry_offset = (entry_size > 4) ? read_as<uint32_t>(mn_data + ofs + 8, endian) : uint32_t(ofs + 8);
+        if (!maker_note_range_within(entry_offset, entry_size, uint32_t(mn_size)))
         {
-            spdlog::warn("skipping");
+            spdlog::warn("ExifMnoteApple: tag 0x{:04x} points outside the maker note; skipping.", tag);
             continue;
         }
 

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring> // for memcmp
+#include <cstring>  // for memcmp
 #include <iterator> // for std::size
 #include <libexif/exif-byte-order.h>
 #include <libexif/exif-data.h>
@@ -582,7 +582,19 @@ json Exif::to_json() const
             }
 
             spdlog::debug("Exif::to_json: Processing entry {} (tag 0x{:04x}) in IFD {}", i, (int)entry->tag, ifd_idx);
-            ifd_json.update(entry_to_json(entry, exif_data_get_byte_order(ed), ifd_idx));
+
+            // One tag is not worth the rest of them. entry_to_json() names a tag's value by reading it back
+            // out of JSON as the scalar the tag number implies -- at forty-odd sites, none of which the file
+            // is obliged to agree with -- and the throw would otherwise leave this loop, abandoning every
+            // tag in the image including the ones already decoded.
+            try
+            {
+                ifd_json.update(entry_to_json(entry, exif_data_get_byte_order(ed), ifd_idx));
+            }
+            catch (const std::exception &e)
+            {
+                spdlog::warn("Skipping EXIF tag 0x{:04x} in {}: {}.", (int)entry->tag, ExifIfdTable[ifd_idx], e.what());
+            }
         }
     }
 

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -138,6 +138,14 @@ struct Exif::Impl
     vector<uint8_t>                                       data;
     std::unique_ptr<ExifData, decltype(&exif_data_unref)> exif_data{nullptr, &exif_data_unref};
     std::unique_ptr<ExifLog, decltype(&exif_log_unref)>   exif_log{nullptr, &exif_log_unref};
+
+    //! Set by the log callback below, which libexif keeps calling for as long as exif_log lives.
+    /*!
+        It must therefore live that long too. The callback fires well after loading -- reading an entry's
+        value logs, so exif_entry_get_value() during to_json() reaches it -- and a flag local to the
+        constructor would by then be a dead stack slot.
+    */
+    bool load_error = false;
 };
 
 Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<Impl>())
@@ -161,8 +169,6 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
             m_impl->data.assign(data_ptr, data_ptr + data_size);
 
         // 2) Create ExifData and ExifLog with custom log function
-        bool error = false;
-
         m_impl->exif_data = std::unique_ptr<ExifData, decltype(&exif_data_unref)>(exif_data_new(), &exif_data_unref);
         if (!m_impl->exif_data)
             throw std::invalid_argument("Failed to allocate ExifData.");
@@ -191,14 +197,14 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
                     break;
                 }
             },
-            &error);
+            &m_impl->load_error);
 
         exif_data_log(m_impl->exif_data.get(), m_impl->exif_log.get());
 
         // 3) Load the EXIF data from memory buffer
         exif_data_load_data(m_impl->exif_data.get(), m_impl->data.data(), (unsigned)m_impl->data.size());
 
-        if (error)
+        if (m_impl->load_error)
             spdlog::warn("There were errors while loading EXIF data, but trying to continue.");
 
         if (!m_impl->exif_data)

--- a/src/imageio/exif.h
+++ b/src/imageio/exif.h
@@ -10,6 +10,16 @@
 #include <cstdint>
 #include <optional>
 
+/*!
+    Whether a maker-note tag's [offset, offset + size) lies inside a note of \p bound bytes.
+
+    All three are 32-bit fields read straight out of the file, so the arithmetic is 32-bit by nature and
+    adding the first two can wrap. Widening to size_t hides that only where size_t is wider -- not on the
+    wasm32 build, where an offset near 4 GB wrapped past the check and the read landed outside the note.
+    Compared by subtraction instead, which cannot wrap at any width.
+*/
+bool maker_note_range_within(uint32_t offset, uint32_t size, uint32_t bound);
+
 json        entry_to_json(void *entry, int boi, unsigned int ifd_idx_i = 0);
 json        exif_to_json(const uint8_t *data_ptr, size_t data_size);
 inline json exif_to_json(const std::vector<uint8_t> &data) { return exif_to_json(data.data(), data.size()); }

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -305,7 +305,6 @@ json attribute_to_json(const Imf::Attribute &a)
     }
     if (const auto *ta = dynamic_cast<const Imf::RationalAttribute *>(&a))
     {
-        j["value"]["numerator"]   = ta->value().n / ta->value().d;
         j["value"]["numerator"]   = ta->value().n;
         j["value"]["denominator"] = ta->value().d;
         j["string"] = fmt::format("{}/{} ({})", ta->value().n, ta->value().d, static_cast<double>(ta->value()));

--- a/src/imageio/psd.cpp
+++ b/src/imageio/psd.cpp
@@ -1,5 +1,6 @@
 #include "psd.h"
 #include <cstring>
+#include <spdlog/spdlog.h>
 
 static uint16_t read_uint16_be(std::istream &stream)
 {
@@ -112,9 +113,18 @@ void PSDMetadata::read(std::istream &stream)
         // Read resource data size
         uint32_t data_size = read_uint32_be(stream);
 
-        // Sanity check
-        if (data_size > 100 * 1024 * 1024) // 100MB limit
-            throw std::runtime_error("Resource data size too large");
+        // A resource lives inside the Image Resources section, so it cannot be larger than what is left of
+        // it. Without this the read runs on into the layer and pixel data that follows, and whatever it
+        // picks up is handed onwards as this image's XMP, EXIF or ICC profile -- and a block declaring
+        // megabytes is allocated for before the stream reports it has run out.
+        const std::streamoff remaining = section_end - stream.tellg();
+        if (remaining < 0 || data_size > uint64_t(remaining))
+        {
+            spdlog::warn("PSD resource 0x{:04x} claims {} bytes, more than the {} left in the image "
+                         "resources section; ignoring the rest of the section.",
+                         resource_id, data_size, remaining < 0 ? 0 : remaining);
+            break;
+        }
 
         // Extract metadata based on resource ID
         if (resource_id == 1028 && iptc.empty()) // IPTC-NAA

--- a/src/imageio/xmp.cpp
+++ b/src/imageio/xmp.cpp
@@ -75,6 +75,25 @@ static std::string_view extract_XMP_content(const string &xmp_blob)
     return sv.substr(first, last - first + 1);
 }
 
+//! Stores `value` under `prefix`.`local`, without assuming what may already be at `prefix`.
+/*!
+    Both loops below group a prefixed name into a nested object. Nothing guarantees the prefix is free:
+    an unprefixed attribute of the same name may already have put a plain string there, and indexing into
+    that throws -- out of Image::finalize(), which parses XMP with nothing catching around the call, so a
+    packet HDRView disliked cost the whole image. Fall back to the flat "prefix:local" key, which collides
+    with nothing and keeps both values.
+*/
+static void assign_prefixed(json &result, const std::string &prefix, const std::string &local, json value)
+{
+    if (!result.contains(prefix))
+        result[prefix] = json::object();
+
+    if (result[prefix].is_object())
+        result[prefix][local] = std::move(value);
+    else
+        result[prefix + ":" + local] = std::move(value);
+}
+
 json parse_xml_element(const XMLElement *element, const std::string &parent_ns = "")
 {
     json result;
@@ -97,6 +116,15 @@ json parse_xml_element(const XMLElement *element, const std::string &parent_ns =
     {
         std::string attr_name  = attr->Name();
         std::string attr_value = attr->Value();
+        // Namespace declarations describe the document, not the image. add_xmlns_entries() collects them
+        // into their own table; storing them here as well duplicated that, and a default declaration
+        // (plain "xmlns", no colon) landed as a string under the same key that "xmlns:dc" then wanted to
+        // index into as an object.
+        if (attr_name == "xmlns" || attr_name.rfind("xmlns:", 0) == 0)
+        {
+            attr = attr->Next();
+            continue;
+        }
         // Special-case: preserve the full "xml:lang" key and value instead of
         // splitting into namespace/object. This keeps language tags as plain
         // key/value pairs in the resulting JSON.
@@ -118,11 +146,7 @@ json parse_xml_element(const XMLElement *element, const std::string &parent_ns =
                 if (ns_prefix == current_ns && !current_ns.empty())
                     result[local_name] = attr_value;
                 else
-                {
-                    if (!result.contains(ns_prefix))
-                        result[ns_prefix] = json::object();
-                    result[ns_prefix][local_name] = attr_value;
-                }
+                    assign_prefixed(result, ns_prefix, local_name, attr_value);
             }
             else
                 result[attr_name] = attr_value;
@@ -222,11 +246,7 @@ json parse_xml_element(const XMLElement *element, const std::string &parent_ns =
             if (ns_prefix == current_ns && !current_ns.empty())
                 result[local_name] = child_json;
             else
-            {
-                if (!result.contains(ns_prefix))
-                    result[ns_prefix] = json::object();
-                result[ns_prefix][local_name] = child_json;
-            }
+                assign_prefixed(result, ns_prefix, local_name, child_json);
         }
         else
         {

--- a/tests/test_exif.cpp
+++ b/tests/test_exif.cpp
@@ -160,3 +160,24 @@ TEST_CASE("One tag the file describes oddly does not discard the rest of the EXI
         CHECK(has_tag_named(j, "Manufacturer"));
     }
 }
+
+TEST_CASE("A maker-note tag's range is bounded without the arithmetic wrapping")
+{
+    // Ranges that genuinely fit, including the empty and exactly-full ones.
+    CHECK(maker_note_range_within(0, 0, 0));
+    CHECK(maker_note_range_within(0, 100, 100));
+    CHECK(maker_note_range_within(90, 10, 100));
+    CHECK(maker_note_range_within(100, 0, 100));
+
+    // Ranges that do not.
+    CHECK_FALSE(maker_note_range_within(91, 10, 100));
+    CHECK_FALSE(maker_note_range_within(101, 0, 100));
+    CHECK_FALSE(maker_note_range_within(0, 101, 100));
+
+    // And the ones the file gets to choose: an offset high enough that adding the size wraps back into
+    // range. Checked by adding, these read as "fits" -- which is what happens where size_t is 32 bits
+    // wide, as it is in the wasm build.
+    CHECK_FALSE(maker_note_range_within(0xFFFFFFF8u, 32u, 100u));
+    CHECK_FALSE(maker_note_range_within(0xFFFFFFFFu, 1u, 100u));
+    CHECK_FALSE(maker_note_range_within(0x80000000u, 0x80000000u, 100u));
+}

--- a/tests/test_exif.cpp
+++ b/tests/test_exif.cpp
@@ -1,0 +1,162 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+// exif.cpp reads a tag's decoded value back out of JSON to build the human-readable string beside it --
+// value["value"].get<int>() and friends, at forty-odd sites. Each assumes the tag holds the scalar its
+// number implies. A file is free to disagree.
+
+#include <doctest/doctest.h>
+
+#include "imageio/exif.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+//! Builds a little-endian TIFF header with one IFD0, which is what an EXIF block is.
+struct TiffBuilder
+{
+    struct Entry
+    {
+        uint16_t             tag, format;
+        uint32_t             components;
+        std::vector<uint8_t> inline_or_external; //!< the 4 inline bytes, or the payload to place after the IFD
+        bool                 external = false;
+    };
+
+    std::vector<Entry> entries;
+
+    void add_inline(uint16_t tag, uint16_t format, uint32_t components, std::vector<uint8_t> four_bytes)
+    {
+        four_bytes.resize(4, 0);
+        entries.push_back({tag, format, components, std::move(four_bytes), false});
+    }
+    void add_external(uint16_t tag, uint16_t format, uint32_t components, std::vector<uint8_t> payload)
+    {
+        entries.push_back({tag, format, components, std::move(payload), true});
+    }
+
+    std::vector<uint8_t> build() const
+    {
+        std::vector<uint8_t> out;
+        auto                 u16 = [&](uint16_t v) { out.insert(out.end(), {uint8_t(v & 0xff), uint8_t(v >> 8)}); };
+        auto                 u32 = [&](uint32_t v)
+        {
+            for (int i = 0; i < 4; ++i) out.push_back(uint8_t((v >> (8 * i)) & 0xff));
+        };
+
+        out.insert(out.end(), {'I', 'I'});
+        u16(42);
+        u32(8); // IFD0 starts right after the header
+
+        // count + 12 bytes per entry + the next-IFD offset; external payloads follow
+        const uint32_t ifd_end    = 8 + 2 + 12 * (uint32_t)entries.size() + 4;
+        uint32_t       payload_at = ifd_end;
+
+        u16((uint16_t)entries.size());
+        for (const auto &e : entries)
+        {
+            u16(e.tag);
+            u16(e.format);
+            u32(e.components);
+            if (e.external)
+            {
+                u32(payload_at);
+                payload_at += (uint32_t)e.inline_or_external.size();
+            }
+            else
+                out.insert(out.end(), e.inline_or_external.begin(), e.inline_or_external.end());
+        }
+        u32(0); // no IFD1
+
+        for (const auto &e : entries)
+            if (e.external)
+                out.insert(out.end(), e.inline_or_external.begin(), e.inline_or_external.end());
+
+        return out;
+    }
+};
+
+constexpr uint16_t k_tag_make = 0x010f, k_tag_compression = 0x0103, k_tag_orientation = 0x0112;
+constexpr uint16_t k_fmt_byte = 1, k_fmt_ascii = 2, k_fmt_short = 3;
+
+json parse(const std::vector<uint8_t> &blob) { return exif_to_json(blob.data(), blob.size()); }
+
+//! Whether any IFD in the result holds a tag with this title.
+bool has_tag_named(const json &j, const std::string &title)
+{
+    for (auto &[ifd, tags] : j.items())
+        if (tags.is_object() && tags.contains(title))
+            return true;
+    return false;
+}
+
+} // namespace
+
+TEST_CASE("An EXIF block with an ordinary tag decodes it")
+{
+    // Baseline, so a change that stops EXIF parsing entirely cannot pass as one that hardens it.
+    TiffBuilder t;
+    t.add_external(k_tag_make, k_fmt_ascii, 8, {'H', 'D', 'R', 'V', 'i', 'e', 'w', 0});
+    const json j = parse(t.build());
+
+    REQUIRE(j.is_object());
+    REQUIRE(has_tag_named(j, "Manufacturer"));
+}
+
+TEST_CASE("One tag the file describes oddly does not discard the rest of the EXIF block")
+{
+    // Compression is read back as a single int to name it ("Uncompressed", "JPEG", ...). Declaring two
+    // components makes the decoded value an array, and .get<int>() on an array throws -- out of
+    // entry_to_json(), out of the IFD loop, out of to_json(). Every loader wraps that call, so the throw
+    // costs not just this tag but every tag in the file.
+    SUBCASE("a scalar tag carrying an array")
+    {
+        TiffBuilder t;
+        t.add_external(k_tag_make, k_fmt_ascii, 8, {'H', 'D', 'R', 'V', 'i', 'e', 'w', 0});
+        t.add_inline(k_tag_compression, k_fmt_short, 2, {1, 0, 6, 0});
+
+        json j;
+        CHECK_NOTHROW(j = parse(t.build()));
+        CHECK(has_tag_named(j, "Manufacturer"));
+    }
+
+    SUBCASE("a scalar tag carrying text")
+    {
+        TiffBuilder t;
+        t.add_external(k_tag_make, k_fmt_ascii, 8, {'H', 'D', 'R', 'V', 'i', 'e', 'w', 0});
+        t.add_external(k_tag_compression, k_fmt_ascii, 4, {'n', 'o', 'n', 'e'});
+
+        json j;
+        CHECK_NOTHROW(j = parse(t.build()));
+        CHECK(has_tag_named(j, "Manufacturer"));
+    }
+
+    SUBCASE("a tag with no components at all")
+    {
+        TiffBuilder t;
+        t.add_external(k_tag_make, k_fmt_ascii, 8, {'H', 'D', 'R', 'V', 'i', 'e', 'w', 0});
+        t.add_inline(k_tag_orientation, k_fmt_short, 0, {0, 0, 0, 0});
+
+        json j;
+        CHECK_NOTHROW(j = parse(t.build()));
+        CHECK(has_tag_named(j, "Manufacturer"));
+    }
+
+    SUBCASE("a tag whose format is not one EXIF defines")
+    {
+        TiffBuilder t;
+        t.add_external(k_tag_make, k_fmt_ascii, 8, {'H', 'D', 'R', 'V', 'i', 'e', 'w', 0});
+        t.add_inline(k_tag_compression, 999, 1, {1, 0, 0, 0});
+
+        json j;
+        CHECK_NOTHROW(j = parse(t.build()));
+        CHECK(has_tag_named(j, "Manufacturer"));
+    }
+}

--- a/tests/test_exr_io.cpp
+++ b/tests/test_exr_io.cpp
@@ -18,6 +18,7 @@
 #include <ImfFrameBuffer.h>
 #include <ImfHeader.h>
 #include <ImfOutputFile.h>
+#include <ImfRationalAttribute.h>
 #include <ImfStdIO.h>
 
 #ifdef HDRVIEW_TEST_OPENEXR_DIR
@@ -105,11 +106,11 @@ TEST_CASE("EXR load respects channel_selector, including selectors matching noth
     SUBCASE("selecting a single channel")
     {
         std::ostringstream out(std::ios::binary);
-        auto                opts = exr_default_save_options(*img);
+        auto               opts = exr_default_save_options(*img);
         save_exr_image(*img, out, "test.exr", &opts);
 
-        std::istringstream    in(out.str(), std::ios::binary);
-        ImageLoadOptions       load_opts;
+        std::istringstream in(out.str(), std::ios::binary);
+        ImageLoadOptions   load_opts;
         load_opts.channel_selector = "R";
         auto reloaded              = load_exr_image(in, "test.exr", load_opts);
 
@@ -146,11 +147,11 @@ TEST_CASE("EXR load respects channel_selector, including selectors matching noth
     SUBCASE("selector matching no channels yields no images")
     {
         std::ostringstream out(std::ios::binary);
-        auto                opts = exr_default_save_options(*img);
+        auto               opts = exr_default_save_options(*img);
         save_exr_image(*img, out, "test.exr", &opts);
 
-        std::istringstream    in(out.str(), std::ios::binary);
-        ImageLoadOptions       load_opts;
+        std::istringstream in(out.str(), std::ios::binary);
+        ImageLoadOptions   load_opts;
         load_opts.channel_selector = "NoSuchChannel";
         auto reloaded              = load_exr_image(in, "test.exr", load_opts);
 
@@ -195,14 +196,14 @@ TEST_CASE("EXR save/load precision depends on the chosen pixel type")
 
     SUBCASE("HALF (default)")
     {
-        auto opts        = exr_default_save_options(*img);
-        opts.pixel_type  = 1; // HALF
-        auto reloaded    = save_and_reload(*img, opts);
+        auto opts       = exr_default_save_options(*img);
+        opts.pixel_type = 1; // HALF
+        auto reloaded   = save_and_reload(*img, opts);
         REQUIRE(reloaded.size() == 1);
         CHECK(reloaded[0]->channels[0].bits_per_sample == 0); //< floating point, so no quantization lattice
         float value = reloaded[0]->channels[0](0, 0);
-        CHECK(value != doctest::Approx(0.1f).epsilon(1e-6));  // not exact
-        CHECK(value == doctest::Approx(0.1f).epsilon(1e-3));  // but close, within half precision
+        CHECK(value != doctest::Approx(0.1f).epsilon(1e-6)); // not exact
+        CHECK(value == doctest::Approx(0.1f).epsilon(1e-3)); // but close, within half precision
     }
 
     SUBCASE("FLOAT")
@@ -262,7 +263,7 @@ TEST_CASE("is_exr_image correctly identifies real EXR bytes and rejects garbage"
     auto img = make_test_image(int2{1, 1});
 
     std::ostringstream out(std::ios::binary);
-    auto                opts = exr_default_save_options(*img);
+    auto               opts = exr_default_save_options(*img);
     save_exr_image(*img, out, "test.exr", &opts);
 
     std::istringstream valid(out.str(), std::ios::binary);
@@ -287,7 +288,7 @@ namespace
 
 std::ifstream open_test_exr(const char *filename)
 {
-    std::string path = std::string(HDRVIEW_TEST_OPENEXR_DIR) + "/" + filename;
+    std::string   path = std::string(HDRVIEW_TEST_OPENEXR_DIR) + "/" + filename;
     std::ifstream file(path, std::ios::binary);
     REQUIRE_MESSAGE(file.good(), "Could not open vendored test EXR: ", path);
     return file;
@@ -302,9 +303,9 @@ TEST_CASE("EXR load splits a real multi-part file into one Image per part, with 
 
     REQUIRE(reloaded.size() == 10);
 
-    std::set<std::string> expected_names = {"rgba_right",        "depth_left",  "forward_left", "whitebarmask_left",
-                                            "rgba_left",         "depth_right", "forward_right", "disparityL",
-                                            "disparityR",        "whitebarmask_right"};
+    std::set<std::string> expected_names = {"rgba_right", "depth_left",        "forward_left",  "whitebarmask_left",
+                                            "rgba_left",  "depth_right",       "forward_right", "disparityL",
+                                            "disparityR", "whitebarmask_right"};
     std::set<std::string> actual_names;
     for (const auto &img : reloaded) actual_names.insert(img->partname);
     CHECK(actual_names == expected_names);
@@ -405,4 +406,40 @@ TEST_CASE("save_exr_image() with default options writes every group, not an empt
     float4 want = img->rgba_pixel(int2{1, 0}, Target_Primary);
     float4 got  = reloaded[0]->rgba_pixel(int2{1, 0}, Target_Primary);
     for (int c = 0; c < 3; ++c) CHECK(got[c] == doctest::Approx(want[c]).epsilon(1e-3));
+}
+
+TEST_CASE("An EXR rational attribute with a zero denominator does not divide by it")
+{
+    // Imf::Rational is two numbers read out of the file -- an int over an unsigned int -- and nothing in
+    // the format stops the denominator being zero. Framing rates and capture intervals are written this
+    // way, and 0/0 is how some writers spell "not set".
+    const std::string path = (std::filesystem::temp_directory_path() / "hdrview_rational.exr").string();
+
+    {
+        Imf::Header header{4, 4};
+        header.insert("framesPerSecond", Imf::RationalAttribute{Imf::Rational{24, 0}});
+        header.channels().insert("Y", Imf::Channel{Imf::FLOAT});
+
+        std::vector<float> pixels(16, 0.5f);
+        Imf::OutputFile    out{path.c_str(), header};
+        Imf::FrameBuffer   fb;
+        fb.insert("Y", Imf::Slice{Imf::FLOAT, (char *)pixels.data(), sizeof(float), sizeof(float) * 4});
+        out.setFrameBuffer(fb);
+        out.writePixels(4);
+    }
+
+    std::ifstream is{path, std::ios::binary};
+    REQUIRE(is);
+    std::vector<ImagePtr> images;
+    CHECK_NOTHROW(images = load_image(is, path));
+    REQUIRE(images.size() == 1);
+
+    // And the attribute is still reported, with both halves intact rather than a quotient.
+    const json &header_json = images[0]->metadata["header"];
+    REQUIRE(header_json.contains("framesPerSecond"));
+    const json &fps = header_json["framesPerSecond"]["value"];
+    CHECK(fps["numerator"] == 24);
+    CHECK(fps["denominator"] == 0);
+
+    std::filesystem::remove(path);
 }

--- a/tests/test_exr_io.cpp
+++ b/tests/test_exr_io.cpp
@@ -428,10 +428,14 @@ TEST_CASE("An EXR rational attribute with a zero denominator does not divide by 
         out.writePixels(4);
     }
 
-    std::ifstream is{path, std::ios::binary};
-    REQUIRE(is);
+    // Scoped like the writer above: Windows refuses to delete a file that is still open, so the stream
+    // has to be closed before the remove() at the end of the test.
     std::vector<ImagePtr> images;
-    CHECK_NOTHROW(images = load_image(is, path));
+    {
+        std::ifstream is{path, std::ios::binary};
+        REQUIRE(is);
+        CHECK_NOTHROW(images = load_image(is, path));
+    }
     REQUIRE(images.size() == 1);
 
     // And the attribute is still reported, with both halves intact rather than a quotient.

--- a/tests/test_psd_metadata.cpp
+++ b/tests/test_psd_metadata.cpp
@@ -8,7 +8,10 @@
 
 #include "imageio/psd.h"
 
+#include <cstdint>
+#include <sstream>
 #include <string>
+#include <vector>
 
 TEST_CASE("PSDMetadata::color_mode_name is defined for every 16-bit value")
 {
@@ -29,4 +32,96 @@ TEST_CASE("PSDMetadata::color_mode_name is defined for every 16-bit value")
             ++bad;
     }
     CHECK(bad == 0);
+}
+
+namespace
+{
+
+void be16(std::string &o, uint16_t v) { o += char(v >> 8), o += char(v & 0xff); }
+void be32(std::string &o, uint32_t v)
+{
+    for (int i = 3; i >= 0; --i) o += char((v >> (8 * i)) & 0xff);
+}
+
+//! A PSD holding one image resource, whose declared data size need not match what follows it.
+/*!
+    `declared` is what the resource block claims; `payload` is what the section actually holds. Real files
+    agree; a truncated or hand-edited one does not, and the parser reads from the same stream the pixel
+    data lives in.
+*/
+std::string psd_with_resource(uint16_t resource_id, uint32_t declared, const std::string &payload,
+                              const std::string &trailing)
+{
+    std::string res;
+    res += "8BIM";
+    be16(res, resource_id);
+    res += '\0'; // empty Pascal name, already even with its length byte
+    res += '\0';
+    be32(res, declared);
+    res += payload;
+    if (payload.size() % 2 == 1)
+        res += '\0'; // resource data is padded to an even length
+
+    std::string o;
+    o += "8BPS";
+    be16(o, 1); // version
+    o.append(6, '\0');
+    be16(o, 3); // channels
+    be32(o, 1); // height
+    be32(o, 1); // width
+    be16(o, 8); // depth
+    be16(o, 3); // RGB
+    be32(o, 0); // no colour-mode data
+    be32(o, (uint32_t)res.size());
+    o += res;
+    o += trailing;
+    return o;
+}
+
+} // namespace
+
+TEST_CASE("A PSD resource cannot read past the section that contains it")
+{
+    const std::string xmp = "<?xpacket begin=\"\"?><x:xmpmeta/><?xpacket end=\"w\"?>";
+
+    SUBCASE("an honest resource is read whole")
+    {
+        std::istringstream is{psd_with_resource(1060, (uint32_t)xmp.size(), xmp, "")};
+        PSDMetadata        psd;
+        CHECK_NOTHROW(psd.read(is));
+        CHECK(std::string(psd.xmp.begin(), psd.xmp.end()) == xmp);
+    }
+
+    SUBCASE("a resource claiming more than the section holds does not reach past it")
+    {
+        // The section ends after `xmp`; everything after it is the layer and pixel data the resource has
+        // no business seeing.
+        const std::string  secret = std::string(4096, 'P');
+        std::istringstream is{psd_with_resource(1060, (uint32_t)(xmp.size() + secret.size()), xmp, secret)};
+
+        PSDMetadata psd;
+        try
+        {
+            psd.read(is);
+        }
+        catch (const std::exception &)
+        {
+            // Refusing the file outright is a fine answer; swallowing the pixels is not.
+        }
+        CHECK(psd.xmp.size() <= xmp.size());
+    }
+
+    SUBCASE("a resource declaring far more than the file holds is not allocated for")
+    {
+        std::istringstream is{psd_with_resource(1060, 64u << 20, xmp, "")};
+        PSDMetadata        psd;
+        try
+        {
+            psd.read(is);
+        }
+        catch (const std::exception &)
+        {
+        }
+        CHECK(psd.xmp.size() <= xmp.size());
+    }
 }

--- a/tests/test_xmp.cpp
+++ b/tests/test_xmp.cpp
@@ -1,0 +1,163 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+// XMP is informational: it decorates an image, it does not describe its pixels. Image::finalize() parses it
+// with no guard around the call, so anything the parser does to a packet it dislikes happens to the whole
+// load.
+
+#include <doctest/doctest.h>
+
+#include "image.h"
+#include "imageio/image_loader.h"
+#include "imageio/xmp.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+#include <zlib.h>
+
+namespace
+{
+
+//! Wraps `body` in the packet framing a writer normally emits.
+std::string packet(const std::string &body)
+{
+    return "<?xpacket begin=\"\xEF\xBB\xBF\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n"
+           "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n"
+           "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+           body +
+           "\n</rdf:RDF>\n"
+           "</x:xmpmeta>\n"
+           "<?xpacket end=\"w\"?>";
+}
+
+json parse(const std::string &xml)
+{
+    Xmp xmp(xml.data(), xml.size());
+    return xmp.to_json();
+}
+
+} // namespace
+
+TEST_CASE("An ordinary XMP packet parses into its schemas")
+{
+    // Baseline: without this, a change that stops XMP parsing altogether looks the same as one that fixes
+    // a crash in it.
+    const json j = parse(packet(R"(<rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+        xmp:CreatorTool="HDRView">
+        <dc:format>image/jpeg</dc:format>
+      </rdf:Description>)"));
+
+    REQUIRE(j.is_object());
+    REQUIRE(j.contains("dc"));
+    CHECK(j["dc"]["format"] == "image/jpeg");
+    REQUIRE(j.contains("xmp"));
+    CHECK(j["xmp"]["CreatorTool"] == "HDRView");
+    // The namespace table the Info panel groups and orders by.
+    REQUIRE(j.contains("xmlns"));
+    CHECK(j["xmlns"]["dc"]["name"] == "Dublin Core");
+}
+
+TEST_CASE("A default namespace declaration does not take the image down with it")
+{
+    // xmlns= has no colon, so it is stored as a plain string; xmlns:dc= then addresses it as an object.
+    // Both are ordinary XML, and a packet carrying the two together is not exotic -- but the second one
+    // used to throw straight out of Image::finalize(), so the pixels never arrived either.
+    const std::string with_default_ns = packet(R"(<rdf:Description rdf:about=""
+        xmlns="http://purl.org/dc/elements/1.1/"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:title>ok</dc:title>
+      </rdf:Description>)");
+
+    json j;
+    CHECK_NOTHROW(j = parse(with_default_ns));
+    CHECK(j.is_object());
+
+    // Same collision reached through an element's own attributes rather than a namespace declaration.
+    const std::string prefix_used_twice = packet(R"(<rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        dc="plain"
+        dc:title="structured"/>)");
+    CHECK_NOTHROW(parse(prefix_used_twice));
+
+    // And through a child element whose prefix an attribute already claimed as a plain value.
+    const std::string child_after_attribute = packet(R"(<rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        dc="plain">
+        <dc:title>structured</dc:title>
+      </rdf:Description>)");
+    CHECK_NOTHROW(parse(child_after_attribute));
+}
+
+TEST_CASE("A packet that cannot be parsed yields nothing rather than throwing")
+{
+    CHECK_NOTHROW(parse(packet("<rdf:Description"))); // truncated
+    CHECK_NOTHROW(parse("not xml at all"));           // no packet framing
+    CHECK_NOTHROW(parse(packet("")));                 // no descriptions
+    CHECK_NOTHROW(parse(""));                         // nothing at all
+    CHECK(parse("").is_object());
+}
+
+namespace
+{
+
+//! A 1x1 PNG carrying `xmp` in the iTXt chunk the XMP spec assigns it, which png.cpp reads.
+std::string png_with_xmp(const std::string &xmp)
+{
+    auto be32 = [](uint32_t v)
+    {
+        std::string s(4, '\0');
+        for (int i = 0; i < 4; ++i) s[i] = char((v >> (8 * (3 - i))) & 0xff);
+        return s;
+    };
+    auto chunk = [&](const std::string &type, const std::string &data)
+    {
+        const std::string body = type + data;
+        return be32((uint32_t)data.size()) + body +
+               be32((uint32_t)crc32(0, (const Bytef *)body.data(), (uInt)body.size()));
+    };
+
+    // 1x1 8-bit RGB, one uncompressed zlib block holding a single filtered scanline.
+    std::string        ihdr = be32(1) + be32(1) + std::string("\x08\x02\x00\x00\x00", 5);
+    std::string        raw  = std::string("\x00\xff\x00\x00", 4);
+    uLongf             cap  = compressBound((uLong)raw.size());
+    std::vector<Bytef> z(cap);
+    compress(z.data(), &cap, (const Bytef *)raw.data(), (uLong)raw.size());
+
+    // iTXt: keyword \0 compression-flag compression-method language \0 translated \0 text
+    const std::string itxt = std::string("XML:com.adobe.xmp") + '\0' + '\0' + '\0' + '\0' + '\0' + xmp;
+
+    return std::string("\x89PNG\r\n\x1a\n", 8) + chunk("IHDR", ihdr) + chunk("iTXt", itxt) +
+           chunk("IDAT", std::string((char *)z.data(), cap)) + chunk("IEND", "");
+}
+
+} // namespace
+
+TEST_CASE("An image whose XMP the parser dislikes still loads its pixels")
+{
+    // The point of the whole exercise: XMP decorates an image, so however badly a packet is formed, the
+    // pixels have to arrive. Image::finalize() parses XMP with nothing catching around the call.
+    const std::string xmp = packet(R"(<rdf:Description rdf:about=""
+        xmlns="http://purl.org/dc/elements/1.1/"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:title>ok</dc:title>
+      </rdf:Description>)");
+
+    // First the control, so a broken fixture cannot masquerade as the bug.
+    std::istringstream    plain{png_with_xmp("")};
+    std::vector<ImagePtr> plain_images;
+    CHECK_NOTHROW(plain_images = load_image(plain, "plain.png"));
+    REQUIRE(plain_images.size() == 1);
+    CHECK(plain_images[0]->size() == int2{1, 1});
+
+    std::istringstream    is{png_with_xmp(xmp)};
+    std::vector<ImagePtr> images;
+    CHECK_NOTHROW(images = load_image(is, "xmp-test.png"));
+    REQUIRE(images.size() == 1);
+    CHECK(images[0]->size() == int2{1, 1});
+}


### PR DESCRIPTION
The metadata parsers and what they hand the Info panel. `xmp.cpp` and `exif.cpp` had no tests at all, and
between them account for most of what HDRView reads out of a file that is not a pixel.

Five bugs. Two of them cost you the image.

## The image

**An ordinary XMP packet loaded zero images.** A PNG carrying this:

```xml
<rdf:Description rdf:about=""
    xmlns="http://purl.org/dc/elements/1.1/"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
```

Both declarations are ordinary XML and appear together in real files. Every attribute was stored as data,
so the unprefixed `xmlns` landed as a plain string and `xmlns:dc` then indexed into that same key as an
object — `type_error.305`. `Image::finalize()` parses XMP with nothing catching around the call, so the
throw left finalize and took the load with it. An attribute and a child sharing a prefix (`dc` plus
`dc:title`) reach it two other ways.

Namespace declarations are not data: `add_xmlns_entries()` already collects them into the table the Info
panel groups by, so the parser skips them now, which also stops every packet duplicating its declarations
into the output. A prefix that does collide falls back to a flat `prefix:local` key rather than indexing
into a scalar. And deriving the metadata is wrapped — XMP decorates an image, it does not describe its
pixels, so whatever a packet provokes should cost the metadata and nothing else.

**An EXR rational attribute with a zero denominator killed the process.**

```cpp
j["value"]["numerator"] = ta->value().n / ta->value().d;   // dead: overwritten on the next line
j["value"]["numerator"] = ta->value().n;
```

The first line is dead but still runs, and `Imf::Rational` is an `int` over an *unsigned int* read straight
from the file. Zero denominator is integer division by zero — a hardware trap, gone before anything drew.
Nothing in OpenEXR forbids it; `framesPerSecond` and `captureRate` are rationals, and `0/0` is how a writer
with nothing to say spells it. Deleting the line is the whole fix; both halves were already reported
separately, and the human-readable string beside them goes through `Imf::Rational::operator double()`,
which is floating point and says `inf`.

The sanitizer job would have caught this instantly — UBSan reports integer division by zero — but only if
something had opened such a file, and nothing had.

## The metadata

**One oddly-described EXIF tag discarded every tag in the file.** `entry_to_json()` names a tag's value for
display by reading the decoded value back out of JSON as the scalar its tag number implies —
`value["value"].get<int>()` and neighbours, at forty-odd sites. The file is not obliged to agree: a
Compression tag declaring two components decodes to an array, one declaring ASCII decodes to a string, and
`.get<int>()` throws on both. Every loader wraps `to_json()`, so nothing crashed and no image was lost —
but the EXIF went from "one tag we cannot name" to no EXIF at all, including the tags already decoded.
Contained per entry, in the loop, which covers all forty-odd sites without anyone auditing them.

**The EXIF log callback wrote into the stack frame that installed it.** `exif_log_set_func()` was handed
`&error`, a local of `Exif::Exif`, as the `user_data` its callback writes through — but the `ExifLog` it is
installed on is a *member*, so libexif goes on calling that callback long after the constructor returns.
Reading an entry's value logs, so `exif_entry_get_value()` during `to_json()` reaches it and writes a byte
into a frame that is gone. AddressSanitizer names the slot: `[48, 49) 'error'` in the frame of `Exif::Exif`.

Nothing in this branch touched that line. `tests/test_exif.cpp` is simply the first thing ever to call
`exif_to_json()` under a sanitizer, which is the whole reason a latent bug of this age surfaced now.

**A PSD image resource read past the section containing it.** A resource block declares its own data size,
and the only check was a 100 MB ceiling — nothing tied it to the Image Resources section. A block claiming
more simply kept reading, out of the section and into the layer and pixel data after it, and whatever it
picked up was handed on as this image's XMP, EXIF or ICC profile — the last of those to lcms, as a profile.
A block declaring tens of megabytes was also allocated for in full first. Bounded by what is left of the
section now.

**An Apple maker-note tag's bounds check wrapped at 32 bits.** `entry_offset + entry_size > mn_size`, where
all three are 32-bit fields straight from the file, so an offset near 4 GB wraps back into range and the
read lands wherever the offset pointed. On this host it does not, and only by accident — `entry_offset` was
declared `size_t`, which is 64 bits wide here. The wasm32 build, the web one that opens whatever a browser
hands it, has a 32-bit `size_t` and does not. Compared by subtraction now, in a named predicate taking the
three values at their natural width.

## Verification

159/159 `ctest`. Every fix but one was confirmed to fail its test when reverted on its own.

The exception is the EXIF log callback, which has no assertion of its own: it is a memory error, caught by
AddressSanitizer running the tests that were already there. Reproducing it needs
`ASAN_OPTIONS=detect_stack_use_after_return=1` — that detector is off by default, so a plain sanitizer build
sees nothing. Confirmed both ways locally: it reports at `exif.cpp:176` before the fix and is silent after,
with the whole suite clean under ASan and UBSan (63023 assertions, zero reports).

One test of this branch's own also needed fixing rather than the code: the EXR rational case scoped its
writer but left its `ifstream` open across the `remove()` at the end. POSIX unlinks an open file happily,
Windows refuses — so it failed there having passed all six of its own assertions.

`tests/test_xmp.cpp` and `tests/test_exif.cpp` are new — neither file had any tests — and both build their
fixtures byte by byte, so no vendored data is needed: an EXIF block is a TIFF header, and a PNG carries XMP
in the `iTXt` chunk the spec assigns it. The EXR and PSD cases fold into the existing `test_exr_io.cpp` and
`test_psd_metadata.cpp`. Each test covers the working case too, so a change that stops a parser working
cannot pass as one that hardens it — and the XMP end-to-end test runs its control before the bug, so a
broken fixture cannot masquerade as the defect.

The maker-note test needed care to mean anything: with the values at `size_t`, the adding form gets the
right answer on a 64-bit host, which is exactly why this survived. At `uint32_t` the wrap happens
everywhere, and all three wrap cases fail against the adding form — confirmed by putting it back.

Also compiled against the Emscripten toolchain, being the target the maker-note fix actually affects.
`emsdk 6.0.8` cannot *link* this project — pristine master fails identically, mixing `-mt` and non-mt
sysroot libraries — so this is compile-level only; CI does the link.

## Swept and clean

Recorded because it bounds where the remaining risk is not:

- **`get_value()` reading `components` elements without consulting `entry->size`** looked like a classic
  over-read. libexif rejects the multiplication overflow, an offset past the buffer, and `s > size - doff`
  before allocating, then sets `entry->size` to exactly `format_size × components`. In bounds by
  construction.
- **Unbounded recursion** in the XMP parser and in the Info panel's renderer — which threads a `depth`
  parameter it never uses, reading like an abandoned guard. tinyxml2 caps element depth at 500.
- **`parse_icc_cicp_tag()`**, the one hand-rolled ICC parser, is correctly bounded at every step.
- **The Info panel's `["string"].get<std::string>()`**, guarded by `contains` but not `is_string`, has no
  reachable non-string among the 314 assignment sites. Left alone rather than guarded speculatively.

## Two notes for the reader

`src/image.cpp` shows ~90 changed lines for a three-line fix: wrapping a block in `try` indents the block.
That is what the change is.

`tests/test_exr_io.cpp` picked up ~16 lines of formatting I did not otherwise touch. Master's copy is not
`clang-format` clean; running it as CLAUDE.md requires corrected pre-existing drift.

