### PR TITLE
Reduce compiler warnings across all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,11 @@ if(MSVC)
   # Disable annoying secure CRT warnings
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
 
+  # CMake's default flags carry /W3. Drop it so no warning level is inherited globally: each target picks its own
+  # (HDRVIEW_WARNING_OPTIONS below, or /w from disable_target_warnings()), and cl only reports D9025 when it sees both.
+  string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  string(REGEX REPLACE "/W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+
   # Parallel build on MSVC (all targets)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
@@ -1614,19 +1619,18 @@ add_enabled_definition(HDRVIEW_ENABLE_LIBRAW)
 add_enabled_definition(HDRVIEW_ENABLE_X3F)
 
 # ============================================================================
-# Compile remainder of the codebase with compiler warnings turned on
+# Compiler warnings for HDRView's own code
 # ============================================================================
+# Applied per-target (see the loop after the targets are declared) rather than through CMAKE_CXX_FLAGS, which would
+# also reach the third-party targets declared in this directory and leave them compiling at two warning levels at once.
 if(MSVC)
-  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-  endif()
+  # /wd4100 is MSVC's spelling of -Wno-unused-parameter below.
+  set(HDRVIEW_WARNING_OPTIONS /W4 /wd4100)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+  set(HDRVIEW_WARNING_OPTIONS -Wall -Wextra -Wno-unused-parameter)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -Wno-gnu-anonymous-struct -Wno-c99-extensions -Wno-nested-anon-types -Wno-deprecated-register"
+    list(APPEND HDRVIEW_WARNING_OPTIONS -Wno-gnu-anonymous-struct -Wno-c99-extensions -Wno-nested-anon-types
+         -Wno-deprecated-register
     )
   endif()
 endif()
@@ -1998,6 +2002,14 @@ if(HDRVIEW_BUILD_GUI_TESTS AND NOT EMSCRIPTEN)
   enable_testing()
   add_test(NAME hdrview_gui_tests COMMAND hdrview_gui_tests)
 endif()
+
+# Turn warnings on for the targets built from HDRVIEW_SOURCES, now that all of them exist. The optional ones are
+# guarded because they only exist when HDRVIEW_BUILD_TESTS/_GUI_TESTS/_FUZZERS asked for them.
+foreach(hdrview_target HDRView hdrview_version hdrview_tests hdrview_gui_tests hdrview_fuzz_load_image)
+  if(TARGET ${hdrview_target})
+    target_compile_options(${hdrview_target} PRIVATE ${HDRVIEW_WARNING_OPTIONS})
+  endif()
+endforeach()
 
 if(EMSCRIPTEN)
   target_link_options(

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -123,7 +123,11 @@ void HDRViewApp::enable_gui_test_engine(void (*register_tests)(ImGuiTestEngine *
     }
 
     m_params.useImGuiTestEngine      = true;
-    m_params.callbacks.RegisterTests = [register_tests, this]()
+    m_params.callbacks.RegisterTests = [
+#if defined(HELLOIMGUI_HAS_OPENGL)
+        this, // the screen-capture override below is the only thing that needs the app pointer
+#endif
+        register_tests]()
     {
         ImGuiTestEngine   *engine = GetImGuiTestEngine();
         ImGuiTestEngineIO &io     = ImGuiTestEngine_GetIO(engine);

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -641,9 +641,9 @@ void HDRViewApp::setup_frame_callbacks()
                     {
                         if (!it->second.empty())
                         {
-                            int idx = it->second.front();
+                            int entry_idx = it->second.front();
                             it->second.pop_front();
-                            m_pending_session->entries[idx].loaded = new_image;
+                            m_pending_session->entries[entry_idx].loaded = new_image;
                         }
                         if (it->second.empty())
                             m_pending_session->unresolved.erase(it);

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -1033,7 +1033,6 @@ float2 blend(float2 top, float2 bottom, BlendMode_ blend_mode)
     case BlendMode_Difference: return float2(abs(diff), alpha);
     case BlendMode_Relative_Difference: return float2(abs(diff) / (bottom.x + 0.01f), alpha);
     }
-    return float2(0.f);
 }
 
 float4 blend(float4 top, float4 bottom, BlendMode_ blend_mode)
@@ -1053,7 +1052,6 @@ float4 blend(float4 top, float4 bottom, BlendMode_ blend_mode)
     case BlendMode_Difference: return float4(abs(diff), alpha);
     case BlendMode_Relative_Difference: return float4(abs(diff) / (bottom.xyz() + float3(0.01f)), alpha);
     }
-    // return float4(0.f);
 }
 
 void xyYToXZ(float *X, float *Z, float x, float y, float Y)

--- a/src/imageio/gainmap.cpp
+++ b/src/imageio/gainmap.cpp
@@ -499,7 +499,7 @@ std::optional<IsoGainmapParams> parse_hdrgm_xmp(const char *xml, size_t len)
     // hdrgm properties hang off an rdf:Description, as attributes when they are single-valued and as
     // <hdrgm:Name><rdf:Seq><rdf:li>...</rdf:li></rdf:Seq></hdrgm:Name> when they are per-channel.
     // Rather than walk the RDF model, find the prefix bound to the hdrgm namespace and match on it.
-    static constexpr auto k_hdrgm_ns = "http://ns.adobe.com/hdr-gain-map/1.0/";
+    static constexpr string_view k_hdrgm_ns = "http://ns.adobe.com/hdr-gain-map/1.0/";
 
     string     prefix;
     const auto find_prefix = [&](auto &&self, const tinyxml2::XMLElement *e) -> void
@@ -591,7 +591,7 @@ std::optional<IsoGainmapParams> parse_hdrgm_xmp(const char *xml, size_t len)
 
         const auto &v = it->second;
         float3      out{to_float(v[0], fallback[0])};
-        for (size_t c = 1; c < v.size() && c < 3; ++c) out[c] = to_float(v[c], out[0]);
+        for (size_t c = 1; c < v.size() && c < 3; ++c) out[int(c)] = to_float(v[c], out[0]);
         // A single value drives all three channels; two is malformed, so treat the rest as the first.
         if (v.size() == 2)
             out[2] = out[0];

--- a/src/imageio/gainmap.cpp
+++ b/src/imageio/gainmap.cpp
@@ -471,6 +471,10 @@ IsoGainmapParams parse_iso_gainmap(const uint8_t *data, size_t size)
     return p;
 }
 
