### PR TITLE
Build the web app on Ubuntu instead of macOS

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -33,32 +33,36 @@ env:
 jobs:
   build_emscripten:
     name: Build and deploy emscripten webapp
-    runs-on: macos-14
+    runs-on: ubuntu-24.04
     # Shared with release.yml's prerelease deploy (same destination_dir: dev), to avoid two runs racing
     # to push gh-pages.
     concurrency:
       group: gh-pages-deploy-dev
 
     steps:
+      # Everything the wasm build links is fetched by CPM and compiled by emcc, so only the host-side build
+      # tools are needed here - none of the -dev packages ci-linux.yml installs.
       - name: Install dependencies
-        # downloading old version of emscripten since 4.0.13 is broken
-        # run: |
-        #   brew install ninja libpng
-        #   curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/9990c9ddd731e97581a3312ca0358b45b14d1cc6/Formula/e/emscripten.rb
-        #   FORMULA_DIR="$(brew --repository)/Library/Taps/wkjarosz/homebrew-emscripten-old/Formula/"
-        #   mkdir -p "$FORMULA_DIR"
-        #   mv ./emscripten.rb "$FORMULA_DIR"
-        #   brew install wkjarosz/emscripten-old/emscripten
-        run: |
-          brew install ninja emscripten libpng
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
 
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
-      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
-      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
+      # Placed after the checkout, whose default clean would otherwise wipe actions-cache-folder back out
+      # of the workspace.
+      #
+      # Pinned rather than tracking latest: this job publishes straight to gh-pages, so a toolchain
+      # regression ships a broken web app with nothing in the diff to explain it. Emscripten 4.0.13 does not
+      # build HDRView; don't pin back to it.
+      - name: Install Emscripten
+        uses: emscripten-core/setup-emsdk@v16
+        with:
+          version: 6.0.8
+          actions-cache-folder: emsdk-cache
+
+      # cpm_modules is always at the workspace root (CPM_SOURCE_CACHE above), so neither path nor hashFiles
+      # needs a "**" that would walk into build/.
       - uses: actions/cache@v5
         with:
           path: "cpm_modules"
@@ -66,13 +70,14 @@ jobs:
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-
 
-      # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
+      # Caching of build artifacts to reduce total build time. This action only installs ccache and restores
+      # its cache; the compiler-launcher flags on the configure step are what route emcc through it.
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
 
       - name: Configure CMake
         run: |
-          emcmake cmake --preset emscripten
+          emcmake cmake --preset emscripten -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build/emscripten --parallel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,24 +271,36 @@ jobs:
 
   build_emscripten:
     name: Build and deploy emscripten webapp
-    runs-on: macos-14
+    runs-on: ubuntu-24.04
     # Prerelease tags share ci-emscripten.yml's /dev group (same destination_dir); final releases get
     # their own, since /release is never touched by anything else.
     concurrency:
       group: gh-pages-deploy-${{ contains(github.ref_name, '-') && 'dev' || 'release' }}
 
     steps:
+      # Everything the wasm build links is fetched by CPM and compiled by emcc, so only the host-side build
+      # tools are needed here - none of the -dev packages the Linux jobs install.
       - name: Install dependencies
-        run: |
-          brew install ninja emscripten libpng
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
 
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      # path and hashFiles avoid a workspace-root "**", which would walk into build/'s CPack staging symlink and
-      # every installed Xcode SDK - prohibitively expensive to glob. cpm_modules is always at the workspace root
-      # (CPM_SOURCE_CACHE above), so path needs no "**" either.
+      # Placed after the checkout, whose default clean would otherwise wipe actions-cache-folder back out
+      # of the workspace.
+      #
+      # Pinned rather than tracking latest, and kept in step with ci-emscripten.yml: this job publishes
+      # straight to gh-pages, so a toolchain regression ships a broken web app with nothing in the diff to
+      # explain it. Emscripten 4.0.13 does not build HDRView; don't pin back to it.
+      - name: Install Emscripten
+        uses: emscripten-core/setup-emsdk@v16
+        with:
+          version: 6.0.8
+          actions-cache-folder: emsdk-cache
+
+      # cpm_modules is always at the workspace root (CPM_SOURCE_CACHE above), so neither path nor hashFiles
+      # needs a "**" that would walk into build/.
       - uses: actions/cache@v5
         with:
           path: "cpm_modules"
@@ -296,13 +308,14 @@ jobs:
           restore-keys: |
             ${{ github.workflow }}-cpm-modules-
 
-      # Setup caching of build artifacts to reduce total build time (only Linux and MacOS)
+      # Caching of build artifacts to reduce total build time. This action only installs ccache and restores
+      # its cache; the compiler-launcher flags on the configure step are what route emcc through it.
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
 
       - name: Configure CMake
         run: |
