### PR TITLE
Test suite: wait for what the tests are waiting for, and stop waiting on the display

### DIFF
--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -37,6 +37,19 @@ void HDRViewApp::enable_gui_test_engine(void (*register_tests)(ImGuiTestEngine *
     // start from the built-in defaults every run, which is what they should be asserting against anyway.
     m_params.iniDisable = true;
 
+    // The suite is a long sequence of "yield until this becomes true", so what it costs is frames, and
+    // both of these make a frame wait rather than run. Idling throttles the rate whenever nothing is
+    // animating, which during a test run is nearly always; vsync then blocks every remaining frame until
+    // the monitor is ready. Together they were almost the entire wall clock: 57 seconds became 4.
+    //
+    // This applies to the interactive run too, where the display would otherwise pace it. Watching the
+    // suite go past at full speed is less useful than watching it at 60 Hz, but a run that finishes in
+    // seconds is the better tool for finding out why a test fails, and the alternative is a knob nobody
+    // would remember to set. rememberEnableIdling is off so a run cannot inherit the user's own setting.
+    m_params.fpsIdling.enableIdling         = false;
+    m_params.fpsIdling.rememberEnableIdling = false;
+    m_params.fpsIdling.vsyncToMonitor       = false;
+
     m_params.useImGuiTestEngine      = true;
     m_params.callbacks.RegisterTests = [register_tests]()
     {
@@ -624,8 +637,7 @@ void HDRViewApp::update_visibility()
     // m_visible_images and visible_image_names were appended to together above, so they index each other:
     // one shortened name per visible image, in the same order.
     auto short_names = shorten_names(visible_image_names);
-    for (size_t n = 0; n < m_visible_images.size(); ++n)
-        m_images[m_visible_images[n]]->short_name = short_names[n];
+    for (size_t n = 0; n < m_visible_images.size(); ++n) m_images[m_visible_images[n]]->short_name = short_names[n];
 
     set_image_textures();
 }

--- a/tests/gui/test_gui_dialogs.cpp
+++ b/tests/gui/test_gui_dialogs.cpp
@@ -12,6 +12,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <cstring>
 
 #ifndef HDRVIEW_GUI_TEST_IMAGE
@@ -23,8 +27,7 @@
 // disappear rather than assuming one Yield() is enough.
 static void wait_for_window_closed(ImGuiTestContext *ctx, const char *window_name)
 {
-    for (int frame = 0; frame < 30 && ctx->WindowInfo(window_name, ImGuiTestOpFlags_NoError).Window != nullptr; ++frame)
-        ctx->Yield();
+    wait_until(ctx, [&] { return ctx->WindowInfo(window_name, ImGuiTestOpFlags_NoError).Window == nullptr; });
 }
 
 void RegisterTests_Dialogs(ImGuiTestEngine *engine)
@@ -56,7 +59,7 @@ void RegisterTests_Dialogs(ImGuiTestEngine *engine)
         if (hdrview()->num_images() == 0)
         {
             hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE});
-            for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+            wait_for_loads(ctx);
         }
         IM_CHECK(hdrview()->num_images() > 0);
 
@@ -82,7 +85,7 @@ void RegisterTests_Dialogs(ImGuiTestEngine *engine)
         if (hdrview()->num_images() == 0)
         {
             hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE});
-            for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+            wait_for_loads(ctx);
         }
         IM_CHECK(hdrview()->num_images() > 0);
 

--- a/tests/gui/test_gui_filtering.cpp
+++ b/tests/gui/test_gui_filtering.cpp
@@ -15,6 +15,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
 #endif
@@ -31,7 +35,7 @@ static void load_both_fixtures(ImGuiTestContext *ctx)
 
     hdrview()->close_all_images();
     hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
-    for (int frame = 0; frame < 120 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
+    wait_for_loads(ctx);
     IM_CHECK_EQ(hdrview()->num_images(), 2);
     IM_CHECK_EQ(hdrview()->num_visible_images(), 2);
 }

--- a/tests/gui/test_gui_image_io.cpp
+++ b/tests/gui/test_gui_image_io.cpp
@@ -12,6 +12,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <filesystem>
 
 #ifndef HDRVIEW_GUI_TEST_IMAGE
@@ -30,7 +34,7 @@ void RegisterTests_ImageIO(ImGuiTestEngine *engine)
 
         // Loading happens on a background thread and is drained into m_images from ShowGui() one frame at a
         // time, so give it a bounded number of frames to land rather than assuming it's ready immediately.
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK(hdrview()->num_images() > 0);
 
         const float target_exposure = 2.5f;
@@ -52,7 +56,7 @@ void RegisterTests_ImageIO(ImGuiTestEngine *engine)
         IM_CHECK_EQ(hdrview()->num_images(), 0);
 
         hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 2);
 
         hdrview()->set_current_image_index(1);
@@ -91,8 +95,8 @@ void RegisterTests_ImageIO(ImGuiTestEngine *engine)
         if (ec)
         {
             ctx->LogWarning("Skipping: could not create a >260 character path (%s). This requires the "
-                             "system-wide \"Enable Win32 long paths\" policy.",
-                             ec.message().c_str());
+                            "system-wide \"Enable Win32 long paths\" policy.",
+                            ec.message().c_str());
             return;
         }
 