+// At namespace scope because GCC's -Wunused-but-set-variable does not see through the lambda below that
+// is this constant's only reader, and reports a function-local one as unused.
+constexpr string_view k_hdrgm_ns = "http://ns.adobe.com/hdr-gain-map/1.0/";
+
 std::optional<IsoGainmapParams> parse_hdrgm_xmp(const char *xml, size_t len)
 {
     if (!xml || len == 0)
@@ -499,8 +503,6 @@ std::optional<IsoGainmapParams> parse_hdrgm_xmp(const char *xml, size_t len)
     // hdrgm properties hang off an rdf:Description, as attributes when they are single-valued and as
     // <hdrgm:Name><rdf:Seq><rdf:li>...</rdf:li></rdf:Seq></hdrgm:Name> when they are per-channel.
     // Rather than walk the RDF model, find the prefix bound to the hdrgm namespace and match on it.
-    static constexpr string_view k_hdrgm_ns = "http://ns.adobe.com/hdr-gain-map/1.0/";
-
     string     prefix;
     const auto find_prefix = [&](auto &&self, const tinyxml2::XMLElement *e) -> void
     {

--- a/src/imageio/icc.cpp
+++ b/src/imageio/icc.cpp
@@ -801,8 +801,6 @@ std::string CICPProfile::short_name() const
     }
     else
         return fmt::format("Unusual/historical{}", details);
-
-    return fmt::format("CICP ({} {} {} {})", cp_short_name(), tc_short_name(), mc_short_name(), r_short_name());
 }
 
 CICPProfile CICPProfile::from_gamut_and_transfer(ColorGamut_ gamut, TransferFunction tf, int matrix_coeffs,

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -121,17 +121,17 @@ int decode_ascii_hex_to_binary(uint8_t u8[], size_t length)
     for (int i = '0'; i <= '9'; i++)
     {
         valid[i] = true;
-        value[i] = i - '0';
+        value[i] = uint8_t(i - '0');
     }
     for (int i = 'a'; i <= 'f'; i++)
     {
         valid[i] = true;
-        value[i] = 10 + i - 'a';
+        value[i] = uint8_t(10 + i - 'a');
     }
     for (int i = 'A'; i <= 'F'; i++)
     {
         valid[i] = true;
-        value[i] = 10 + i - 'A';
+        value[i] = uint8_t(10 + i - 'A');
     }
 
     for (size_t i = 0; i < length; i++)
@@ -465,15 +465,17 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         {"type", "int"},
         {"description", "PNG sRGB chunk specifies that the image is in sRGB color space"}};
 
