### PR TITLE
Give the web build AVIF and J2K, and fix wheel zoom and pinch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,16 @@ magic-byte sniff (not file extension) and an `#if HDRVIEW_ENABLE_<FORMAT>` compi
 CMake options above. To add a new format: implement `is_X_image()` + `load_X_image()` in a new
 `imageio/x.{h,cpp}`, add a CMake option/target wiring, and register it in `default_loaders()`.
 
+libheif is the one dependency that finds its own codecs, with `find_package()` calls that only ever turn up
+an installed library — which Emscripten has none of. So the web build builds libaom (AVIF) and OpenJPEG
+(J2K) itself, in `CMakeLists.txt` just above the libheif block, and reaches libheif through the
+`<pkg>-extra.cmake` files it writes into `CMAKE_FIND_PACKAGE_REDIRECTS_DIR` — CPM already leaves a redirect
+config there for every package it adds, and the `-extra.cmake` fills in the `AOM_*`/`OPENJPEG_*` variables
+that libheif's own find modules would otherwise have set. Both of those packages also write their own
+preferences into the CMake cache, which is global and read at generate time, so each block undoes that
+afterwards; see the comments there. `HEIC`/`AVCI` stay off in released builds for patent reasons, and
+`HTJ2K` encoding is off in the web build because libheif's `FindOPENJPH.cmake` insists on an install tree.
+
 ### Rendering backend abstraction (GL vs Metal)
 `renderpass.h`, `shader.h`, and `texture.h` declare platform-agnostic interfaces (adapted from NanoGUI),
 each with two mutually-exclusive implementations selected at CMake configure time:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1181,6 +1181,106 @@ else()
   endif()
 endif()
 
