### PR TITLE
Fix web clipboard by removing HDRView's override, and read pinch from browser touch events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,15 +635,6 @@ if(EMSCRIPTEN)
   target_include_directories(emscripten-browser-file INTERFACE "${emscripten-browser-file_SOURCE_DIR}")
   list(APPEND HDRVIEW_DEPENDENCIES "emscripten-browser-file")
 
-  CPMAddPackage("gh:Armchair-Software/emscripten-browser-clipboard#bcba48fee22551b458fe5e1e513f6402c810d886")
-  if(NOT emscripten-browser-clipboard_ADDED)
-    message(FATAL_ERROR "Could not download emscripten-browser-clipboard library.")
-  endif()
-  message(STATUS "emscripten-browser-clipboard library added")
-  add_library(emscripten-browser-clipboard INTERFACE IMPORTED)
-  target_include_directories(emscripten-browser-clipboard INTERFACE "${emscripten-browser-clipboard_SOURCE_DIR}")
-  list(APPEND HDRVIEW_DEPENDENCIES "emscripten-browser-clipboard")
-
 else()
 
   CPMAddPackage(

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -4,6 +4,10 @@
 
 #include <cmath>
 
+#if defined(__EMSCRIPTEN__)
+#include <emscripten/html5.h>
+#endif
+
 #ifdef HELLOIMGUI_USE_SDL2
 #include <SDL.h>
 #endif
@@ -291,7 +295,9 @@ void HDRViewApp::handle_mouse_interaction()
     else
     {
         float2 drag_delta{ImGui::GetMouseDragDelta(ImGuiMouseButton_Left)};
-        if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
+        // A second finger means a pinch, and the first one is still driving a synthesized left-drag; pan
+        // would fight the zoom for the same gesture.
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) && m_active_touches < 2)
         {
             cancel_autofit = true;
             reposition_pixel_to_vp_pos(vp_mouse_pos + drag_delta, pixel_at_vp_pos(vp_mouse_pos));
@@ -302,6 +308,65 @@ void HDRViewApp::handle_mouse_interaction()
     if (cancel_autofit)
         this->cancel_autofit();
 }
+
+#if defined(__EMSCRIPTEN__)
+
+//! Pinch-to-zoom, read straight from the browser's touch events.
+/*!
+    Neither backend can supply this. GLFW has no gesture API on any platform, and the Emscripten port
+    hello_imgui uses tracks a single touch point, synthesizing mouse events from it and discarding the
+    rest -- so the second finger never reaches the application. SDL2's SDL_MULTIGESTURE would, but its
+    Emscripten build has no clipboard at all (no driver entry, so SDL_SetClipboardText only writes a
+    process-local string), which is too much to give up for one gesture.
+
+    Registering here alongside the port's own listeners leaves its single-touch mouse synthesis intact:
+    one finger still pans through the ordinary mouse path, and only the second finger is ours.
+*/
+static EM_BOOL on_touch(int event_type, const EmscriptenTouchEvent *event, void *user_data)
+{
+    auto *app = static_cast<HDRViewApp *>(user_data);
+
+    // Every touch currently on the screen is reported, not just the ones that changed.
+    app->set_active_touches(event->numTouches);
+
+    // The distance between the first two fingers is the gesture; a third changes nothing.
+    static float previous_distance = 0.f;
+    if (event->numTouches < 2 || event_type == EMSCRIPTEN_EVENT_TOUCHEND || event_type == EMSCRIPTEN_EVENT_TOUCHCANCEL)
+    {
+        previous_distance = 0.f;
+        return EM_FALSE; // let the port keep synthesizing mouse events from one finger
+    }
+
+    const float2 a{(float)event->touches[0].targetX, (float)event->touches[0].targetY};
+    const float2 b{(float)event->touches[1].targetX, (float)event->touches[1].targetY};
+    const float  distance = length(b - a);
+
+    // The first frame of a pinch has nothing to compare against, so it only establishes the baseline.
+    if (previous_distance > 0.f && distance > 0.f)
+    {
+        // Scaled by the starting separation so the same finger travel zooms by the same amount whether
+        // the fingers began close together or far apart.
+        constexpr float k_pinch_scale = 8.f;
+        app->zoom_at_vp_pos(k_pinch_scale * (distance - previous_distance) / previous_distance,
+                            app->vp_pos_at_app_pos(0.5f * (a + b)));
+    }
+    previous_distance = distance;
+
+    return EM_TRUE; // ours: do not also scroll or zoom the page
+}
+
+void HDRViewApp::install_touch_handlers()
+{
+    // The canvas hello_imgui draws into. EMSCRIPTEN_EVENT_TARGET_WINDOW would also see touches that
+    // began on the surrounding page.
+    const char *canvas = "#canvas";
+    emscripten_set_touchstart_callback(canvas, this, EM_FALSE, on_touch);
+    emscripten_set_touchmove_callback(canvas, this, EM_FALSE, on_touch);
+    emscripten_set_touchend_callback(canvas, this, EM_FALSE, on_touch);
+    emscripten_set_touchcancel_callback(canvas, this, EM_FALSE, on_touch);
+}
+
+#endif // __EMSCRIPTEN__
 
 bool HDRViewApp::process_event(void *e)
 {

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -4,14 +4,6 @@
 
 #include <cmath>
 
-#if defined(__EMSCRIPTEN__)
-#include <emscripten/html5.h>
-#endif
-
-#ifdef HELLOIMGUI_USE_SDL2
-#include <SDL.h>
-#endif
-
 using namespace std;
 using namespace HelloImGui;
 
@@ -309,102 +301,13 @@ void HDRViewApp::handle_mouse_interaction()
         this->cancel_autofit();
 }
 