@@ -101,7 +105,7 @@ void RegisterTests_ImageIO(ImGuiTestEngine *engine)
         IM_CHECK(!ec);
 
         hdrview()->load_images({long_path.u8string()});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK(hdrview()->num_images() > 0);
 
         hdrview()->close_all_images();

--- a/tests/gui/test_gui_info.cpp
+++ b/tests/gui/test_gui_info.cpp
@@ -9,6 +9,7 @@
 #include "app.h"
 #include "image.h"
 #include "test_gui_registry.h"
+#include "test_gui_support.h"
 
 #include "imgui_internal.h"
 #include "imgui_test_engine/imgui_te_context.h"
@@ -27,8 +28,7 @@ static void load_fixture_and_show_info(ImGuiTestContext *ctx)
 {
     if (hdrview()->num_images() == 0)
     {
-        hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        hdrview_test::load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE});
     }
     IM_CHECK(hdrview()->num_images() > 0);
 

--- a/tests/gui/test_gui_lifetime.cpp
+++ b/tests/gui/test_gui_lifetime.cpp
@@ -14,6 +14,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
 #endif
@@ -26,12 +30,9 @@ void RegisterTests_Lifetime(ImGuiTestEngine *engine)
     ImGuiTest *t = IM_REGISTER_TEST(engine, "lifetime", "close_reference_during_stats");
     t->TestFunc  = [](ImGuiTestContext *ctx)
     {
-        while (hdrview()->num_images() > 0) hdrview()->close_image(0);
-        ctx->Yield();
+        reset_images(ctx);
 
-        hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
-        for (int frame = 0; frame < 240 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
-        IM_CHECK(hdrview()->num_images() == 2);
+        IM_CHECK_EQ(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2}), 2);
 
         // Compare image 0 against image 1: only a blend mode other than Normal makes calculate() sample
         // the reference, which is what puts the reference's channels behind the raw pointers.
@@ -45,13 +46,15 @@ void RegisterTests_Lifetime(ImGuiTestEngine *engine)
         IM_CHECK(img != nullptr);
         auto &group = img->groups[img->selected_group];
         for (int c = 0; c < group.num_channels; ++c)
-            img->channels[group.channels[c]].update_stats(c, hdrview()->current_image(),
-                                                          hdrview()->reference_image());
+            img->channels[group.channels[c]].update_stats(c, hdrview()->current_image(), hdrview()->reference_image());
 
         hdrview()->close_image(1);
 
-        // Let the worker run against the freed channels.
-        for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+        // Deliberately a soak rather than a wait for some condition: there is no state to wait for, and
+        // the point is to give the worker a window in which to touch the channels it no longer owns. What
+        // catches that is the sanitizer job, so the window has to exist even though nothing observable
+        // changes -- and it is a duration, since frames are no longer paced by anything.
+        soak(ctx, std::chrono::milliseconds(250));
 
         IM_CHECK(hdrview()->num_images() == 1);
     };

--- a/tests/gui/test_gui_loader.cpp
+++ b/tests/gui/test_gui_loader.cpp
@@ -15,15 +15,13 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
-#include <miniz.h>
-#include <spdlog/sinks/base_sink.h>
-#include <spdlog/spdlog.h>
+#include "../test_log_capture.h"
+#include "test_gui_support.h"
 
-#include <algorithm>
+#include <miniz.h>
+
 #include <filesystem>
 #include <fstream>
-#include <memory>
-#include <mutex>
 
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
@@ -33,16 +31,6 @@ namespace fs = std::filesystem;
 
 namespace
 {
-
-//! A fresh, empty directory under the system temp dir, canonicalized the way the loader stores paths.
-fs::path make_temp_dir(const char *stem)
-{
-    std::error_code ec;
-    fs::path        d = fs::temp_directory_path(ec) / fmt::format("hdrview_watch_test_{}", stem);
-    fs::remove_all(d, ec);
-    fs::create_directories(d, ec);
-    return fs::weakly_canonical(d, ec);
-}
 
 //! Copies the fixture into `dir` under `name`, returning its path.
 fs::path place_fixture(const fs::path &dir, const char *name)
@@ -54,37 +42,6 @@ fs::path place_fixture(const fs::path &dir, const char *name)
 }
 
 bool is_watched(const fs::path &dir) { return hdrview()->image_loader().watched_directories().count(dir) != 0; }
-
-//! Collects everything logged while it is in scope. See the same helper in tests/test_loader_limits.cpp:
-//! refusing an entry up front and failing to extract it look identical from outside, so the warning is the
-//! only thing that tells them apart.
-struct LogCapture
-{
-    struct Sink : spdlog::sinks::base_sink<std::mutex>
-    {
-        std::vector<std::string> messages;
-        void                     sink_it_(const spdlog::details::log_msg &msg) override
-        {
-            messages.emplace_back(msg.payload.data(), msg.payload.size());
-        }
-        void flush_() override {}
-    };
-
-    std::shared_ptr<Sink> sink = std::make_shared<Sink>();
-
-    LogCapture() { spdlog::default_logger()->sinks().push_back(sink); }
-    ~LogCapture()
-    {
-        auto &sinks = spdlog::default_logger()->sinks();
-        sinks.erase(std::remove(sinks.begin(), sinks.end(), sink), sinks.end());
-    }
-
-    bool saw(const std::string &substring) const
-    {
-        return std::any_of(sink->messages.begin(), sink->messages.end(),
-                           [&](const std::string &m) { return m.find(substring) != std::string::npos; });
-    }
-};
 
 //! Writes a zip holding `contents` under "inside.png". A non-zero `declared` overwrites the entry's
 //! uncompressed size in both of its headers, so the archive claims more than it stores; zero leaves the