+# libheif reaches its codecs through find_package(), which only ever turns up a library the system has
+# installed, and Emscripten has none -- so the AV1 codec AVIF needs is built here instead. CPM already
+# leaves a redirect in CMAKE_FIND_PACKAGE_REDIRECTS_DIR that points libheif's find_package(AOM) at this
+# build of it; the -extra.cmake below adds the rest of what libheif's own FindAOM.cmake would have set.
+if(EMSCRIPTEN AND HDRVIEW_ENABLE_AVIF)
+  # aom appends the compiler flags it wants straight to the cache with FORCE. A cache entry is global and
+  # read at generate time, so those flags reach every target in the build -- the -std=c99 among them stops
+  # OpenEXR's C sources compiling. Snapshot what aom rewrites and put it back once it has been added, the
+  # cache entry from the cache and the directory-scope variable from the directory, or a configure would
+  # bake this directory's own flags into the cache for the next one to append to again.
+  set(HDRVIEW_AOM_CLOBBERED_VARS "")
+  foreach(_flags CMAKE_C_FLAGS CMAKE_CXX_FLAGS CMAKE_EXE_LINKER_FLAGS)
+    foreach(_config "" "_DEBUG" "_RELEASE" "_MINSIZEREL" "_RELWITHDEBINFO")
+      list(APPEND HDRVIEW_AOM_CLOBBERED_VARS "${_flags}${_config}")
+    endforeach()
+  endforeach()
+  foreach(_var IN LISTS HDRVIEW_AOM_CLOBBERED_VARS)
+    set("HDRVIEW_SAVED_${_var}" "${${_var}}")
+    set("HDRVIEW_SAVED_CACHE_${_var}" "$CACHE{${_var}}")
+    get_property(_doc CACHE "${_var}" PROPERTY HELPSTRING)
+    set("HDRVIEW_SAVED_DOC_${_var}" "${_doc}")
+  endforeach()
+
+  CPMAddPackage(
+    NAME aom
+    VERSION 3.13.1
+    URL https://storage.googleapis.com/aom-releases/libaom-3.13.1.tar.gz
+    OPTIONS # No SIMD path, no thread pool, and no CPU to probe for features: wasm has none of aom's
+            # assembly, and this build has no pthreads.
+            "AOM_TARGET_CPU generic"
+            "CONFIG_MULTITHREAD 0"
+            "CONFIG_RUNTIME_CPU_DETECT 0"
+            "CONFIG_AV1_DECODER 1"
+            "CONFIG_AV1_ENCODER 1"
+            # Container and scaling code only aom's own command-line tools use
+            "CONFIG_WEBM_IO 0"
+            "CONFIG_LIBYUV 0"
+            "ENABLE_EXAMPLES OFF"
+            "ENABLE_TESTS OFF"
+            "ENABLE_TOOLS OFF"
+            "ENABLE_DOCS OFF"
+            "BUILD_SHARED_LIBS OFF"
+    SYSTEM YES
+    EXCLUDE_FROM_ALL YES
+  )
+  foreach(_var IN LISTS HDRVIEW_AOM_CLOBBERED_VARS)
+    set("${_var}" "${HDRVIEW_SAVED_CACHE_${_var}}" CACHE STRING "${HDRVIEW_SAVED_DOC_${_var}}" FORCE)
+    set("${_var}" "${HDRVIEW_SAVED_${_var}}")
+  endforeach()
+
+  if(NOT aom_ADDED)
+    message(FATAL_ERROR "Failed to fetch libaom, which the Emscripten build needs for AVIF support.")
+  endif()
+  message(STATUS "Will build libaom library")
+  mark_as_system_library(aom)
+  disable_target_warnings(aom)
+  # aom publishes its headers only to an install tree, so the source directory is what libheif's plugins
+  # have to include the aom/*.h they ask for from.
+  file(
+    WRITE "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/aom-extra.cmake"
+    "set(AOM_LIBRARIES aom)\n" "set(AOM_INCLUDE_DIRS \"${aom_SOURCE_DIR}\")\n"
+    "set(AOM_DECODER_FOUND TRUE)\n" "set(AOM_ENCODER_FOUND TRUE)\n"
+  )
+endif()
+
+# The same story as libaom above: OpenJPEG is what decodes the J2K- and HTJ2K-compressed HEIF images, and
+# under Emscripten there is no installed copy for libheif's find_package(OpenJPEG) to turn up.
+if(EMSCRIPTEN AND HDRVIEW_ENABLE_J2K)
+  CPMAddPackage(
+    NAME OpenJPEG
+    VERSION 2.5.4
+    GITHUB_REPOSITORY uclouvain/openjpeg
+    GIT_TAG v2.5.4
+    OPTIONS "BUILD_SHARED_LIBS OFF"
+            "BUILD_CODEC OFF"
+            "BUILD_TESTING OFF"
+            "BUILD_PKGCONFIG_FILES OFF"
+    SYSTEM YES
+    EXCLUDE_FROM_ALL YES
+  )
+  if(NOT OpenJPEG_ADDED)
+    message(FATAL_ERROR "Failed to fetch OpenJPEG, which the Emscripten build needs for J2K support.")
+  endif()
+  # OpenJPEG puts the legacy EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH into the cache, and both are
+  # global: left there, every target in the build -- HDRView's own executable included -- is written into
+  # OpenJPEG's bin directory. Nothing else here sets them, so dropping them restores the default layout.
+  unset(EXECUTABLE_OUTPUT_PATH CACHE)
+  unset(LIBRARY_OUTPUT_PATH CACHE)
+
+  message(STATUS "Will build OpenJPEG library")
+  mark_as_system_library(openjp2)
+  disable_target_warnings(openjp2)
+  # openjpeg.h lives beside the sources, and the opj_config.h it includes is generated into the build tree.
+  file(
+    WRITE "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/openjpeg-extra.cmake"
+    "set(OPENJPEG_FOUND TRUE)\n" "set(OPENJPEG_LIBRARIES openjp2)\n"
+    "set(OPENJPEG_INCLUDE_DIRS \"${OpenJPEG_SOURCE_DIR}/src/lib/openjp2;${OpenJPEG_BINARY_DIR}/src/lib/openjp2\")\n"
+  )
+endif()
+
 if(HDRVIEW_ENABLE_LIBHEIF)
   CPMAddPackage(
     NAME Libheif
@@ -1216,6 +1316,12 @@ if(HDRVIEW_ENABLE_LIBHEIF)
   )
   if(Libheif_ADDED)
     message(STATUS "Will build libheif library")