-#if defined(__EMSCRIPTEN__)
-
-//! Pinch-to-zoom, read straight from the browser's touch events.
-/*!
-    Neither backend can supply this. GLFW has no gesture API on any platform, and the Emscripten port
-    hello_imgui uses tracks a single touch point, synthesizing mouse events from it and discarding the
-    rest -- so the second finger never reaches the application. SDL2's SDL_MULTIGESTURE would, but its
-    Emscripten build has no clipboard at all (no driver entry, so SDL_SetClipboardText only writes a
-    process-local string), which is too much to give up for one gesture.
-
-    Registering here alongside the port's own listeners leaves its single-touch mouse synthesis intact:
-    one finger still pans through the ordinary mouse path, and only the second finger is ours.
-*/
-static EM_BOOL on_touch(int event_type, const EmscriptenTouchEvent *event, void *user_data)
+void HDRViewApp::touch_gesture(int num_touches, float relative_delta, float2 app_pos)
 {
-    auto *app = static_cast<HDRViewApp *>(user_data);
+    m_active_touches = num_touches;
 
-    // Every touch currently on the screen is reported, not just the ones that changed.
-    app->set_active_touches(event->numTouches);
-
-    // The distance between the first two fingers is the gesture; a third changes nothing.
-    static float previous_distance = 0.f;
-    if (event->numTouches < 2 || event_type == EMSCRIPTEN_EVENT_TOUCHEND || event_type == EMSCRIPTEN_EVENT_TOUCHCANCEL)
-    {
-        previous_distance = 0.f;
-        return EM_FALSE; // let the port keep synthesizing mouse events from one finger
-    }
-
-    const float2 a{(float)event->touches[0].targetX, (float)event->touches[0].targetY};
-    const float2 b{(float)event->touches[1].targetX, (float)event->touches[1].targetY};
-    const float  distance = length(b - a);
-
-    // The first frame of a pinch has nothing to compare against, so it only establishes the baseline.
-    if (previous_distance > 0.f && distance > 0.f)
-    {
-        // Scaled by the starting separation so the same finger travel zooms by the same amount whether
-        // the fingers began close together or far apart.
-        constexpr float k_pinch_scale = 8.f;
-        app->zoom_at_vp_pos(k_pinch_scale * (distance - previous_distance) / previous_distance,
-                            app->vp_pos_at_app_pos(0.5f * (a + b)));
-    }
-    previous_distance = distance;
-
-    return EM_TRUE; // ours: do not also scroll or zoom the page
-}
-
-void HDRViewApp::install_touch_handlers()
-{
-    // The canvas hello_imgui draws into. EMSCRIPTEN_EVENT_TARGET_WINDOW would also see touches that
-    // began on the surrounding page.
-    const char *canvas = "#canvas";
-    emscripten_set_touchstart_callback(canvas, this, EM_FALSE, on_touch);
-    emscripten_set_touchmove_callback(canvas, this, EM_FALSE, on_touch);
-    emscripten_set_touchend_callback(canvas, this, EM_FALSE, on_touch);
-    emscripten_set_touchcancel_callback(canvas, this, EM_FALSE, on_touch);
-}
-
-#endif // __EMSCRIPTEN__
-
-bool HDRViewApp::process_event(void *e)
-{
-#ifdef HELLOIMGUI_USE_SDL2
-    auto &io = ImGui::GetIO();
-    if (io.WantCaptureMouse)
-        return false;
-
-    SDL_Event *event = static_cast<SDL_Event *>(e);
-    switch (event->type)
-    {
-    case SDL_QUIT: spdlog::trace("Got an SDL_QUIT event"); break;
-    case SDL_WINDOWEVENT: spdlog::trace("Got an SDL_WINDOWEVENT event"); break;
-    case SDL_MOUSEWHEEL: spdlog::trace("Got an SDL_MOUSEWHEEL event"); break;
-    case SDL_MOUSEMOTION: spdlog::trace("Got an SDL_MOUSEMOTION event"); break;
-    case SDL_MOUSEBUTTONDOWN: spdlog::trace("Got an SDL_MOUSEBUTTONDOWN event"); break;
-    case SDL_MOUSEBUTTONUP: spdlog::trace("Got an SDL_MOUSEBUTTONUP event"); break;
-    case SDL_FINGERMOTION: spdlog::trace("Got an SDL_FINGERMOTION event"); break;
-    case SDL_FINGERDOWN: spdlog::trace("Got an SDL_FINGERDOWN event"); break;
-    case SDL_MULTIGESTURE:
-    {
-        spdlog::trace("Got an SDL_MULTIGESTURE event; numFingers: {}; dDist: {}; x: {}, y: {}; io.MousePos: {}, {}; "
-                      "io.MousePosFrac: {}, {}",
-                      event->mgesture.numFingers, event->mgesture.dDist, event->mgesture.x, event->mgesture.y,
-                      io.MousePos.x, io.MousePos.y, io.MousePos.x / io.DisplaySize.x, io.MousePos.y / io.DisplaySize.y);
-        constexpr float cPinchZoomThreshold(0.0001f);
-        constexpr float cPinchScale(80.0f);
-        if (event->mgesture.numFingers == 2 && fabs(event->mgesture.dDist) >= cPinchZoomThreshold)
-        {
-            // Zoom in/out by positive/negative mPinch distance
-            zoom_at_vp_pos(event->mgesture.dDist * cPinchScale, vp_pos_at_app_pos(io.MousePos));
-            return true;
-        }
-    }
-    break;
-    case SDL_FINGERUP: spdlog::trace("Got an SDL_FINGERUP event"); break;
-    }
-#endif
-    (void)e; // prevent unreferenced formal parameter warning
-    return false;
+    // Scaled by the fingers' own separation, so the same travel zooms by the same amount whether they
+    // started close together or far apart.
+    constexpr float k_pinch_scale = 8.f;
+    if (relative_delta != 0.f)
+        zoom_at_vp_pos(k_pinch_scale * relative_delta, vp_pos_at_app_pos(app_pos));
 }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -407,7 +407,7 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
     m_params.callbacks.PostInit = [this, force_exposure, force_gamma, force_dither, force_apple_keys]
     {
 #if defined(__EMSCRIPTEN__)
-        install_touch_handlers();
+        install_touch_handlers(); // see platform_utils
 #endif
 
         spdlog::info("Loading user settings from '{}'", IniSettingsLocation(m_params).value_or("(disabled)"));
@@ -661,7 +661,6 @@ void HDRViewApp::setup_frame_callbacks()
     };
     m_params.callbacks.CustomBackground        = [this]() { draw_background(); };
     m_params.callbacks.BeforeSwap              = [this]() { end_colorpass_frame(); };