@@ -124,18 +81,7 @@ fs::path write_zip(const fs::path &dir, const char *name, uint32_t declared, con
     return out;
 }
 
-void reset_images(ImGuiTestContext *ctx)
-{
-    hdrview()->close_all_images();
-    for (int frame = 0; frame < 60 && hdrview()->num_images() != 0; ++frame) ctx->Yield();
-}
-
-void load_and_wait(ImGuiTestContext *ctx, const fs::path &file)
-{
-    const int before = hdrview()->num_images();
-    hdrview()->load_images({file.u8string()});
-    for (int frame = 0; frame < 240 && hdrview()->num_images() <= before; ++frame) ctx->Yield();
-}
+using namespace hdrview_test;
 
 } // namespace
 
@@ -161,7 +107,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         IM_CHECK(is_watched(watch_dir));
 
         // An image from somewhere else entirely; the watched folder stays empty throughout.
-        load_and_wait(ctx, image);
+        load_and_wait(ctx, {image.u8string()});
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK(is_watched(watch_dir));
 
@@ -170,7 +116,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         IM_CHECK(is_watched(watch_dir));
 
         // Nor may closing everything, for the same reason: the folder was asked for in its own right.
-        load_and_wait(ctx, image);
+        load_and_wait(ctx, {image.u8string()});
         hdrview()->close_all_images();
         IM_CHECK(is_watched(watch_dir));
 
@@ -182,7 +128,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         // only because its images were opened is still dropped once none of them is loaded.
         reset_images(ctx);
         hdrview()->load_images({image_dir.u8string()});
-        for (int frame = 0; frame < 240 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK(is_watched(image_dir));
         hdrview()->close_image(0);
@@ -216,7 +162,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         {
             LogCapture log;
             hdrview()->load_images({lying.u8string()});
-            for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+            wait_for_loads(ctx);
             IM_CHECK_EQ(hdrview()->num_images(), 0);
             IM_CHECK(log.saw("Skipping zip entry 'inside.png'"));
         }
@@ -229,7 +175,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         IM_CHECK(!honest.empty());
         reset_images(ctx);
         hdrview()->load_images({honest.u8string()});
-        for (int frame = 0; frame < 240 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 1);
 
         reset_images(ctx);
@@ -252,7 +198,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         const fs::path file = place_fixture(dir, "a.png");
 
         reset_images(ctx);
-        load_and_wait(ctx, file);
+        load_and_wait(ctx, {file.u8string()});
         IM_CHECK_EQ(hdrview()->num_images(), 1);
 
         auto original = hdrview()->image(0);
@@ -261,7 +207,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         // Both scheduled before either can finish, the way the watch loop schedules them.
         hdrview()->reload_image(original);
         hdrview()->reload_image(original);
-        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         // One file, one entry -- whichever reload landed last.
         IM_CHECK_EQ(hdrview()->num_images(), 1);
@@ -271,7 +217,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         // However many pile up, not just two.
         auto current = hdrview()->image(0);
         for (int i = 0; i < 4; ++i) hdrview()->reload_image(current);
-        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK(hdrview()->image(0)->path == fs::path(file));
 
@@ -309,18 +255,18 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         hdrview()->image_loader().clear_recent_files();
 
         hdrview()->load_images({empty_dir.u8string()});
-        for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 0);
         IM_CHECK(!is_recent(empty_dir));
 
         hdrview()->load_images({junk_dir.u8string()});
-        for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 0);
         IM_CHECK(!is_recent(junk_dir));
 
         // And a folder that does hold an image is still recorded.
         hdrview()->load_images({full_dir.u8string()});
-        for (int frame = 0; frame < 240 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK(is_recent(full_dir));
 
@@ -349,7 +295,7 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         {
             LogCapture log;
             hdrview()->load_images({empty.u8string()});
-            for (int frame = 0; frame < 120; ++frame) ctx->Yield();
+            wait_for_loads(ctx);
             IM_CHECK_EQ(hdrview()->num_images(), 0);
             IM_CHECK(log.saw("is empty"));
             // Whatever it says, it must not claim something is missing from the filesystem: the name it
@@ -374,18 +320,18 @@ void RegisterTests_Loader(ImGuiTestEngine *engine)
         const fs::path file = place_fixture(dir, "a.png");
 
         reset_images(ctx);
-        load_and_wait(ctx, file);
+        load_and_wait(ctx, {file.u8string()});
         IM_CHECK_EQ(hdrview()->num_images(), 1);
 
         hdrview()->reload_image(hdrview()->image(0));
         hdrview()->close_image(0);
         IM_CHECK_EQ(hdrview()->num_images(), 0);
 
-        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 0);
 
         // An ordinary load still adds, so this is not refusing arrivals in general.
-        load_and_wait(ctx, file);
+        load_and_wait(ctx, {file.u8string()});
         IM_CHECK_EQ(hdrview()->num_images(), 1);
 
         reset_images(ctx);

--- a/tests/gui/test_gui_multipart.cpp
+++ b/tests/gui/test_gui_multipart.cpp
@@ -23,6 +23,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <string>
 
 // Loads the multi-part fixture and waits for its image count to stabilize (all parts loaded) rather than a
@@ -35,15 +39,9 @@ static void load_multipart(ImGuiTestContext *ctx)
     hdrview()->close_all_images();
     hdrview()->load_images({std::string(HDRVIEW_TEST_OPENEXR_DIR) + "/multipart.0001.exr"});
 
-    int last_count = -1;
-    for (int frame = 0; frame < 240; ++frame)
-    {
-        int count = hdrview()->num_images();
-        if (count > 0 && count == last_count)
-            break;
-        last_count = count;
-        ctx->Yield();
-    }
+    // Every part arrives from one background load, so an empty queue means all of them have -- no need
+    // to watch for the count to stop changing.
+    hdrview_test::wait_for_loads(ctx);
     IM_CHECK(hdrview()->num_images() > 1);
     hdrview()->set_current_image_index(0);
 }