+    if(EMSCRIPTEN)
+      # Otherwise libheif compiles in the embind bindings for its JavaScript API, which HDRView has no use
+      # for and which no longer compile: they bind raw pointers, which embind has since made an error. This
+      # is the switch libheif's own build-emscripten.sh uses to leave them out.
+      target_compile_definitions(heif PRIVATE __EMSCRIPTEN_STANDALONE_WASM__=1)
+    endif()
     # Remove the doc_doxygen target created with 'ALL'
     if(TARGET doc_doxygen)
       set_target_properties(doc_doxygen PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,16 +19,14 @@
     {
       "name": "emscripten",
       "displayName": "Emscripten (WebAssembly)",
-      "description": "Build for web using Emscripten (requires EMSDK environment variable)",
+      "description": "Build for web using Emscripten (requires EMSDK environment variable). HEIC and AVCI are off for the same patent reasons as in released builds; HTJ2K encoding is off because libheif only accepts an already-installed OpenJPH, and Emscripten installs nothing.",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "toolchainFile": "$env{EMSDK}/cmake/Modules/Platform/Emscripten.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "MinSizeRel",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/${presetName}/deploy",
-        "HDRVIEW_ENABLE_J2K": "OFF",
         "HDRVIEW_ENABLE_HTJ2K": "OFF",
-        "HDRVIEW_ENABLE_AVIF": "OFF",
         "HDRVIEW_ENABLE_HEIC": "OFF",
         "HDRVIEW_ENABLE_AVCI": "OFF",
         "UHDR_BUILD_DEPS": "ON"

--- a/src/app-zoom.cpp
+++ b/src/app-zoom.cpp
@@ -233,6 +233,42 @@ void HDRViewApp::calculate_viewport()
         }
 }
 
+//! One notch of a discrete mouse wheel, in the units a precise scrolling device reports.
+static constexpr float k_units_per_notch = 10.f;
+
+//! Frames without any wheel input after which the next event is taken to start a fresh gesture.
+static constexpr int k_scroll_gesture_gap = 10;
+
+//! Puts a wheel delta on one scale, whichever kind of device produced it.
+/*!
+    Every backend HDRView builds against reports a discrete wheel as one whole unit per notch, and a
+    trackpad -- or any other precise device -- as a stream of small fractions that add up to many units
+    over a single gesture. Nothing but the magnitude tells the two apart, so a whole-numbered delta is
+    taken for notches and brought up to the rate the fractions arrive at. Scaling both the same way
+    leaves either a notch changing the zoom by a fraction of a percent or a trackpad flying.
+
+    The classification is latched for the length of a gesture, so a precise device that happens to land
+    on a whole unit part way through one doesn't produce a single jumped frame.
+*/
+static float2 scroll_units(float2 wheel)
+{
+    static bool discrete         = true;
+    static int  last_input_frame = 0;
+
+    if (wheel == float2{0.f})
+        return wheel;
+
+    const int frame = ImGui::GetFrameCount();
+    if (frame - last_input_frame > k_scroll_gesture_gap)
+        discrete = true;
+    last_input_frame = frame;
+
+    if (wheel != round(wheel))
+        discrete = false;
+
+    return discrete ? wheel * k_units_per_notch : wheel;
+}
+
 void HDRViewApp::handle_mouse_interaction()
 {
     auto &io = ImGui::GetIO();
@@ -242,12 +278,7 @@ void HDRViewApp::handle_mouse_interaction()
     auto vp_mouse_pos   = vp_pos_at_app_pos(io.MousePos);
     bool cancel_autofit = false;
 
-#if defined(__EMSCRIPTEN__)
-    static constexpr float scroll_multiplier = 10.0f;
-#else
-    static constexpr float scroll_multiplier = 1.0f;
-#endif
-    auto scroll = float2{io.MouseWheelH, io.MouseWheel} * scroll_multiplier;
+    auto scroll = scroll_units(float2{io.MouseWheelH, io.MouseWheel});
 
     if (length2(scroll) > 0.f)
     {
@@ -286,13 +317,17 @@ void HDRViewApp::handle_mouse_interaction()
     }
     else
     {
-        float2 drag_delta{ImGui::GetMouseDragDelta(ImGuiMouseButton_Left)};
-        // A second finger means a pinch, and the first one is still driving a synthesized left-drag; pan
-        // would fight the zoom for the same gesture.
-        if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) && m_active_touches < 2)
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
         {
-            cancel_autofit = true;
-            reposition_pixel_to_vp_pos(vp_mouse_pos + drag_delta, pixel_at_vp_pos(vp_mouse_pos));
+            // A second finger means a pinch, and the first one is still driving a synthesized left-drag;
+            // pan would fight the zoom for the same gesture. The drag is still consumed while it does --
+            // left to accumulate, it would pan by the whole pinch's travel the moment a finger lifts.
+            if (m_active_touches < 2)
+            {
+                cancel_autofit = true;
+                reposition_pixel_to_vp_pos(vp_mouse_pos + float2{ImGui::GetMouseDragDelta(ImGuiMouseButton_Left)},
+                                           pixel_at_vp_pos(vp_mouse_pos));
+            }
             ImGui::ResetMouseDragDelta();
         }
     }