-    m_params.callbacks.AnyBackendEventCallback = [this](void *event) { return process_event(event); };
 }
 
 auto HDRViewApp::dialog(const string &title) -> PopupDialog &

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -406,7 +406,9 @@ void HDRViewApp::setup_persistence_callbacks(optional<float> force_exposure, opt
     m_params.iniFilename        = "HDRView/settings.ini";
     m_params.callbacks.PostInit = [this, force_exposure, force_gamma, force_dither, force_apple_keys]
     {
-        setup_imgui_clipboard();
+#if defined(__EMSCRIPTEN__)
+        install_touch_handlers();
+#endif
 
         spdlog::info("Loading user settings from '{}'", IniSettingsLocation(m_params).value_or("(disabled)"));
 

--- a/src/app.h
+++ b/src/app.h
@@ -210,6 +210,17 @@ public:
         the same place before and after the zoom.
     */
     void zoom_at_vp_pos(float amount, float2 focus_vp_pos);
+
+#if defined(__EMSCRIPTEN__)
+    //! Register the browser touch listeners that supply pinch-to-zoom. \see on_touch in app-zoom.cpp
+    /*!
+        Public because that listener is a plain function: Emscripten's event API takes a function pointer,
+        so it cannot be a member, and it drives the two calls below from outside the class.
+    */
+    void install_touch_handlers();
+    //! Fingers currently on the screen, as those listeners last reported them.
+    void set_active_touches(int n) { m_active_touches = n; }
+#endif
     /// Zoom in to the next power of two
     void zoom_in();
     /// Zoom out to the previous power of two
@@ -343,13 +354,6 @@ private:
     void draw_tweak_window();
     void process_shortcuts();
     bool process_event(void *event);
-
-#if defined(__EMSCRIPTEN__)
-    //! Register the browser touch listeners that supply pinch-to-zoom. \see on_touch in app-zoom.cpp
-    void install_touch_handlers();
-    //! Fingers currently on the screen, from those listeners.
-    void set_active_touches(int n) { m_active_touches = n; }
-#endif
     void set_image_textures();
     void update_visibility();
 

--- a/src/app.h
+++ b/src/app.h
@@ -211,16 +211,16 @@ public:
     */
     void zoom_at_vp_pos(float amount, float2 focus_vp_pos);
 
-#if defined(__EMSCRIPTEN__)
-    //! Register the browser touch listeners that supply pinch-to-zoom. \see on_touch in app-zoom.cpp
+    //! Respond to a touch gesture the browser reported. \see install_touch_handlers() in platform_utils
     /*!
-        Public because that listener is a plain function: Emscripten's event API takes a function pointer,
-        so it cannot be a member, and it drives the two calls below from outside the class.
+        \param [] num_touches    Fingers currently on the screen
+        \param [] relative_delta Change in the first two fingers' separation, as a fraction of it
+        \param [] app_pos        Point to zoom about, midway between them
+
+        Public because Emscripten's event API takes a plain function pointer, so the listener that calls
+        this cannot be a member.
     */
-    void install_touch_handlers();
-    //! Fingers currently on the screen, as those listeners last reported them.
-    void set_active_touches(int n) { m_active_touches = n; }
-#endif
+    void touch_gesture(int num_touches, float relative_delta, float2 app_pos);
     /// Zoom in to the next power of two
     void zoom_in();
     /// Zoom out to the previous power of two
@@ -353,7 +353,6 @@ private:
     void draw_developer_windows();
     void draw_tweak_window();
     void process_shortcuts();
-    bool process_event(void *event);
     void set_image_textures();
     void update_visibility();
 

--- a/src/app.h
+++ b/src/app.h
@@ -343,6 +343,13 @@ private:
     void draw_tweak_window();
     void process_shortcuts();
     bool process_event(void *event);
+
+#if defined(__EMSCRIPTEN__)
+    //! Register the browser touch listeners that supply pinch-to-zoom. \see on_touch in app-zoom.cpp
+    void install_touch_handlers();
+    //! Fingers currently on the screen, from those listeners.
+    void set_active_touches(int n) { m_active_touches = n; }
+#endif
     void set_image_textures();
     void update_visibility();
 
@@ -399,6 +406,14 @@ private:
     BackgroundImageLoader m_image_loader;
 
     int m_remaining_download = 0;
+
+    //! Number of fingers currently on the screen, tracked only under Emscripten.
+    /*!
+        The GLFW port synthesizes mouse events from the first touch and drops the rest ("we don't handle
+        multitouch", Context.cpp), so during a two-finger pinch it is still reporting a left-drag. Panning
+        is suppressed while this exceeds one, or the image would pan and zoom at the same time.
+    */
+    int m_active_touches = 0;
 
     ImGuiTextFilter m_file_filter, m_channel_filter;
     vector<size_t>  m_visible_images;

--- a/src/platform_utils.cpp
+++ b/src/platform_utils.cpp
@@ -7,6 +7,8 @@
 #ifdef __EMSCRIPTEN__
 #include "app.h"
 
+#include <emscripten/html5.h>
+
 EM_JS(bool, isSafari, (), {
     var is_safari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     return is_safari;
@@ -92,6 +94,58 @@ void show_in_file_manager(const char *filename)
 //------------------------------------------------------------------------------
 //  Javascript interface functions
 //
+//! Pinch-to-zoom, read straight from the browser's touch events.
+/*!
+    Neither backend supplies it. GLFW has no gesture API on any platform, and the Emscripten port
+    hello_imgui uses tracks a single touch point, synthesizing mouse events from it and discarding the
+    rest -- so the second finger never reaches the application otherwise.
+
+    Registering alongside the port's own listeners leaves that synthesis intact: one finger still pans
+    through the ordinary mouse path. The gesture is reduced here to a dimensionless change in the
+    fingers' separation; what that does to the viewport is HDRViewApp::touch_gesture()'s business.
+*/
+static EM_BOOL on_touch(int event_type, const EmscriptenTouchEvent *event, void *)
+{
+    // The separation of the first two fingers is the gesture; a third changes nothing.
+    static float previous_distance = 0.f;
+
+    const bool pinching =
+        event->numTouches >= 2 && event_type != EMSCRIPTEN_EVENT_TOUCHEND && event_type != EMSCRIPTEN_EVENT_TOUCHCANCEL;
+
+    float  relative_delta = 0.f;
+    float2 midpoint{0.f};
+    if (pinching)
+    {
+        const float2 a{(float)event->touches[0].targetX, (float)event->touches[0].targetY};
+        const float2 b{(float)event->touches[1].targetX, (float)event->touches[1].targetY};
+        const float  distance = length(b - a);
+
+        // The first frame of a pinch has nothing to compare against, so it only sets the baseline.
+        if (previous_distance > 0.f && distance > 0.f)
+            relative_delta = (distance - previous_distance) / previous_distance;
+        previous_distance = distance;
+        midpoint          = 0.5f * (a + b);
+    }
+    else
+        previous_distance = 0.f;
+
+    hdrview()->touch_gesture(event->numTouches, relative_delta, midpoint);
+
+    // Claim the event only while pinching, so one finger still reaches the port's mouse synthesis.
+    return pinching ? EM_TRUE : EM_FALSE;
+}
+
+void install_touch_handlers()
+{
+    // The canvas hello_imgui draws into (id="canvas" in shell.emscripten.html).
+    // EMSCRIPTEN_EVENT_TARGET_WINDOW would also catch touches beginning on the surrounding page.
+    const char *canvas = "#canvas";
+    emscripten_set_touchstart_callback(canvas, nullptr, EM_FALSE, on_touch);
+    emscripten_set_touchmove_callback(canvas, nullptr, EM_FALSE, on_touch);
+    emscripten_set_touchend_callback(canvas, nullptr, EM_FALSE, on_touch);
+    emscripten_set_touchcancel_callback(canvas, nullptr, EM_FALSE, on_touch);
+}
+
 extern "C"
 {
     EMSCRIPTEN_KEEPALIVE int hdrview_loadfile(const char *filename, const char *buffer, size_t buffer_size,

--- a/src/platform_utils.cpp
+++ b/src/platform_utils.cpp
@@ -1,4 +1,3 @@
-
 #include "platform_utils.h"
 
 #include <cstdlib>
@@ -7,9 +6,6 @@
 
 #ifdef __EMSCRIPTEN__
 #include "app.h"
-#include "common.h"
-#include "imgui.h"
-#include <emscripten_browser_clipboard.h>
 
 EM_JS(bool, isSafari, (), {
     var is_safari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
@@ -20,39 +16,7 @@ EM_JS(bool, isAppleDevice, (), {
     return (ua.includes("Macintosh") || ua.includes("iPad") || ua.includes("iPhone") || ua.includes("iPod"));
 });
 
-static std::string g_clipboard_content; // this stores the content for our internal clipboard
-
-static char const *get_clipboard_for_imgui(ImGuiContext *user_data [[maybe_unused]])
-{
-    /// Callback for imgui, to return clipboard content
-    spdlog::info("ImGui requested clipboard content, returning '{}'", g_clipboard_content);
-    return g_clipboard_content.c_str();
-}
-
-static void set_clipboard_from_imgui(ImGuiContext *user_data [[maybe_unused]], char const *text)
-{
-    /// Callback for imgui, to set clipboard content
-    g_clipboard_content = text;
-    spdlog::info("ImGui setting clipboard content to '{}'", g_clipboard_content);
-    emscripten_browser_clipboard::copy(g_clipboard_content); // send clipboard data to the browser
-}
 #endif
-
-void setup_imgui_clipboard()
-{
-#ifdef __EMSCRIPTEN__
-    // spdlog::info("Setting up paste callback");
-    // emscripten_browser_clipboard::paste(
-    //     [](std::string &&paste_data, void *)
-    //     {
-    //         /// Callback to handle clipboard paste from browser
-    //         spdlog::info("Browser pasted: '{}'", paste_data);
-    //         g_clipboard_content = std::move(paste_data);
-    //     });
-    ImGui::GetPlatformIO().Platform_SetClipboardTextFn = set_clipboard_from_imgui;
-    ImGui::GetPlatformIO().Platform_GetClipboardTextFn = get_clipboard_for_imgui;
-#endif
-}
 
 bool host_is_apple()
 {

--- a/src/platform_utils.h
+++ b/src/platform_utils.h
@@ -9,6 +9,9 @@ void        show_in_file_manager(const char *filename);
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 
+//! Register the browser touch listeners that supply pinch-to-zoom, which no backend provides.
+void install_touch_handlers();
+
 extern "C"
 {
     EMSCRIPTEN_KEEPALIVE int hdrview_loadfile(const char *filename, const char *buffer, size_t buffer_size,

--- a/src/platform_utils.h
+++ b/src/platform_utils.h
@@ -1,6 +1,5 @@
 #pragma once
 
-void        setup_imgui_clipboard();
 bool        host_is_apple();
 bool        host_is_safari();
 const char *file_manager_name();


### PR DESCRIPTION
**Draft: the pinch gesture is unverified.** It cannot be tested from here — the Emscripten build does not
configure on my machine (`Could NOT find Threads`, pre-existing) — so this needs trying on a phone. Opening
it as a draft is what builds the branch and publishes to `gh-pages/dev`; a push alone triggers nothing,
since `branches: ["*"]` does not match a slashed branch name.

Two web-only defects, sharing a cause: HDRView was replacing what the platform already does well, and doing
without what it does not do at all.

## The clipboard override goes (#137)

`setup_imgui_clipboard()` installed `Platform_Get/SetClipboardTextFn` from `PostInit`, *after* the backend
had installed its own — and what it installed was worse in both directions.

Reads returned a module-local string that nothing ever filled: the browser paste hook that would have
filled it is commented out in the same file, and has been **since the commit that introduced it**, so paste
has never worked in any released version. Writes called `navigator.clipboard.writeText()` from the frame
loop, which runs from `requestAnimationFrame` rather than inside a user gesture, so the promise rejects for
want of transient activation — and is discarded unexamined. Safari enforces this most strictly, which is
where it was reported.

Underneath it the GLFW port has a complete implementation: DOM listeners for `cut`, `copy` **and** `paste`,
and a `Clipboard` that timestamps its own text against the OS clipboard's and returns whichever is newer —
exactly the reconciliation a synchronous ImGui API needs from an event-driven browser one. ImGui's GLFW
backend already wires `glfwGet/SetClipboardString` to it. So the fix is deletion:
`emscripten-browser-clipboard` goes too, having no other user.

## Pinch is read from the browser directly

Nothing supplies it. GLFW has no gesture API on any platform — the only "touch" in `glfw3.h` is the scroll
callback's documentation — and the Emscripten port tracks a single touch point by its own admission ("we
don't handle multitouch"), synthesizing mouse events from the first finger and discarding the second. That
is precisely the reported symptom: one-finger panning still works, pinch does nothing.

So `on_touch()` reads the two-finger separation from the browser's own touch events and feeds
`zoom_at_vp_pos()` at the midpoint. It registers *alongside* the port's listeners rather than instead of
them, so one finger still pans through the ordinary mouse path.

That leaves the port still reporting a left-drag from the first finger throughout a pinch, so panning is
suppressed while a second finger is down — otherwise the image pans and zooms at once.

## Why not SDL2

That was the first thing tried, on the branch `fix/wasm-pinch-zoom`, and it works: `SDL_MULTIGESTURE` is
delivered, and hello_imgui's `AnyBackendEventCallback` — which `HDRViewApp::process_event` hangs on — is
invoked from `runner_sdl2.cpp` and nowhere else, which is why the existing handler compiles to nothing
under any other backend.

But SDL2's Emscripten build has **no clipboard at all**: no driver entry, so `SDL_SetClipboardText` falls
back to `SDL_strdup` into a process-local string and returns success. That is the clipboard bug above, made
permanent. Staying on GLFW keeps both, so that branch should be dropped rather than merged.

## What is and is not verified

Desktop builds clean and 151/151 tests pass; `HDRView --help` runs. The Emscripten API surface was
compiled against the real headers with `emcc -Wall -Wextra` in isolation, confirming the callback
signature, argument order and the `EMSCRIPTEN_EVENT_TOUCHEND`/`TOUCHCANCEL` constants; `#canvas` matches
`id="canvas"` in `shell.emscripten.html`.

Not verified: the wasm build itself — CI is its first compile — and the gesture. The zoom scale
(`k_pinch_scale = 8.f`) is a guess, and whether the pan suppression feels right is a judgement only a phone
can make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limitation, tracked not fixed

Paste is now wired up, but runs one event behind: it returns the *previous* clipboard contents, so pasting
the same text twice looks like it works on the second attempt. This is upstream, in
`pongasoft/emscripten-glfw`. The browser dispatches `keydown` before `paste`, the port forwards keydown
synchronously, and Dear ImGui reads the clipboard while handling the shortcut — before `onPaste` has stored
anything. `Clipboard::getText()`'s timestamp comparison is sound; there is simply no fresh value yet.

Shipping regardless: before this change paste never worked at all, in any released version, and copy
silently failed outside a user gesture. A one-event lag is a different order of problem, and the fix
belongs in the port rather than here — working around it would mean reinstating the override this PR
deletes.