@@ -81,14 +79,14 @@ void RegisterTests_Multipart(ImGuiTestEngine *engine)
         IM_CHECK(parts > 1);
 
         hdrview()->reload_image(hdrview()->image(0));
-        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        hdrview_test::wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), parts);
 
         // And with a second reload already queued behind the first, which is what a file being written
         // repeatedly produces.
         hdrview()->reload_image(hdrview()->image(0));
         hdrview()->reload_image(hdrview()->image(0));
-        for (int frame = 0; frame < 240; ++frame) ctx->Yield();
+        hdrview_test::wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), parts);
 
         for (int i = 0; i < hdrview()->num_images(); ++i) IM_CHECK(hdrview()->image(i) != nullptr);
@@ -104,14 +102,7 @@ void RegisterTests_Multipart(ImGuiTestEngine *engine)
         auto &group = img->groups[img->selected_group];
         IM_CHECK(group.num_channels > 0);
 
-        PixelStats *stats = nullptr;
-        for (int frame = 0; frame < 120; ++frame)
-        {
-            stats = img->channels[group.channels[0]].get_stats();
-            if (stats->computed)
-                break;
-            ctx->Yield();
-        }
+        PixelStats *stats = wait_for_stats(ctx, img->channels[group.channels[0]]);
         IM_CHECK(stats != nullptr);
         IM_CHECK(stats->computed);
 

--- a/tests/gui/test_gui_navigation.cpp
+++ b/tests/gui/test_gui_navigation.cpp
@@ -13,6 +13,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <algorithm>
 #include <cstring>
 #include <vector>
@@ -34,7 +38,7 @@ static void load_both_fixtures(ImGuiTestContext *ctx)
 
     hdrview()->close_all_images();
     hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
-    for (int frame = 0; frame < 120 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
+    wait_for_loads(ctx);
     IM_CHECK_EQ(hdrview()->num_images(), 2);
     IM_CHECK_EQ(hdrview()->num_visible_images(), 2);
 }

--- a/tests/gui/test_gui_session.cpp
+++ b/tests/gui/test_gui_session.cpp
@@ -28,6 +28,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <filesystem>
 #include <fstream>
 
@@ -72,7 +76,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
         // through (see load_images() in src/app-file-io.cpp) - calling it directly with a .hsess path is a
         // faithful stand-in for dragging one onto the app.
         hdrview()->load_images({session_path.string()});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK_EQ(hdrview()->current_image_index(), 0);
@@ -103,7 +107,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
         // itself opens a native file dialog that can't be driven here.
         hdrview()->close_all_images();
         hdrview()->load_session(session_path.string());
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 1);
 
         hdrview()->close_all_images();
@@ -134,7 +138,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
         IM_CHECK(recent_id != 0);
         ctx->ItemClick(recent_id);
 
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK_EQ(hdrview()->current_image_index(), 0);
     };
@@ -165,7 +169,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
         // load_session(const string&) is the non-dialog overload load_images() dispatches .hsess paths to;
         // calling it directly here skips the native file-picker, which can't be driven by the test engine.
         hdrview()->load_session(session_path.string());
-        for (int frame = 0; frame < 120 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 2);
         // The core of the bug: both occurrences of the same path must resolve to distinct Image instances,
@@ -202,7 +206,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
 
         hdrview()->close_all_images();
         hdrview()->load_session(session_path.string());
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         // The missing entry never arrives; only the good one should load, and reference (entry 1) should
         // stay unset rather than the modal hanging or the app crashing.
@@ -218,7 +222,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
         // divisors. None of these values is reachable through the GUI; they stand in for a hand-edited,
         // truncated, or version-skewed file.
         json entry;
-        entry["path"]            = fs::path(HDRVIEW_GUI_TEST_IMAGE).generic_u8string();
+        entry["path"]           = fs::path(HDRVIEW_GUI_TEST_IMAGE).generic_u8string();
         entry["selected_group"] = 9999; // indexed unchecked by raw_pixel() via active_group_index()
 
         json view;
@@ -241,7 +245,7 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
 
         hdrview()->close_all_images();
         hdrview()->load_session(session_path.string());
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK(hdrview()->current_image() != nullptr);