@@ -301,13 +336,20 @@ void HDRViewApp::handle_mouse_interaction()
         this->cancel_autofit();
 }
 
-void HDRViewApp::touch_gesture(int num_touches, float relative_delta, float2 app_pos)
+void HDRViewApp::touch_gesture(int num_touches, float scale, float2 from_app_pos, float2 to_app_pos)
 {
     m_active_touches = num_touches;
 
-    // Scaled by the fingers' own separation, so the same travel zooms by the same amount whether they
-    // started close together or far apart.
-    constexpr float k_pinch_scale = 8.f;
-    if (relative_delta != 0.f)
-        zoom_at_vp_pos(k_pinch_scale * relative_delta, vp_pos_at_app_pos(app_pos));
+    if (scale == 1.f && from_app_pos == to_app_pos)
+        return;
+
+    // Pin whatever the fingers' midpoint was over to wherever that midpoint has moved, and magnify by
+    // exactly the ratio their separation grew by. The image then stays under the fingers: spreading them
+    // apart by a factor magnifies by that factor, and moving both together pans without zooming.
+    const float2 to    = vp_pos_at_app_pos(to_app_pos);
+    const float2 pixel = pixel_at_vp_pos(vp_pos_at_app_pos(from_app_pos));
+    set_zoom(scale * m_zoom);
+    reposition_pixel_to_vp_pos(to, pixel);
+
+    cancel_autofit();
 }

--- a/src/app.h
+++ b/src/app.h
@@ -222,14 +222,19 @@ public:
 
     //! Respond to a touch gesture the browser reported. \see install_touch_handlers() in platform_utils
     /*!
-        \param [] num_touches    Fingers currently on the screen
-        \param [] relative_delta Change in the first two fingers' separation, as a fraction of it
-        \param [] app_pos        Point to zoom about, midway between them
+        Scales the view by \p scale about the fingers while moving whatever was under \p from_app_pos to
+        \p to_app_pos, so the image follows the fingers: two fingers moving together pan, and spreading
+        them apart magnifies by exactly the ratio they spread by.
+
+        \param [] num_touches  Fingers currently on the screen
+        \param [] scale        The first two fingers' separation, as a ratio of what it just was
+        \param [] from_app_pos Midpoint between them before this event
+        \param [] to_app_pos   Midpoint between them after it
 
         Public because Emscripten's event API takes a plain function pointer, so the listener that calls
         this cannot be a member.
     */
-    void touch_gesture(int num_touches, float relative_delta, float2 app_pos);
+    void touch_gesture(int num_touches, float scale, float2 from_app_pos, float2 to_app_pos);
     /// Zoom in to the next power of two
     void zoom_in();
     /// Zoom out to the previous power of two

--- a/src/platform_utils.cpp
+++ b/src/platform_utils.cpp
@@ -94,42 +94,66 @@ void show_in_file_manager(const char *filename)
 //------------------------------------------------------------------------------
 //  Javascript interface functions
 //