-    png_byte color_primaries;
-    png_byte transfer_function;
-    png_byte matrix_coefficients;
-    png_byte video_full_range_flag = 1;
-    string   cicp_desc =
+    string cicp_desc =
         "Coding-independent code points (CICP) is a way to signal the color properties of the image via four "
         "properties: color primaries (CP), transfer function (TF), matrix coefficients (MC), and full-range vs. "
         "narrow-range flag (FR).";
+    // Full range unless the cICP chunk or the ICC profile's cicp tag below says otherwise. Declared outside
+    // the #ifdef because the sample dequantization further down reads it even without cICP support.
+    png_byte video_full_range_flag = 1;
 #ifdef PNG_cICP_SUPPORTED
+    png_byte color_primaries;
+    png_byte transfer_function;
+    png_byte matrix_coefficients;
     if (png_get_cICP(png_ptr, info_ptr.get(), &color_primaries, &transfer_function, &matrix_coefficients,
                      &video_full_range_flag))
     {

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace ImGui
 {
@@ -187,10 +188,7 @@ inline void TextUnformatted(const std::string &text) { return TextUnformatted(te
 template <typename... T>
 inline void TextFmt(fmt::format_string<T...> fmt, T &&...args)
 {
-    // TODO the below produces an obscure compiler message that we could decipher and resolve properly
-    //      for now, we just bypass the compile-time validation
-    // std::string str = fmt::format(fmt, fmt::make_format_args(args...));
-    std::string str = fmt::format(fmt::runtime(fmt), args...);
+    std::string str = fmt::format(fmt, std::forward<T>(args)...);
     ImGui::TextUnformatted(str.c_str());
 }
 

--- a/tests/test_dds_io.cpp
+++ b/tests/test_dds_io.cpp
@@ -60,7 +60,7 @@ std::string make_one_block_dds(const char fourcc[4])
     // Both endpoints the same mid-gray, so all sixteen texels decode to one color whatever the
     // interpolation does, and every index selects endpoint 0.
     const uint16_t rgb565 = uint16_t((16u << 11) | (32u << 5) | 16u);
-    v.insert(v.end(), {uint8_t(rgb565), uint8_t(rgb565 >> 8), uint8_t(rgb565), uint8_t(rgb565 >> 8)});
+    v.insert(v.end(), {uint8_t(rgb565 & 0xFF), uint8_t(rgb565 >> 8), uint8_t(rgb565 & 0xFF), uint8_t(rgb565 >> 8)});
     for (int i = 0; i < 4; ++i) v.push_back(0); // all indices 0
 
     return std::string(v.begin(), v.end());

--- a/tests/test_exif.cpp
+++ b/tests/test_exif.cpp
@@ -84,7 +84,7 @@ struct TiffBuilder
 };
 
 constexpr uint16_t k_tag_make = 0x010f, k_tag_compression = 0x0103, k_tag_orientation = 0x0112;
-constexpr uint16_t k_fmt_byte = 1, k_fmt_ascii = 2, k_fmt_short = 3;
+constexpr uint16_t k_fmt_ascii = 2, k_fmt_short = 3;
 
 json parse(const std::vector<uint8_t> &blob) { return exif_to_json(blob.data(), blob.size()); }
 

--- a/tests/test_loader_limits.cpp
+++ b/tests/test_loader_limits.cpp
@@ -44,11 +44,6 @@ void append_be32(std::vector<uint8_t> &v, uint32_t x)
     v.insert(v.end(), {uint8_t(x >> 24), uint8_t(x >> 16), uint8_t(x >> 8), uint8_t(x)});
 }
 
-void append_le32(std::vector<uint8_t> &v, uint32_t x)
-{
-    v.insert(v.end(), {uint8_t(x), uint8_t(x >> 8), uint8_t(x >> 16), uint8_t(x >> 24)});
-}
-
 //! A QOI header declaring \p w by \p h. Big-endian dimensions at bytes 4..12, then channels and colorspace.
 std::string qoi_header(uint32_t w, uint32_t h)
 {


### PR DESCRIPTION
Sweeps the compile warnings HDRView's own code raises on macOS, Linux, Windows and Emscripten, and stops the build from asking third-party code for warnings it then discards.

## Scoping the warning level

`CMAKE_CXX_FLAGS` reaches every target declared in the top-level directory, dependencies included, so raising the warning level there had third-party targets compiling at two levels at once — `/w` from `disable_target_warnings()` against an inherited `/W3`. MSVC reports `D9025` for every such file, and that collision alone accounted for most of the Windows build's warning output.

The level is now set per-target, and CMake's default `/W[0-4]` is stripped from `CMAKE_C_FLAGS` as well as `CMAKE_CXX_FLAGS`. The C half matters on its own — dependencies built as C (freetype, plutovg) were never covered by the old C++-only substitution and kept warning at the default `/W3`.

Measured on Windows CI: **`D9025` 1,721 → 529, total warning lines 2,680 → 1,100.**

## The code fixes

Unused variables, narrowing conversions needing an explicit cast, one shadowed local, and two returns after an exhaustive `switch`/`if`-chain that MSVC flags as unreachable. All mechanical.

Three worth a second look:

- **`png.cpp`** keeps `video_full_range_flag` outside the `#ifdef PNG_cICP_SUPPORTED`. Unlike the three code points declared beside it, it is read further down — by the ICC `cicp`-tag fallback and by sample dequantization — whether or not libpng has cICP support. Moving it inside would not compile against a libpng built without it.
- **`gainmap.cpp`** gives `k_hdrgm_ns` namespace scope. Its only reader is inside the recursive lambda that walks the XMP tree, and GCC's `-Wunused-but-set-variable` does not look there, so it reports the function-local constant as unused. Changing its type alone does not satisfy the warning — only moving it out of the function does.
- **`TextFmt`** now uses the compile-time-checked `fmt::format` overload instead of bypassing validation with `fmt::runtime()`, which in newer fmt (Homebrew's, in the `-local` CI jobs) reaches a deprecated conversion. This also restores format-string checking at every call site; they all already pass.

`app-windows.cpp` captures `this` only under `HELLOIMGUI_HAS_OPENGL`, where the screen-capture override actually uses it — casting it to void in the body does not count as a use, so the capture itself had to become conditional.

## Verification

CI logs were swept for warnings rather than read as pass/fail, since warnings are not errors here — an earlier all-green round still had a live warning in it. Both a path-based and an independent filename-based grep were run over the complete logs, so this covers every job configuration (Debug/Release, CPM/Local, x86/arm, sanitizers), not one sample per platform.

| Platform | Jobs | HDRView-owned warnings |
|---|---|---|
| macOS | 16 | **0** |
| Linux | 18 | **0** |
| Windows | 7 | **0** |
| Emscripten | 1 | **0** |

Locally: `macos-arm64-cpm` Release with tests and GUI tests enabled builds with zero compile warnings, and `hdrview_tests` passes 162/162.

Deliberately left alone: the macOS deployment-target `ld` warnings (Homebrew dylibs vs. the 11.0 target — environmental), `ld: ignoring duplicate libraries`, and the remaining third-party volume. Of the 529 `D9025` still on Windows, 352 are hello_imgui setting `/W1` on its own `imgui`/`plutosvg`/`stb_hello_imgui` targets; `disable_target_warnings()` already strips `/W[0-4]` from target `COMPILE_OPTIONS`, so those arrive via directory-scope flags inside hello_imgui's own `add_subdirectory` and are not reachable without patching the dependency.

---

Supersedes #204, which sat on a single-segment branch name and so triggered every workflow twice (once on `push`, once on `pull_request`).

Worth a separate PR: the `concurrency` group in each workflow is `${{ github.workflow }}-${{ github.head_ref || github.ref }}`, and its comment says a push run and a pull_request run for the same branch share a group. They do not — on a push `github.ref` is the full `refs/heads/...` while a PR's `head_ref` is the bare name, so the groups never match and neither cancels the other. `github.ref_name` in place of `github.ref` would make the code match the comment for every branch, not just slashed ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)