--- a/tests/gui/test_gui_session_bundle.cpp
+++ b/tests/gui/test_gui_session_bundle.cpp
@@ -23,6 +23,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -94,7 +98,7 @@ void RegisterTests_SessionBundle(ImGuiTestEngine *engine)
         hdrview()->close_all_images();
         // The same entry point drag-and-drop and CLI args use.
         hdrview()->load_images({zip_path.string()});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK_EQ(hdrview()->current_image_index(), 0);
@@ -111,7 +115,7 @@ void RegisterTests_SessionBundle(ImGuiTestEngine *engine)
 
         hdrview()->close_all_images();
         hdrview()->load_images({zip_path.string()});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 2);
     };
@@ -144,7 +148,7 @@ void RegisterTests_SessionBundle(ImGuiTestEngine *engine)
 
         hdrview()->close_all_images();
         hdrview()->load_images({zip_path.string()});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() < 2; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 2);
         IM_CHECK(hdrview()->current_image_index() != hdrview()->reference_image_index());
@@ -178,7 +182,7 @@ void RegisterTests_SessionBundle(ImGuiTestEngine *engine)
 
         hdrview()->close_all_images();
         hdrview()->load_session(zip_path.string());
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         IM_CHECK_EQ(hdrview()->current_image_index(), 0);
@@ -227,7 +231,7 @@ void RegisterTests_SessionBundle(ImGuiTestEngine *engine)
 
         hdrview()->close_all_images();
         hdrview()->load_images({zip_path.string()});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
 
         IM_CHECK_EQ(hdrview()->num_images(), 1);
         auto img = hdrview()->image(0);

--- a/tests/gui/test_gui_stats.cpp
+++ b/tests/gui/test_gui_stats.cpp
@@ -13,6 +13,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
 #endif
@@ -25,7 +29,7 @@ void RegisterTests_Stats(ImGuiTestEngine *engine)
         if (hdrview()->num_images() == 0)
         {
             hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE});
-            for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+            wait_for_loads(ctx);
         }
         IM_CHECK(hdrview()->num_images() > 0);
 
@@ -34,14 +38,7 @@ void RegisterTests_Stats(ImGuiTestEngine *engine)
         auto &group = img->groups[img->selected_group];
         IM_CHECK(group.num_channels > 0);
 
-        PixelStats *stats = nullptr;
-        for (int frame = 0; frame < 120; ++frame)
-        {
-            stats = img->channels[group.channels[0]].get_stats();
-            if (stats->computed)
-                break;
-            ctx->Yield();
-        }
+        PixelStats *stats = wait_for_stats(ctx, img->channels[group.channels[0]]);
         IM_CHECK(stats != nullptr);
         IM_CHECK(stats->computed);
 
@@ -64,7 +61,7 @@ void RegisterTests_Stats(ImGuiTestEngine *engine)
         if (hdrview()->num_images() == 0)
         {
             hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE});
-            for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+            wait_for_loads(ctx);
         }
         IM_CHECK(hdrview()->num_images() > 0);
 
@@ -82,14 +79,8 @@ void RegisterTests_Stats(ImGuiTestEngine *engine)
         auto &group = img->groups[img->selected_group];
         IM_CHECK(group.num_channels > 0);
 
-        PixelStats *stats = nullptr;
-        for (int frame = 0; frame < 240; ++frame)
-        {
-            stats = img->channels[group.channels[0]].get_stats();
-            if (stats->computed && stats->settings.roi == hdrview()->roi())
-                break;
-            ctx->Yield();
-        }
+        PixelStats *stats = wait_for_stats(ctx, img->channels[group.channels[0]],
+                                           [](const PixelStats *s) { return s->settings.roi == hdrview()->roi(); });
         IM_CHECK(stats != nullptr);
         IM_CHECK(stats->computed);
         IM_CHECK_EQ(stats->summary.valid_pixels, 0);