-//! Pinch-to-zoom, read straight from the browser's touch events.
+//! Two-finger pan and pinch-to-zoom, read straight from the browser's touch events.
 /*!
     Neither backend supplies it. GLFW has no gesture API on any platform, and the Emscripten port
     hello_imgui uses tracks a single touch point, synthesizing mouse events from it and discarding the
     rest -- so the second finger never reaches the application otherwise.
 
     Registering alongside the port's own listeners leaves that synthesis intact: one finger still pans
-    through the ordinary mouse path. The gesture is reduced here to a dimensionless change in the
-    fingers' separation; what that does to the viewport is HDRViewApp::touch_gesture()'s business.
+    through the ordinary mouse path. The gesture is reduced here to how the first two fingers' separation
+    and midpoint changed; what that does to the viewport is HDRViewApp::touch_gesture()'s business.
+
+    The deltas are taken per event rather than per frame because several touchmoves can arrive between
+    two frames, and every one of them is part of the same continuous motion.
 */
 static EM_BOOL on_touch(int event_type, const EmscriptenTouchEvent *event, void *)
 {
-    // The separation of the first two fingers is the gesture; a third changes nothing.
-    static float previous_distance = 0.f;
+    // The first two fingers are the gesture; a third changes nothing.
+    static float  previous_distance = 0.f;
+    static float2 previous_midpoint{0.f};
 
-    const bool pinching =
-        event->numTouches >= 2 && event_type != EMSCRIPTEN_EVENT_TOUCHEND && event_type != EMSCRIPTEN_EVENT_TOUCHCANCEL;
+    const bool ending = event_type == EMSCRIPTEN_EVENT_TOUCHEND || event_type == EMSCRIPTEN_EVENT_TOUCHCANCEL;
 
-    float  relative_delta = 0.f;
-    float2 midpoint{0.f};
+    // touches[] carries the fingers that just left alongside those still down, so the ones that ended
+    // have to be skipped to find what is actually on the glass -- including when picking the first two,
+    // which a lifted finger would otherwise be one of.
+    int down[2]      = {0, 0};
+    int touches_down = 0;
+    for (int i = 0; i < event->numTouches; ++i)
+    {
+        if (ending && event->touches[i].isChanged)
+            continue;
+        if (touches_down < 2)
+            down[touches_down] = i;
+        ++touches_down;
+    }
+
+    const bool pinching = touches_down >= 2;
+
+    float  scale = 1.f;
+    float2 from{0.f}, to{0.f};
     if (pinching)
     {
-        const float2 a{(float)event->touches[0].targetX, (float)event->touches[0].targetY};
-        const float2 b{(float)event->touches[1].targetX, (float)event->touches[1].targetY};
+        const float2 a{(float)event->touches[down[0]].targetX, (float)event->touches[down[0]].targetY};
+        const float2 b{(float)event->touches[down[1]].targetX, (float)event->touches[down[1]].targetY};
         const float  distance = length(b - a);
+        const float2 midpoint = 0.5f * (a + b);
 
-        // The first frame of a pinch has nothing to compare against, so it only sets the baseline.
+        // The first event of a pinch has nothing to compare against, so it only sets the baseline.
         if (previous_distance > 0.f && distance > 0.f)
-            relative_delta = (distance - previous_distance) / previous_distance;
+        {
+            scale = distance / previous_distance;
+            from  = previous_midpoint;
+            to    = midpoint;
+        }
         previous_distance = distance;
-        midpoint          = 0.5f * (a + b);
+        previous_midpoint = midpoint;
     }
     else
         previous_distance = 0.f;
 
-    hdrview()->touch_gesture(event->numTouches, relative_delta, midpoint);
+    hdrview()->touch_gesture(touches_down, scale, from, to);
 
     // Claim the event only while pinching, so one finger still reaches the port's mouse synthesis.
     return pinching ? EM_TRUE : EM_FALSE;

--- a/tests/gui/test_gui_viewport.cpp
+++ b/tests/gui/test_gui_viewport.cpp
@@ -5,6 +5,9 @@
     image shader is actually asked to draw. Everything the app says about where a pixel is -- the mouse
     readout, the pixel-value overlay, the window borders, the watched-pixel crosshairs -- is one of these
     functions, so they and the shader have to describe the same place.
+
+    And what moves that transform: every way of zooming promises to hold one point still while it does, and
+    the scroll wheel and a two-finger gesture are the two ways of asking for a zoom by hand.
 */
 
 #include "app.h"
@@ -209,5 +212,175 @@ void RegisterTests_Viewport(ImGuiTestEngine *engine)
         }
 
         hdrview()->set_reference_image_index(-1, true);