-          emcmake cmake --preset emscripten
+          emcmake cmake --preset emscripten -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build/emscripten --parallel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,11 @@ Windows (Visual Studio generator):
 cmake --preset windows-msvc
 cmake --build --preset windows-msvc-release
 ```
-Emscripten (web build):
+Emscripten (web build) — always through `emcmake`, which points `CMAKE_TOOLCHAIN_FILE` at the active SDK.
+The preset's own `toolchainFile` resolves only against a Homebrew-style `EMSDK`, not an `emsdk`-installed
+one, so `cmake --preset emscripten` on its own is not portable:
 ```bash
-cmake --preset emscripten
+emcmake cmake --preset emscripten
 cmake --build build/emscripten --parallel
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1343,6 +1343,16 @@ if(HDRVIEW_ENABLE_LIBRAW)
     message(STATUS "No math library needed on Windows/MSVC/Emscripten for LibRaw")
   endif()
 
+  # Emscripten's OpenMP runtime is pthread-backed, so in a non-pthread build it drags the -mt sysroot
+  # libraries onto a link line that already carries the single-threaded ones and every pthread symbol comes
+  # up duplicated. LibRaw-cmake defaults ENABLE_OPENMP to ON and only probes whether OpenMP works, so the
+  # exclusion has to be stated here.
+  if(EMSCRIPTEN AND NOT HELLOIMGUI_EMSCRIPTEN_PTHREAD)
+    set(LIBRAW_OPENMP OFF)
+  else()
+    set(LIBRAW_OPENMP ON)
+  endif()
+
   CPMAddPackage(
       NAME LibRaw
       GITHUB_REPOSITORY LibRaw/LibRaw-cmake
@@ -1354,6 +1364,7 @@ if(HDRVIEW_ENABLE_LIBRAW)
               "LIBRAW_BUILD_TESTS OFF"
               "LIBRAW_BUILD_EXAMPLES OFF"
               "LIBRAW_INSTALL OFF"
+              "ENABLE_OPENMP ${LIBRAW_OPENMP}"
               "ENABLE_X3FTOOLS ${HDRVIEW_ENABLE_X3F}"
       EXCLUDE_FROM_ALL YES
       SYSTEM YES
@@ -1895,7 +1906,9 @@ if(EMSCRIPTEN)
   hello_imgui_set_emscripten_target_initial_memory_megabytes(HDRView 120)
 endif()
 
-if(UNIX AND NOT IS_MULTI AND NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
+# Emscripten is excluded even though it sets UNIX: the target file there is the HTML shell, which GNU
+# strip rejects outright (Apple's only warns), and emcc has already stripped the wasm it links.
+if(UNIX AND NOT EMSCRIPTEN AND NOT IS_MULTI AND NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
   add_custom_command(
     TARGET HDRView
     POST_BUILD


### PR DESCRIPTION
Moves the emscripten job off `macos-14` and onto `ubuntu-24.04`, in both `ci-emscripten.yml` and the copy in `release.yml`. It was the last job on a macOS runner, and nothing about it needs one: every library it links is fetched by CPM and compiled by emcc, so the host only supplies build tools.

## What changed

- **Toolchain**: `brew install emscripten` → `emscripten-core/setup-emsdk@v16` pinned to `6.0.8`. Homebrew's emscripten was the one toolchain here that moved without a commit — which is what the disabled formula-pinning block in the old Install step was working around. That block goes away.
- **Deps**: `brew install ninja emscripten libpng` → `apt-get install cmake ninja-build`. `libpng` was never used; CPM builds it for wasm regardless.
- **ccache**: the step has been installing ccache and doing nothing else, since the action shims `gcc`/`clang` on PATH and never `emcc`. Configure now passes the same compiler-launcher flags the other jobs already use.

## Two fixes needed to survive a Linux host

Both are latent bugs rather than anything specific to this move:

1. **`POST_BUILD` strip fired under Emscripten**, which sets `UNIX`, with the target file being the HTML shell. Apple's `strip` warns and exits 0 — a silent no-op on macOS all along. GNU binutils `strip` errors and fails the build. `emcc` has already stripped the wasm by then, so the step is excluded rather than repaired.

2. **LibRaw picked up OpenMP.** LibRaw-cmake defaults `ENABLE_OPENMP=ON` and only probes whether OpenMP works. It doesn't under the emscripten Homebrew ships today (6.0.1), which is why this never surfaced — but it does under newer ones, and emscripten's OpenMP runtime is pthread-backed. In this non-pthread build that pulls the `-mt` sysroot libraries onto a link line already carrying the single-threaded ones, and every pthread symbol comes up duplicated. Gated off the same way `OPENEXR_THREADING_OPTIONS` already is.

Native builds are unaffected: `linux-cpm` still configures LibRaw with OpenMP `ON`, and the strip step still runs everywhere except Emscripten.

## Verification

Built end to end on Linux — configure, build, `cmake --install` — and the resulting wasm was loaded in headless Chrome on SwiftShader, where it reaches `Welcome to HDRView!` and renders the full UI at 24 fps. That is more than the macOS job has ever checked; nothing in either workflow loads the build it publishes.

Worth watching on this PR specifically: the run deploys to gh-pages `/dev/` like every PR does, so the dev site becomes this Ubuntu build. If it looks wrong, don't merge and re-dispatch `ci-emscripten.yml` on master to restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