--- a/tests/gui/test_gui_support.h
+++ b/tests/gui/test_gui_support.h
@@ -1,0 +1,132 @@
+/** \file test_gui_support.h
+    \author Wojciech Jarosz
+
+    Shared scaffolding for the GUI suite: waiting, loading, and temporary files.
+
+    Every one of these tests has to wait for something -- a background load to land, a window to close, a
+    queue to drain -- and each file had grown its own loop to do it. Besides the duplication, a loop that
+    yields a fixed number of frames is waiting for a duration rather than for the thing it cares about: too
+    long here (a load that finished in three frames still costs two hundred), and potentially too short on
+    a busy CI runner, which is a flake nobody would reproduce locally.
+
+    So there is one primitive, wait_until(), and everything else is phrased in terms of the condition it is
+    actually waiting for.
+*/
+
+#pragma once
+
+#include "app.h"
+#include "image.h"
+#include "imageio/image_loader.h"
+
+#include "imgui_test_engine/imgui_te_context.h"
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+#include <string>
+#include <vector>
+
+namespace hdrview_test
+{
+
+namespace fs = std::filesystem;
+
+//! Yields until `done` holds, or `timeout` passes. Returns whether it held.
+/*!
+    The budget is a duration, not a number of frames. What these tests wait on is background work -- a
+    decode on another thread, a file appearing -- whose length has nothing to do with how fast this thread
+    can spin, and the suite runs with vsync off, so a frame costs microseconds. A frame budget that stood
+    for "about two seconds" at 60 Hz stands for about five milliseconds now, and the wait would return
+    before the work it is waiting for could possibly have finished.
+
+    It is a backstop against hanging the suite, not the thing being waited for: pass a condition that says
+    what has to become true, and the wait costs only as long as that takes.
+*/
+template <typename F>
+bool wait_until(ImGuiTestContext *ctx, F &&done, std::chrono::milliseconds timeout = std::chrono::seconds(20))
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!done())
+    {
+        if (std::chrono::steady_clock::now() > deadline)
+            return done();
+        ctx->Yield();
+    }
+    return true;
+}
+
+//! Waits for every queued background load to be drained into the image list.
+/*!
+    This is the honest end of a load: BackgroundImageLoader hands finished images to the app and drops them
+    from its queue in the same pass, so an empty queue means every image that is going to arrive has. It is
+    also the only way to wait for an image *not* to appear -- a fixed number of frames only ever says "not
+    yet".
+*/
+inline bool wait_for_loads(ImGuiTestContext *ctx)
+{
+    return wait_until(ctx, [] { return hdrview()->image_loader().num_pending_images() == 0; });
+}
+
+//! Loads `paths` and waits for all of them, returning the resulting image count.
+inline int load_and_wait(ImGuiTestContext *ctx, const std::vector<std::string> &paths)
+{
+    hdrview()->load_images(paths);
+    wait_for_loads(ctx);
+    return hdrview()->num_images();
+}
+
+//! Closes everything and waits for the list to empty, so a test starts from a known state.
+inline void reset_images(ImGuiTestContext *ctx)
+{
+    hdrview()->close_all_images();
+    wait_until(ctx, [] { return hdrview()->num_images() == 0; });
+}
+
+//! Keeps the frame loop running for `duration`, whatever happens.
+/*!
+    For the one case that is not waiting for a condition: giving a thread that should no longer be running
+    a window in which to prove that it is. There is nothing to observe -- what catches the misbehaviour is
+    the sanitizer -- so the window is a duration, and has to stay one. Counting frames instead would have
+    quietly become a 400x shorter soak the moment the suite stopped waiting on the display.
+*/
+inline void soak(ImGuiTestContext *ctx, std::chrono::milliseconds duration)
+{
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline) ctx->Yield();
+}
+
+//! Waits for a channel's statistics to finish, and returns them.
+/*!
+    Statistics are computed off the main thread, and get_stats() hands back a different object as that work
+    lands, so it has to be re-read each time round rather than cached before the wait.
+*/
+inline PixelStats *wait_for_stats(ImGuiTestContext *ctx, Channel &channel,
+                                  const std::function<bool(const PixelStats *)> &also = {})
+{
+    PixelStats *stats = nullptr;
+    wait_until(ctx,
+               [&]
+               {
+                   stats = channel.get_stats();
+                   return stats && stats->computed && (!also || also(stats));
+               });
+    return stats;
+}
+
+//! A fresh, empty directory under the system temp dir, canonicalized the way the loader stores paths.
+inline fs::path make_temp_dir(const char *stem)
+{
+    std::error_code ec;
+    fs::path        d = fs::temp_directory_path(ec) / (std::string("hdrview_test_") + stem);
+    fs::remove_all(d, ec);
+    fs::create_directories(d, ec);
+    return fs::weakly_canonical(d, ec);
+}
+
+} // namespace hdrview_test

--- a/tests/gui/test_gui_view.cpp
+++ b/tests/gui/test_gui_view.cpp
@@ -13,6 +13,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
 #endif
@@ -22,7 +26,7 @@ static void ensure_image_loaded(ImGuiTestContext *ctx)
     if (hdrview()->num_images() == 0)
     {
         hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE});
-        for (int frame = 0; frame < 120 && hdrview()->num_images() == 0; ++frame) ctx->Yield();
+        wait_for_loads(ctx);
     }
     IM_CHECK(hdrview()->num_images() > 0);
 }
@@ -76,9 +80,9 @@ void RegisterTests_View(ImGuiTestEngine *engine)
         ctx->MenuClick("View/100%");
     };
 