+    };
+
+    /*
+        Every way of zooming does it about some point, and that point is the promise the user is relying on:
+        whatever pixel was under it is still under it afterwards, so the thing being looked at does not slide
+        away as the zoom changes. Checked through each entry point that makes that promise, since each picks
+        its own focus and each could pick the wrong one:
+
+          - zoom_at_vp_pos(), what the scroll wheel calls, about an arbitrary point -- and a step of `amount`
+            has to be exactly `amount` on the zoom_level() scale the zoom readout and the zoom slider share.
+          - zoom_in()/zoom_out(), the menu's power-of-two steps, about the viewport center.
+          - touch_gesture(), a two-finger pinch, whose focus is the one that also *moves*: the pixel under
+            the fingers' midpoint follows that midpoint, and the zoom changes by exactly the ratio their
+            separation did. That is what makes two fingers moved together pan, and what makes the image grow
+            by as much as the fingers spread rather than by some fraction of it.
+
+        Swept over zoom, pan and both flip axes.
+    */
+    ImGuiTest *t3 = IM_REGISTER_TEST(engine, "viewport", "zooming_pins_the_pixel_under_its_focus");
+    t3->TestFunc  = [](ImGuiTestContext *ctx)
+    {
+        reset_images(ctx);
+        IM_CHECK_EQ(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE}), 1);
+
+        FlipState flip;
+
+        // Puts the viewport in a known state before each case below.
+        auto set_view = [](float zoom, float2 pan)
+        {
+            hdrview()->set_zoom(zoom);
+            hdrview()->center();
+            hdrview()->reposition_pixel_to_vp_pos(pan, float2{0.f, 0.f});
+        };
+
+        for (int f = 0; f < 4; ++f)
+        {
+            flip.set(f);
+            for (float zoom : {0.125f, 1.f, 3.f, 64.f})
+                for (float2 pan : {float2{0.f, 0.f}, float2{37.f, -19.f}})
+                {
+                    // Zooming about a point, by a step measured on the zoom_level() scale.
+                    for (float amount : {-2.5f, 0.7f, 2.5f})
+                        for (float2 focus : {float2{101.f, 83.f}, float2{0.f, 0.f}})
+                        {
+                            set_view(zoom, pan);
+                            const float2 pinned = hdrview()->pixel_at_vp_pos(focus);
+                            const float  level  = hdrview()->zoom_level();
+
+                            hdrview()->zoom_at_vp_pos(amount, focus);
+
+                            IM_CHECK_LT(std::abs(hdrview()->zoom_level() - (level + amount)), 1e-3f);
+                            // A viewport unit is 1/zoom of a pixel, so the tolerance has to be too.
+                            IM_CHECK(approx(hdrview()->pixel_at_vp_pos(focus), pinned, 1e-2f / hdrview()->zoom()));
+                        }
+
+                    // The menu's steps, which hold the viewport center rather than the mouse.
+                    for (bool in : {true, false})
+                    {
+                        set_view(zoom, pan);
+                        const float2 center = 0.5f * hdrview()->viewport_size();
+                        const float2 pinned = hdrview()->pixel_at_vp_pos(center);
+
+                        if (in)
+                            hdrview()->zoom_in();
+                        else
+                            hdrview()->zoom_out();
+
+                        IM_CHECK(approx(hdrview()->pixel_at_vp_pos(center), pinned, 1e-2f / hdrview()->zoom()));
+                    }
+
+                    // A two-finger gesture: pinch only, pan only, and both at once.
+                    for (float scale : {1.f, 1.0f / 1.03f, 1.4f, 0.5f})
+                        for (float2 travel : {float2{0.f, 0.f}, float2{53.f, -27.f}})
+                        {
+                            set_view(zoom, pan);
+                            const float2 from   = float2{101.f, 83.f};
+                            const float2 to     = from + travel;
+                            const float2 pinned = hdrview()->pixel_at_vp_pos(from);
+
+                            hdrview()->touch_gesture(2, scale, hdrview()->app_pos_at_vp_pos(from),
+                                                     hdrview()->app_pos_at_vp_pos(to));
+
+                            const float zoomed = zoom * scale;
+                            IM_CHECK_LT(std::abs(hdrview()->zoom() - zoomed), 1e-3f * zoomed);
+                            IM_CHECK(approx(hdrview()->pixel_at_vp_pos(to), pinned, 1e-2f / zoomed));
+                        }
+                }
+        }
+
+        // Leave no fingers down: while any are, the viewport suppresses drag-panning.
+        hdrview()->touch_gesture(0, 1.f, float2{0.f}, float2{0.f});
+    };
+
+    /*
+        The scroll wheel, driven the way a user drives it, through the input path rather than the transform
+        it ends up calling. Two things are worth stating there and nowhere else:
+
+        Rate. A notch of a discrete wheel arrives as one whole unit, while a trackpad reports the same travel
+        as a stream of small fractions adding up to many units -- so the two are only comparable once the
+        notch has been scaled up, and a notch left on the trackpad's scale moves the viewport by a fraction
+        of what it should, which reads as the wheel doing nothing. Stated as bounds and as a comparison
+        between the devices, since the exact step is a tuning choice and the fractions are what it is tuned
+        against.
+
+        Mode. The wheel zooms about the mouse, and shift makes the same wheel pan instead -- neither of which
+        the functions it calls can be asked about, since they cannot know what was passed to them.
+    */
+    ImGuiTest *t4 = IM_REGISTER_TEST(engine, "viewport", "scrolling_zooms_or_pans_alike_from_either_device");
+    t4->TestFunc  = [](ImGuiTestContext *ctx)
+    {
+        reset_images(ctx);
+        IM_CHECK_EQ(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE}), 1);
+
+        ctx->MouseMoveToPos(hdrview()->app_pos_at_vp_pos(0.25f * hdrview()->viewport_size()));
+        // Where the pointer actually landed, which is what the viewport anchors a wheel zoom on. Asking for
+        // a position and assuming the pointer is at it leaves a sub-pixel difference, and the drift that
+        // difference causes is larger than the anchoring being checked below.
+        const float2 mouse = float2{ImGui::GetIO().MousePos};
+
+        // Scrolls `events` wheel events of `wheel` units each over the viewport, from a known starting view.
+        // The idle frames make each call a gesture of its own: which kind of device is scrolling is latched
+        // until scrolling stops, so without them a call would inherit the previous call's device.
+        auto scroll = [ctx](float wheel, int events)
+        {
+            ctx->Yield(30);
+            hdrview()->set_zoom(1.f);
+            hdrview()->center();
+            for (int i = 0; i < events; ++i) ctx->MouseWheelY(wheel);
+        };
+
+        // One notch of zoom: enough to see, and not so much that the image leaps past what was being
+        // looked at. And it happens about the mouse, not about the center or the corner.
+        scroll(1.f, 1);
+        const float notch = hdrview()->zoom();
+        IM_CHECK_GT(notch, 1.05f);
+        IM_CHECK_LT(notch, 2.f);
+        {
+            const float2 pinned = hdrview()->pixel_at_app_pos(mouse);
+            ctx->MouseWheelY(1.f);
+            IM_CHECK(approx(hdrview()->pixel_at_app_pos(mouse), pinned, 1e-2f / hdrview()->zoom()));
+        }
+
+        // The same notch the other way is its inverse.
+        scroll(-1.f, 1);
+        IM_CHECK_LT(std::abs(notch * hdrview()->zoom() - 1.f), 1e-3f);
+
+        // The travel a trackpad spreads over many fractional events does what the notch it adds up to does,
+        // rather than a tenth of it.
+        scroll(0.5f, 20);
+        IM_CHECK_LT(std::abs(hdrview()->zoom() - notch), 0.05f * notch);
+
+        // Held shift turns the same wheel into a pan: the zoom stays put and the image translates, by an
+        // amount a user can see, and again at one rate for both devices.
+        auto shift_scroll = [ctx, &scroll](float wheel, int events)
+        {
+            ctx->KeyDown(ImGuiMod_Shift);
+            scroll(wheel, events);
+            const float2 moved = hdrview()->vp_pos_at_pixel(float2{0.f, 0.f});
+            ctx->KeyUp(ImGuiMod_Shift);
+            return moved;
+        };
+
+        // Where the origin sits with the view reset and nothing scrolled, to measure the translation from.
+        scroll(0.f, 0);
+        const float2 unmoved = hdrview()->vp_pos_at_pixel(float2{0.f, 0.f});
+
+        const float2 panned = shift_scroll(1.f, 1);
+        IM_CHECK_LT(std::abs(hdrview()->zoom() - 1.f), 1e-4f);
+        IM_CHECK_GT(la::length(panned - unmoved), 10.f);
+        IM_CHECK(approx(shift_scroll(0.5f, 20), panned, 1.f));
     };
 }