-    // Flipping mirrors the image inside the rectangle it already occupies, so the two menu items toggle
-    // their state without the image moving or resizing on screen. The transforms behind that rectangle are
-    // exercised in their own right by the "viewport" tests.
+    // That the two menu items toggle the two axes. Where the image then lands is the "viewport" tests'
+    // subject: they state the placement against a specification rather than against another part of the
+    // transform, and there is only one flip state for a menu click and an action-pointer write to reach.
     t           = IM_REGISTER_TEST(engine, "view", "flip_toggle");
     t->TestFunc = [](ImGuiTestContext *ctx)
     {
@@ -86,23 +90,11 @@ void RegisterTests_View(ImGuiTestEngine *engine)
         bool orig_h = *hdrview()->action("Flip horizontally").p_selected;
         bool orig_v = *hdrview()->action("Flip vertically").p_selected;
 
-        const Box2i dw        = hdrview()->current_image()->display_window;
-        auto        on_screen = [&dw] {
-            return Box2f{hdrview()->vp_pos_at_pixel(float2{dw.min}), hdrview()->vp_pos_at_pixel(float2{dw.max})}
-                .make_valid();
-        };
-        const Box2f before = on_screen();
-
         ctx->SetRef("##MainMenuBar");
         ctx->MenuClick("View/Flip horizontally");
         IM_CHECK_EQ(*hdrview()->action("Flip horizontally").p_selected, !orig_h);
-        IM_CHECK(la::maxelem(la::abs(on_screen().min - before.min)) < 1e-2f);
-        IM_CHECK(la::maxelem(la::abs(on_screen().max - before.max)) < 1e-2f);
-
         ctx->MenuClick("View/Flip vertically");
         IM_CHECK_EQ(*hdrview()->action("Flip vertically").p_selected, !orig_v);
-        IM_CHECK(la::maxelem(la::abs(on_screen().min - before.min)) < 1e-2f);
-        IM_CHECK(la::maxelem(la::abs(on_screen().max - before.max)) < 1e-2f);
 
         // restore
         ctx->MenuClick("View/Flip horizontally");

--- a/tests/gui/test_gui_viewport.cpp
+++ b/tests/gui/test_gui_viewport.cpp
@@ -14,6 +14,10 @@
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
+#include "test_gui_support.h"
+
+using namespace hdrview_test;
+
 #include <cmath>
 
 #ifndef HDRVIEW_GUI_TEST_IMAGE
@@ -25,16 +29,6 @@
 
 namespace
 {
-
-//! Loads `paths` and waits for all of them to arrive.
-void load_and_wait(ImGuiTestContext *ctx, const std::vector<std::string> &paths)
-{
-    hdrview()->close_all_images();
-    for (int frame = 0; frame < 60 && hdrview()->num_images() != 0; ++frame) ctx->Yield();
-    hdrview()->load_images(paths);
-    for (int frame = 0; frame < 240 && hdrview()->num_images() < (int)paths.size(); ++frame) ctx->Yield();
-    IM_CHECK_EQ(hdrview()->num_images(), (int)paths.size());
-}
 
 bool approx(float2 a, float2 b, float eps = 1e-2f) { return la::maxelem(la::abs(a - b)) < eps; }
 
@@ -90,7 +84,8 @@ void RegisterTests_Viewport(ImGuiTestEngine *engine)
     ImGuiTest *t = IM_REGISTER_TEST(engine, "viewport", "pixel_transform_is_affine_and_invertible");
     t->TestFunc  = [](ImGuiTestContext *ctx)
     {
-        load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE});
+        reset_images(ctx);
+        IM_CHECK_EQ(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE}), 1);
 
         auto      img = hdrview()->current_image();
         FlipState flip;
@@ -146,7 +141,8 @@ void RegisterTests_Viewport(ImGuiTestEngine *engine)
     {
         // Two images of different sizes, so a reference whose windows differ from the current image's is
         // exercised rather than the coincidence of them matching.
-        load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
+        reset_images(ctx);
+        IM_CHECK_EQ(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2}), 2);
         hdrview()->set_current_image_index(0);
         hdrview()->set_reference_image_index(1);
         auto img = hdrview()->current_image();

--- a/tests/test_loader_limits.cpp
+++ b/tests/test_loader_limits.cpp
@@ -16,9 +16,9 @@
 #include "imageio/raw.h"
 #include "imageio/stb.h"
 
+#include "test_log_capture.h"
+
 #include <miniz.h>
-#include <spdlog/sinks/base_sink.h>
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <memory>
@@ -170,40 +170,6 @@ void declare_uncompressed_size(std::string &zip, uint32_t declared)
     patch_at("PK\x03\x04", 22);
     patch_at("PK\x01\x02", 24);
 }
-
-//! Collects everything logged while it is in scope, so a test can assert that a call site was reached.
-/*!
-    The guard's only observable effect is that the extraction is not attempted: an archive lying about an
-    entry's size fails to extract either way, just with a large allocation and a decompression first. So the
-    warning is what distinguishes "refused up front" from "tried and failed", and the log is where it shows.
-*/
-struct LogCapture
-{
-    struct Sink : spdlog::sinks::base_sink<std::mutex>
-    {
-        std::vector<std::string> messages;
-        void                     sink_it_(const spdlog::details::log_msg &msg) override
-        {
-            messages.emplace_back(msg.payload.data(), msg.payload.size());
-        }
-        void flush_() override {}
-    };
-
-    std::shared_ptr<Sink> sink = std::make_shared<Sink>();
-
-    LogCapture() { spdlog::default_logger()->sinks().push_back(sink); }
-    ~LogCapture()
-    {
-        auto &sinks = spdlog::default_logger()->sinks();
-        sinks.erase(std::remove(sinks.begin(), sinks.end(), sink), sinks.end());
-    }
-
-    bool saw(const std::string &substring) const
-    {
-        return std::any_of(sink->messages.begin(), sink->messages.end(),
-                           [&](const std::string &m) { return m.find(substring) != std::string::npos; });
-    }
-};
 
 } // namespace
 

--- a/tests/test_log_capture.h
+++ b/tests/test_log_capture.h
@@ -1,0 +1,57 @@
+/** \file test_log_capture.h
+    \author Wojciech Jarosz
+
+    Collects everything logged while it is in scope.
+
+    Some guards have no other observable effect. Refusing to extract a zip entry that lies about its size
+    and failing to extract it look identical from outside -- same empty result, same absent image -- and
+    differ only in the memory and time spent finding out. Asserting on the returned value there passes
+    whether or not the guard exists; the warning is what tells the two apart.
+
+    Shared by the doctest and GUI suites, which both need it for exactly that reason.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+#include <string>
+#include <vector>
+
+class LogCapture
+{
+public:
+    LogCapture() { spdlog::default_logger()->sinks().push_back(m_sink); }
+    ~LogCapture()
+    {
+        auto &sinks = spdlog::default_logger()->sinks();
+        sinks.erase(std::remove(sinks.begin(), sinks.end(), m_sink), sinks.end());
+    }
+
+    //! Whether anything logged so far contains `substring`.
+    bool saw(const std::string &substring) const
+    {
+        std::lock_guard<std::mutex> lock(m_sink->mutex_);
+        return std::any_of(m_sink->messages.begin(), m_sink->messages.end(),
+                           [&](const std::string &m) { return m.find(substring) != std::string::npos; });
+    }
+
+private:
+    struct Sink : spdlog::sinks::base_sink<std::mutex>
+    {
+        std::vector<std::string> messages;
+        std::mutex               mutex_;
+
+        void sink_it_(const spdlog::details::log_msg &msg) override
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            messages.emplace_back(msg.payload.data(), msg.payload.size());
+        }
+        void flush_() override {}
+    };
+
+    std::shared_ptr<Sink> m_sink = std::make_shared<Sink>();
+};


### PR DESCRIPTION
The GUI suite took 57 seconds to run 48 tests, and almost none of it was work. `ctest` overall is now
**6.7 seconds instead of 31**, with the same 163 tests.

## Waiting on the display

The test binary inherited the app's `vsyncToMonitor` and `fpsIdling`. Every test in the suite is a loop of
"yield until this becomes true", so each yield blocked until the monitor was ready, and idling throttled
the rate further whenever nothing was animating — which during a test run is nearly always. The suite
spent its life in the swap.

Both are off now in `enable_gui_test_engine()`, where `ConfigRunSpeed` is already overridden for the same
kind of reason. That is the entire speedup. It applies to the interactive run too: watching the suite at
full speed is less useful than watching it at 60 Hz, but a run that finishes in seconds is the better tool
for finding out why a test failed, and the alternative is a knob nobody would remember to set.

## What that exposed

Turning it off broke two tests immediately, which is the more interesting half. They waited a fixed 120
frames for a background decode. At 60 Hz that is about two seconds; once frames cost microseconds it is
about five milliseconds. **Nothing had ever guaranteed the duration** — the same tests would fail today on
a runner busy enough to slow a decode. This was a flake waiting for a bad afternoon, not something the
change introduced.

A frame count cannot bound a wait on another thread. There is one primitive now, `wait_until()`, bounded by
wall clock, with the conditions named on top of it:

- `wait_for_loads()` — the loader's queue empty. This is the honest end of a load, and the only way to wait
  for an image *not* to appear; a frame count only ever says "not yet".
- `wait_for_stats()`, `load_and_wait()`, `reset_images()`.

Eight files had grown their own version of this loop. `LogCapture` had been written out twice — once in the
doctest suite and once in the GUI suite — and moves to a header both include.

## The one place this could have quietly cost coverage

`lifetime/close_reference_during_stats` soaks deliberately: it gives a worker a window in which to touch
channels it no longer owns, and what catches that is the sanitizer job, not an assertion. Left at 120
frames it would have become a **400× shorter** soak the moment the suite stopped waiting on the display —
a test that still passes while no longer testing anything.

It is a wall-clock `soak(250ms)` now, and says why it must stay a duration. `view/flip_toggle` also loses
its geometry assertions: they predate
`viewport/images_land_where_the_viewport_specifies`, which states the placement against a specification
rather than against another part of the transform, and a menu click and an action-pointer write reach the
same flip state. Confirmed by reverting the flip fix and watching the viewport test fail without them.

Otherwise nothing was deleted. The suite was slow and duplicative in its *scaffolding*, not padded in its
coverage, and cutting tests to reach a smaller number would have been the wrong read of "comprehensive".

## Verification

| | |
|---|---|
| plain `ctest` | 163/163, **6.7 s** (was ~31 s) |
| ASan + UBSan, doctests | 162/162 |
| ASan + UBSan, GUI suite | passed, **zero sanitizer reports** |

The sanitizer runs used CI's own options (`abort_on_error=1`, `halt_on_error=1`, the repo's UBSan
suppressions). Worth doing rather than leaving to CI, because this change alters the GUI suite's timing by
more than a factor of ten and that job runs the suite instrumented — and because the soak above is exactly
the kind of thing a timing change can hollow out without failing.

## One thing for afterwards

While this was in progress, master added `tests/gui/test_gui_info.cpp` using the fixed-frame idiom, and it
had to be converted here. That idiom is what anyone reaches for, because it is what every test did. These
helpers need to be the obvious path or the next test will do the same — worth a line in CLAUDE.md's
"quirks worth knowing before writing new tests here" list, which I would rather add once this has been
looked at than fold into the same change.