### PR DESCRIPTION
Three unrelated things, split into two commits: the web build's missing formats, and moving the viewport by hand.

## The web build was missing AVIF (and J2K)

The blocker was never a library that won't compile under Emscripten. It was two things:

- **libheif finds its codecs with `find_package()`**, which only ever turns up an *installed* library — and Emscripten has none, so AVIF/J2K/HTJ2K/HEIC/AVCI were all switched off in the preset. The web build now builds libaom 3.13.1 and OpenJPEG 2.5.4 itself and reaches libheif through the `<pkg>-extra.cmake` files written into `CMAKE_FIND_PACKAGE_REDIRECTS_DIR`, where CPM already leaves a redirect config for every package it adds.
- **`heif.cc` pulls in `heif_emscripten.h`**, whose embind bindings for libheif's JS API bind raw pointers — which embind has since made a hard error. `__EMSCRIPTEN_STANDALONE_WASM__` switches them off; it's what libheif's own `build-emscripten.sh` does.

Both new packages also write their preferences into the CMake cache, which is global and read at generate time: aom `FORCE`s its compiler flags in (the `-std=c99` stops OpenEXR's C sources compiling), and OpenJPEG's legacy `EXECUTABLE_OUTPUT_PATH` sent `HDRView.wasm` into OpenJPEG's `bin/`. Each block puts back what it disturbed.

HEIC and AVCI stay off for the same patent reasons as in released builds. HTJ2K *encoding* stays off — `FindOPENJPH.cmake` insists on an install tree, and J2K's decoder already reads HTJ2K HEIFs.

**Worth a decision: the wasm goes 10.1 MB → 13.2 MB**, most of it the AV1 encoder. Decode-only would save ~1.7 MB but needs `HDRVIEW_ENABLE_AVIF` to grow a read-only mode first, since the save dialog assumes an encoder exists for any enabled codec.

Verified end to end rather than just linked: served the build, loaded it in headless Chrome with `?url=` pointing at an AVIF, and read the screenshot back — it decodes and displays. (J2K-in-HEIF is built but not runtime-checked; I had no fixture for it.)

## Mouse wheel zoom was ~1.7% per notch

A notch reaches GLFW as exactly `1.0` on every backend — Wayland's `axis_value120`/120, X11 buttons 4/5, Win32 delta/120, a browser's 100 px — and that zoomed by `1.0718^0.25`. Meanwhile ImGui scrolls a window by `5 x font size` per notch, which is why the wheel felt dead over the image but fine over the panels.

A trackpad reports the same travel as a stream of small fractions, so one scale can't serve both and only magnitude distinguishes them: a whole-numbered delta is now taken for notches and scaled to the rate the fractions arrive at, latched for the length of a gesture so a trackpad landing on a whole unit doesn't jump a frame. A notch is now 2^(1/4). Shift+wheel panning went through the same path and was equally slow. The Emscripten-only `x10` multiplier was compensating for exactly this and is gone.

## Pinch: three causes, not one

1. **Jump on release** — the pinch suppressed panning but `GetMouseDragDelta` kept accumulating, paying out the whole gesture's travel in one frame when a finger lifted. Now consumed and discarded while the pinch owns the gesture. The finger count it was suppressed on was stale too: `touches[]` lists fingers that just left alongside those still down.
2. **Two fingers moving together did nothing** — the midpoint's movement is now tracked and applied.
3. **Zoom lagged the physical pinch** — the change in separation was fed through the exponential zoom-sensitivity curve, giving ~0.55x. Pinning the pixel under the old midpoint to the new one and scaling by exactly the separation ratio gives 2 and 3 together.

## Tests

Two GUI tests, both stating the property rather than the bug:

- `viewport/zooming_pins_the_pixel_under_its_focus` — holding one point still is what *every* zoom promises, so it's checked through `zoom_at_vp_pos()`, the menu's `zoom_in()`/`zoom_out()` about the viewport center, and a two-finger gesture, swept over zoom x pan x both flips. Two of the three cases cover code this PR doesn't touch.
- `viewport/scrolling_zooms_or_pans_alike_from_either_device` — drives the wheel through the real input path, which is the only place the focus being the *mouse*, and shift switching to pan, can be observed at all.

Both were mutation-checked: breaking `zoom_at_vp_pos`'s re-anchor, `zoom_in`'s center, the pinch's pan, the wheel's device scaling, or the shift-pan step each fails the right assertion, the last two reporting exactly the pre-fix numbers.

52/52 GUI tests and 155/155 doctests pass; Linux and Emscripten both build clean.

Opened partly to watch the wasm land on the `dev` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)