### PR TITLE
Decode AVIF with dav1d

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -88,11 +88,11 @@ jobs:
       # stores no alpha -- so a HEIF written on a -local build silently loses it.
       - name: Install dependencies (Ubuntu 24.04)
         if: startsWith(matrix.config.os, 'ubuntu-24.04')
-        run: sudo apt-get update && sudo apt-get install -y cmake xorg-dev libglu1-mesa-dev zlib1g-dev libxrandr-dev ninja-build libglfw3-dev libfreetype-dev libjpeg-dev libimath-dev libopenexr-dev libpng-dev libtiff-dev liblcms2-dev libwebp-dev libraw-dev libheif-dev libheif-plugin-x265 libheif-plugin-libde265 libheif-plugin-aomenc libheif-plugin-aomdec libaom-dev libde265-dev libx265-dev libjxl-dev libcli11-dev libspdlog-dev libfmt-dev libexif-dev libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev libopenh264-dev libopenjp2-7-dev xvfb
+        run: sudo apt-get update && sudo apt-get install -y cmake xorg-dev libglu1-mesa-dev zlib1g-dev libxrandr-dev ninja-build libglfw3-dev libfreetype-dev libjpeg-dev libimath-dev libopenexr-dev libpng-dev libtiff-dev liblcms2-dev libwebp-dev libraw-dev libheif-dev libheif-plugin-x265 libheif-plugin-libde265 libheif-plugin-aomenc libheif-plugin-aomdec libheif-plugin-dav1d libaom-dev libdav1d-dev libde265-dev libx265-dev libjxl-dev libcli11-dev libspdlog-dev libfmt-dev libexif-dev libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev libopenh264-dev libopenjp2-7-dev xvfb
 
       - name: Install dependencies (Ubuntu 22.04)
         if: startsWith(matrix.config.os, 'ubuntu-22.04')
-        run: sudo apt-get update && sudo apt-get install -y cmake xorg-dev libglu1-mesa-dev zlib1g-dev libxrandr-dev ninja-build libglfw3-dev libfreetype-dev libjpeg-dev libpng-dev libtiff-dev liblcms2-dev libwebp-dev libraw-dev libheif-dev libaom-dev libde265-dev libx265-dev libcli11-dev libspdlog-dev libfmt-dev libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev libopenh264-dev libopenjp2-7-dev
+        run: sudo apt-get update && sudo apt-get install -y cmake xorg-dev libglu1-mesa-dev zlib1g-dev libxrandr-dev ninja-build libglfw3-dev libfreetype-dev libjpeg-dev libpng-dev libtiff-dev liblcms2-dev libwebp-dev libraw-dev libheif-dev libaom-dev libdav1d-dev libde265-dev libx265-dev libcli11-dev libspdlog-dev libfmt-dev libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev libopenh264-dev libopenjp2-7-dev
 
       - name: Install Python dependencies
         run: pip install --upgrade pip && pip install Pillow

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: brew install --quiet ninja create-dmg dylibbundler libjpeg-turbo little-cms2 zlib aom libde265 x265 openjpeg openh264
+        run: brew install --quiet ninja create-dmg dylibbundler libjpeg-turbo little-cms2 zlib aom dav1d libde265 x265 openjpeg openh264
 
       # The packages below are each also built from source by CPM for -cpm/-universal presets (which don't set
       # CPM_USE_LOCAL_PACKAGES, so CPM always fetches regardless of what's installed system-wide). Installing them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,15 @@ preferences into the CMake cache, which is global and read at generate time, so 
 afterwards; see the comments there. `HEIC`/`AVCI` stay off in released builds for patent reasons, and
 `HTJ2K` encoding is off in the web build because libheif's `FindOPENJPH.cmake` insists on an install tree.
 
+AVIF has two AV1 decoders in play. libaom is always there — it is also the AVIF *encoder*, which dav1d
+cannot be — but dav1d decodes several times faster, so `HDRVIEW_ENABLE_DAV1D` asks libheif for its dav1d
+plugin too and libheif then prefers it (plugin priority 150 vs libaom's 100). Output is bit-identical;
+AV1 decoding is specified exactly. dav1d builds only under meson, so unlike libaom there is no CPM
+fallback: the CMake block finds a system dav1d or quietly leaves AVIF on libaom, which is what currently
+happens on Windows and Emscripten. `tests/bench_heif_decode.cpp` (behind `HDRVIEW_BUILD_BENCHMARKS`) is
+what measures the two against each other and checks they agree; it uses
+`heif_decoding_options::decoder_id` to address a specific plugin, so one build can exercise both.
+
 ### Rendering backend abstraction (GL vs Metal)
 `renderpass.h`, `shader.h`, and `texture.h` declare platform-agnostic interfaces (adapted from NanoGUI),
 each with two mutually-exclusive implementations selected at CMake configure time:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(HDRVIEW_ENABLE_LIBJXL "Enable JPEG-XL support" ON)
 option(HDRVIEW_ENABLE_J2K "Enable JPEG-2000 support" ON)
 option(HDRVIEW_ENABLE_HTJ2K "Enable high-throughput JPEG2000 (HTJ2K) support" ON)
 option(HDRVIEW_ENABLE_AVIF "Enable AVIF support" ON)
+option(HDRVIEW_ENABLE_DAV1D "Decode AVIF with dav1d, which is roughly twice as fast as libaom's decoder" ON)
 option(HDRVIEW_ENABLE_HEIC "Enable HEIC support" ON)
 option(HDRVIEW_ENABLE_AVCI "Enable AVCI support" ON)
 option(HDRVIEW_ENABLE_LIBWEBP "Enable LIBWEBP support" ON)
@@ -1281,6 +1282,34 @@ if(EMSCRIPTEN AND HDRVIEW_ENABLE_J2K)
   )
 endif()
 
+# dav1d decodes the AV1 in an AVIF about twice as fast as libaom's decoder, to the same pixels, so libheif
+# prefers it (plugin priority 150 vs 100) whenever both are compiled in. libaom stays in the build
+# regardless -- it is still the AVIF *encoder*, and its decoder is the fallback when dav1d is absent.
+#
+# dav1d builds only under meson, so unlike libaom above there is no CPM fallback: this uses a dav1d the
+# system already has, and quietly leaves libheif on libaom when there is none. Emscripten never has one.
+if(HDRVIEW_ENABLE_DAV1D AND HDRVIEW_ENABLE_AVIF AND NOT EMSCRIPTEN)
+  find_package(PkgConfig QUIET)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(HDRVIEW_DAV1D QUIET dav1d)
+  endif()
+  if(NOT HDRVIEW_DAV1D_FOUND)
+    find_path(HDRVIEW_DAV1D_INCLUDE_DIR NAMES dav1d/dav1d.h)
+    find_library(HDRVIEW_DAV1D_LIBRARY NAMES dav1d libdav1d)
+    if(HDRVIEW_DAV1D_INCLUDE_DIR AND HDRVIEW_DAV1D_LIBRARY)
+      set(HDRVIEW_DAV1D_FOUND TRUE)
+    endif()
+  endif()
+  if(NOT HDRVIEW_DAV1D_FOUND)
+    message(STATUS "dav1d not found; AVIF will be decoded with libaom. Install dav1d's development "
+                   "package for roughly twice the AVIF decoding speed."
+    )
+    set(HDRVIEW_ENABLE_DAV1D OFF)
+  endif()
+else()
+  set(HDRVIEW_ENABLE_DAV1D OFF)
+endif()
+
 if(HDRVIEW_ENABLE_LIBHEIF)
   CPMAddPackage(
     NAME Libheif
@@ -1310,12 +1339,16 @@ if(HDRVIEW_ENABLE_LIBHEIF)
             "WITH_JPEG_DECODER ${HDRVIEW_ENABLE_LIBJPEG}"
             "WITH_AOM_ENCODER ${HDRVIEW_ENABLE_AVIF}"
             "WITH_AOM_DECODER ${HDRVIEW_ENABLE_AVIF}"
+            "WITH_DAV1D ${HDRVIEW_ENABLE_DAV1D}"
             "HAVE_JPEG_WRITE_ICC_PROFILE ${HAVE_JPEG_WRITE_ICC_PROFILE}"
     SYSTEM YES
     EXCLUDE_FROM_ALL YES
   )
   if(Libheif_ADDED)
     message(STATUS "Will build libheif library")
+    if(HDRVIEW_ENABLE_DAV1D)
+      message(STATUS "Will decode AVIF with dav1d ${HDRVIEW_DAV1D_VERSION}")
+    endif()
     if(EMSCRIPTEN)
       # Otherwise libheif compiles in the embind bindings for its JavaScript API, which HDRView has no use
       # for and which no longer compile: they bind raw pointers, which embind has since made an error. This
@@ -1343,6 +1376,10 @@ if(HDRVIEW_ENABLE_LIBHEIF)
     mark_as_system_library(heif)
     disable_target_warnings(heif)
   elseif(TARGET heif)
+    # A system libheif brings whichever decoders the distribution compiled into it, so WITH_DAV1D above was
+    # never read and this build cannot claim dav1d either way. The image info panel reports which AV1
+    # decoder libheif actually chose.
+    set(HDRVIEW_ENABLE_DAV1D OFF)
     message(STATUS "Using system-installed libheif library")
   else()
     message(
@@ -1606,6 +1643,7 @@ add_enabled_definition(HDRVIEW_ENABLE_LIBHEIF)
 add_enabled_definition(HDRVIEW_ENABLE_J2K)
 add_enabled_definition(HDRVIEW_ENABLE_HTJ2K)
 add_enabled_definition(HDRVIEW_ENABLE_AVIF)
+add_enabled_definition(HDRVIEW_ENABLE_DAV1D)
 add_enabled_definition(HDRVIEW_ENABLE_HEIC)
 add_enabled_definition(HDRVIEW_ENABLE_AVCI)
 add_enabled_definition(HDRVIEW_ENABLE_LIBWEBP)
@@ -1918,6 +1956,17 @@ if(HDRVIEW_BUILD_FUZZERS AND NOT EMSCRIPTEN)
     target_link_libraries(hdrview_fuzz_load_image PRIVATE "-framework ApplicationServices")
     target_compile_definitions(hdrview_fuzz_load_image PRIVATE IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
   endif()
+endif()
+
+# Times this build's libheif AV1 decoder plugins against each other, which is how the choice between dav1d
+# and libaom's decoder was made and how it can be re-checked on another machine or a newer libheif. It talks
+# to libheif directly and needs none of HDRView's own sources, so it is its own tiny target rather than a
+# doctest case -- and it is a measurement, not a pass/fail, so it stays out of ctest.
+option(HDRVIEW_BUILD_BENCHMARKS "Build the libheif AV1 decoder benchmark" OFF)
+if(HDRVIEW_BUILD_BENCHMARKS AND HDRVIEW_ENABLE_LIBHEIF AND NOT EMSCRIPTEN)
+  add_executable(hdrview_bench_heif tests/bench_heif_decode.cpp)
+  set_target_properties(hdrview_bench_heif PROPERTIES CXX_STANDARD 17)
+  target_link_libraries(hdrview_bench_heif PRIVATE heif)
 endif()
 
 # GUI regression tests, driven by Dear ImGui Test Engine (https://github.com/ocornut/imgui_test_engine),

--- a/README.md
+++ b/README.md
@@ -193,9 +193,14 @@ sudo apt-get install cmake ninja-build xorg-dev libglu1-mesa-dev libxrandr-dev l
   libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev zlib1g-dev libfreetype-dev \
   libjpeg-dev libpng-dev libtiff-dev libwebp-dev libjxl-dev libopenexr-dev libimath-dev \
   liblcms2-dev libraw-dev libexif-dev libspdlog-dev libfmt-dev libcli11-dev libopenjp2-7-dev \
-  libopenh264-dev libheif-dev libaom-dev libde265-dev libx265-dev \
-  libheif-plugin-x265 libheif-plugin-libde265 libheif-plugin-aomenc libheif-plugin-aomdec
+  libopenh264-dev libheif-dev libaom-dev libdav1d-dev libde265-dev libx265-dev \
+  libheif-plugin-x265 libheif-plugin-libde265 libheif-plugin-aomenc libheif-plugin-aomdec \
+  libheif-plugin-dav1d
 ```
+
+`libdav1d-dev` is optional but worth having: it decodes the AV1 in an AVIF several times faster than
+libaom does, and libheif prefers it whenever both are present. Without it AVIF still works, just more
+slowly. See `HDRVIEW_ENABLE_DAV1D`.
 
 See the workflows under [`.github/workflows/`](.github/workflows) for the other platforms.
 

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -1433,6 +1433,7 @@ void HDRViewApp::draw_about_dialog(bool &open)
                     info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_J2K);
                     info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_HTJ2K);
                     info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_AVIF);
+                    info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_DAV1D);
                     info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_HEIC);
                     info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_AVCI);
                     info += PRINT_FEATURE("{:22} : {}\n", HDRVIEW_ENABLE_LIBWEBP);
@@ -1475,8 +1476,8 @@ void HDRViewApp::draw_about_dialog(bool &open)
                     if (heif_info.value("enabled", false))
                     {
                         info += "\nlibheif compression support:\n";
-                        info += fmt::format("{:<13} {:<8} {:<8}\n", "Format", "decoding", "encoding");
-                        info += fmt::format("{:=<13} {:=<8} {:=<8}\n", "", "", "");
+                        info += fmt::format("{:<13} {:<8} {:<8} {}\n", "Format", "decoding", "encoding", "decoder");
+                        info += fmt::format("{:=<13} {:=<8} {:=<8} {:=<24}\n", "", "", "", "");
                         if (heif_info.contains("features") && heif_info["features"].contains("compression"))
                         {
                             for (auto &it : heif_info["features"]["compression"].items())
@@ -1485,8 +1486,10 @@ void HDRViewApp::draw_about_dialog(bool &open)
                                 auto val   = it.value();
                                 bool dec   = val.value("decoder", false);
                                 bool enc   = val.value("encoder", false);
-                                info +=
-                                    fmt::format("{:<13} {:<8} {:<8}\n", codec, dec ? "yes" : "no", enc ? "yes" : "no");
+                                // Which plugin decodes matters where more than one can: AVIF is decoded by
+                                // dav1d when it is available and by libaom otherwise, several times slower.
+                                info += fmt::format("{:<13} {:<8} {:<8} {}\n", codec, dec ? "yes" : "no",
+                                                    enc ? "yes" : "no", val.value("decoder_used", ""));
                             }
                         }
                     }

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -224,9 +224,18 @@ json get_heif_info()
 
     auto add_codec = [&](const char *name, heif_compression_format comp)
     {
-        bool dec          = (heif_have_decoder_for_format(comp) != 0);
-        bool enc          = (heif_have_encoder_for_format(comp) != 0);
-        compression[name] = json{{"decoder", dec}, {"encoder", enc}};
+        bool dec = (heif_have_decoder_for_format(comp) != 0);
+        bool enc = (heif_have_encoder_for_format(comp) != 0);
+        json entry{{"decoder", dec}, {"encoder", enc}};
+
+        // libheif returns the descriptors in descending plugin priority, so the first is the one it will
+        // pick. That matters for AV1, where dav1d and libaom can both be present and one is about twice
+        // as fast as the other.
+        const heif_decoder_descriptor *descriptors[8];
+        if (int n = heif_get_decoder_descriptors(comp, descriptors, 8); n > 0)
+            entry["decoder_used"] = heif_decoder_descriptor_get_name(descriptors[0]);
+
+        compression[name] = entry;
     };
 
     add_codec("AVC", heif_compression_AVC);

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -461,18 +461,32 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
         }
         float bpc_div = 1.f / ((1 << bpc) - 1);
 
-        // copy pixels into a contiguous float buffer and normalize values to [0,1]
-        vector<float> float_pixels((size_t)size.x * size.y * cpp);
-        bool          is_16bit = (bpp_storage == cpp * 16);
-        for (int y = 0; y < size.y; ++y)
-        {
-            auto row8  = reinterpret_cast<const uint8_t *>(pixels + y * (size_t)bytes_per_line);
-            auto row16 = reinterpret_cast<const uint16_t *>(pixels + y * (size_t)bytes_per_line);
-            for (int x = 0; x < size.x; ++x)
-                for (int c = 0; c < cpp; ++c)
-                    float_pixels[(y * size.x + x) * cpp + c] =
-                        bpc_div * (is_16bit ? row16[cpp * x + c] : row8[cpp * x + c]);
-        }
+        // Copy pixels into a contiguous float buffer, normalized to [0,1] -- tens of millions of samples at
+        // full resolution, so it runs on the thread pool like the linearize and channel-copy stages below.
+        // Branching on the sample width per row rather than per sample lets each loop vectorize, and the
+        // buffer is a unique_ptr because value-initializing a vector this size costs more than the loop
+        // that goes on to overwrite every element of it.
+        auto       float_pixels = std::unique_ptr<float[]>(new float[(size_t)size.x * size.y * cpp]);
+        const bool is_16bit     = (bpp_storage == cpp * 16);
+        const int  block_size   = std::max(1, 1024 * 1024 / (size.x * cpp));
+        parallel_for(blocked_range<int>(0, size.y, block_size),
+                     [&](int begin_y, int end_y, int, int)
+                     {
+                         for (int y = begin_y; y < end_y; ++y)
+                         {
+                             float *out = &float_pixels[(size_t)y * size.x * cpp];
+                             if (is_16bit)
+                             {
+                                 auto row = reinterpret_cast<const uint16_t *>(pixels + y * (size_t)bytes_per_line);
+                                 for (int i = 0; i < size.x * cpp; ++i) out[i] = bpc_div * row[i];
+                             }
+                             else
+                             {
+                                 auto row = reinterpret_cast<const uint8_t *>(pixels + y * (size_t)bytes_per_line);
+                                 for (int i = 0; i < size.x * cpp; ++i) out[i] = bpc_div * row[i];
+                             }
+                         }
+                     });
 
         // Alpha is not a color: it carries neither a transfer function nor primaries, so it is copied
         // through as decoded. Only the monochrome path reaches this with a separate alpha plane -- the
@@ -486,7 +500,7 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
 
                 string         profile_desc = color_profile_name(ColorGamut_Unspecified, TransferFunction::Unspecified);
                 Chromaticities chr;
-                if (linearize_pixels(float_pixels.data(), int3{size.xy(), cpp},
+                if (linearize_pixels(float_pixels.get(), int3{size.xy(), cpp},
                                      gamut_chromaticities(opts.gamut_override), opts.tf_override, opts.keep_primaries,
                                      &profile_desc, &chr))
                 {
@@ -510,14 +524,14 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
                 // for SDR profiles, try to transform the interleaved data using the icc profile.
                 // Then try the nclx profile
                 if ((prefer_icc && ICCProfile(image->icc_data)
-                                       .linearize_pixels(float_pixels.data(), int3{size.xy(), cpp}, opts.keep_primaries,
+                                       .linearize_pixels(float_pixels.get(), int3{size.xy(), cpp}, opts.keep_primaries,
                                                          &profile_desc, &chr)) ||
-                    linearize_colors(float_pixels.data(), int3{size.xy(), cpp}, opts.keep_primaries, nclx,
-                                     &profile_desc, &chr))
+                    linearize_colors(float_pixels.get(), int3{size.xy(), cpp}, opts.keep_primaries, nclx, &profile_desc,
+                                     &chr))
                     image->chromaticities = chr;
                 else
                     // icc and nclx profiles failed or not present, so we can only assume we are sRGB/BT709
-                    to_linear(float_pixels.data(), int3{size.xy(), cpp}, TransferFunction::Unspecified);
+                    to_linear(float_pixels.get(), int3{size.xy(), cpp}, TransferFunction::Unspecified);
 
                 image->metadata["color profile"] = profile_desc;
             }
@@ -525,7 +539,7 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
 
         // copy the interleaved float pixels into the channels
         for (int c = 0; c < cpp; ++c)
-            image->channels[p * cpp + c].copy_from_interleaved(float_pixels.data(), size.x, size.y, cpp, c,
+            image->channels[p * cpp + c].copy_from_interleaved(float_pixels.get(), size.x, size.y, cpp, c,
                                                                [](float v) { return v; });
     }
 

--- a/tests/bench_heif_decode.cpp
+++ b/tests/bench_heif_decode.cpp
@@ -1,0 +1,472 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+// Times libheif's AV1 decoder plugins against each other on real files. libheif picks a decoder by
+// priority unless heif_decoding_options::decoder_id names one, so a single build with both plugins
+// compiled in can decode the same bitstream through each of them and report the difference.
+//
+// Usage: hdrview_bench_heif [-n iterations] [-y] [-v] [-c] <file-or-directory>...
+//   -n  timed repetitions per file per decoder (default 5); the fastest is reported
+//   -y  request the decoder's native YCbCr output instead of interleaved RGB
+//   -v  compare the decoders' pixels instead of timing them; exits nonzero on any mismatch
+//   -c  CSV instead of a table
+//
+// By default the decode is set up exactly as src/imageio/heif.cpp sets it up, so the numbers include
+// the YCbCr->RGB conversion HDRView actually pays. That conversion is libheif's own and runs
+// identically whichever plugin decoded the frame, so it dilutes the difference between them; -y
+// leaves it out and measures the codecs alone. The gap between the two runs is what the conversion
+// costs.
+//
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <libheif/heif.h>
+#include <libheif/heif_items.h>
+
+namespace fs = std::filesystem;
+using namespace std::chrono;
+
+namespace
+{
+
+// Thrown for a file whose primary item is some other codec (HEVC in a .heic, say), which says nothing
+// about the AV1 decoders and so is passed over rather than counted as a failure.
+struct NotAV1
+{
+};
+
+struct Timing
+{
+    double best_ms  = 0.0; // fastest of the repetitions
+    double total_ms = 0.0; // sum over all repetitions, for a mean
+    int    reps     = 0;
+    bool   ok       = false;
+};
+
+struct Result
+{
+    std::string                   name;
+    size_t                        bytes = 0;
+    int                           width = 0, height = 0, depth = 0;
+    std::string                   chroma;
+    std::map<std::string, Timing> timings; // keyed by decoder id
+};
+
+std::vector<uint8_t> read_file(const fs::path &p)
+{
+    std::ifstream f(p, std::ios::binary);
+    if (!f)
+        throw std::runtime_error("cannot open " + p.string());
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+// The AV1 decoder plugins libheif was built with, in the order it would fall back through them.
+std::vector<std::string> av1_decoder_ids()
+{
+    const heif_decoder_descriptor *descriptors[16];
+    int                            n = heif_get_decoder_descriptors(heif_compression_AV1, descriptors, 16);
+
+    std::vector<std::string> ids;
+    for (int i = 0; i < n; ++i)
+        if (const char *id = heif_decoder_descriptor_get_id_name(descriptors[i]))
+            ids.emplace_back(id);
+    return ids;
+}
+
+const char *chroma_name(heif_chroma c)
+{
+    switch (c)
+    {
+    case heif_chroma_monochrome: return "mono";
+    case heif_chroma_420: return "4:2:0";
+    case heif_chroma_422: return "4:2:2";
+    case heif_chroma_444: return "4:4:4";
+    default: return "?";
+    }
+}
+
+// One open+decode of an in-memory file through the named decoder. Unless `native` asks for whatever
+// the codec produces, the request mirrors heif.cpp's: interleaved little-endian 16-bit RGB(A) with
+// bilinear chroma upsampling. `pixels`, when given, receives the decoded interleaved plane so two
+// decoders' output can be compared.
+double decode_once(const std::vector<uint8_t> &data, const char *decoder_id, bool native, Result *info,
+                   std::vector<uint8_t> *pixels = nullptr)
+{
+    heif_context *ctx = heif_context_alloc();
+    if (!ctx)
+        throw std::runtime_error("heif_context_alloc failed");
+    struct CtxGuard
+    {
+        heif_context *c;
+        ~CtxGuard() { heif_context_free(c); }
+    } ctx_guard{ctx};
+
+    if (auto err = heif_context_read_from_memory_without_copy(ctx, data.data(), data.size(), nullptr);
+        err.code != heif_error_Ok)
+        throw std::runtime_error(err.message);
+
+    heif_image_handle *handle = nullptr;
+    if (auto err = heif_context_get_primary_image_handle(ctx, &handle); err.code != heif_error_Ok)
+        throw std::runtime_error(err.message);
+    struct HandleGuard
+    {
+        heif_image_handle *h;
+        ~HandleGuard() { heif_image_handle_release(h); }
+    } handle_guard{handle};
+
+    // These plugins only decode AV1, so anything else in a .heif/.heic container is not theirs to compare.
+    if (heif_item_get_item_type(ctx, heif_image_handle_get_item_id(handle)) != heif_fourcc('a', 'v', '0', '1'))
+        throw NotAV1{};
+
+    heif_colorspace preferred_colorspace = heif_colorspace_undefined;
+    heif_chroma     preferred_chroma     = heif_chroma_undefined;
+    heif_image_handle_get_preferred_decoding_colorspace(handle, &preferred_colorspace, &preferred_chroma);
+
+    const bool mono      = preferred_chroma == heif_chroma_monochrome;
+    const bool has_alpha = heif_image_handle_has_alpha_channel(handle) != 0;
+
+    heif_colorspace out_colorspace = heif_colorspace_undefined;
+    heif_chroma     out_chroma     = heif_chroma_undefined;
+    if (!native)
+    {
+        out_colorspace = mono ? heif_colorspace_monochrome : heif_colorspace_RGB;
+        out_chroma     = mono ? heif_chroma_monochrome
+                              : (has_alpha ? heif_chroma_interleaved_RRGGBBAA_LE : heif_chroma_interleaved_RRGGBB_LE);
+    }
+
+    heif_decoding_options *options = heif_decoding_options_alloc();
+    struct OptGuard
+    {
+        heif_decoding_options *o;
+        ~OptGuard() { heif_decoding_options_free(o); }
+    } opt_guard{options};
+    options->color_conversion_options.preferred_chroma_upsampling_algorithm = heif_chroma_upsampling_bilinear;
+    options->color_conversion_options.only_use_preferred_chroma_algorithm   = true;
+    options->decoder_id                                                     = decoder_id;
+
+    heif_image *img = nullptr;
+
+    auto t0  = steady_clock::now();
+    auto err = heif_decode_image(handle, &img, out_colorspace, out_chroma, options);
+    auto t1  = steady_clock::now();
+
+    if (err.code != heif_error_Ok)
+        throw std::runtime_error(err.message);
+
+    if (info)
+    {
+        info->width  = heif_image_get_primary_width(img);
+        info->height = heif_image_get_primary_height(img);
+        info->depth  = heif_image_handle_get_luma_bits_per_pixel(handle);
+        info->chroma = chroma_name(preferred_chroma);
+    }
+
+    if (pixels)
+    {
+        // Rows are padded to the decoder's stride, so copy the meaningful bytes of each one.
+        const heif_channel channel = mono ? heif_channel_Y : heif_channel_interleaved;
+        int                stride  = 0;
+        const uint8_t     *plane   = heif_image_get_plane_readonly(img, channel, &stride);
+        const int          h       = heif_image_get_height(img, channel);
+        const int          w       = heif_image_get_width(img, channel);
+        const int          bpp     = heif_image_get_bits_per_pixel(img, channel); // per pixel, all components
+        const size_t       row     = (size_t)w * ((bpp + 7) / 8);
+
+        pixels->resize(row * h);
+        for (int y = 0; y < h; ++y) memcpy(pixels->data() + row * y, plane + (size_t)stride * y, row);
+    }
+
+    heif_image_release(img);
+
+    return duration<double, std::milli>(t1 - t0).count();
+}
+
+void collect_files(const fs::path &p, std::vector<fs::path> &out)
+{
+    if (fs::is_directory(p))
+    {
+        for (auto &e : fs::recursive_directory_iterator(p))
+        {
+            auto ext = e.path().extension().string();
+            std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+            if (e.is_regular_file() && (ext == ".avif" || ext == ".heif" || ext == ".heic"))
+                out.push_back(e.path());
+        }
+    }
+    else
+        out.push_back(p);
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    int                   reps   = 5;
+    bool                  csv    = false;
+    bool                  native = false;
+    bool                  verify = false;
+    std::vector<fs::path> inputs;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string a = argv[i];
+        if (a == "-n" && i + 1 < argc)
+            reps = std::max(1, atoi(argv[++i]));
+        else if (a == "-c")
+            csv = true;
+        else if (a == "-y")
+            native = true;
+        else if (a == "-v")
+            verify = true;
+        else if (a == "-h" || a == "--help")
+        {
+            printf("usage: %s [-n iterations] [-y] [-v] [-c] <file-or-directory>...\n", argv[0]);
+            return 0;
+        }
+        else
+            inputs.push_back(a);
+    }
+
+    if (inputs.empty())
+    {
+        fprintf(stderr, "no input files given; see --help\n");
+        return 1;
+    }
+
+    auto decoders = av1_decoder_ids();
+    if (decoders.empty())
+    {
+        fprintf(stderr, "libheif was built without any AV1 decoder plugin\n");
+        return 1;
+    }
+
+    fprintf(stderr, "libheif %s, decoding to %s, AV1 decoders (priority order):\n", heif_get_version(),
+            native ? "the codec's native output" : "interleaved 16-bit RGB");
+    {
+        const heif_decoder_descriptor *descriptors[16];
+        int                            n = heif_get_decoder_descriptors(heif_compression_AV1, descriptors, 16);
+        for (int i = 0; i < n; ++i)
+            fprintf(stderr, "  %-8s %s\n", heif_decoder_descriptor_get_id_name(descriptors[i]),
+                    heif_decoder_descriptor_get_name(descriptors[i]));
+    }
+
+    std::vector<fs::path> files;
+    for (auto &p : inputs) collect_files(p, files);
+    std::sort(files.begin(), files.end());
+
+    // Comparison mode: every decoder has to reproduce the first one's pixels exactly. AV1 decoding is
+    // specified bit-exactly, so anything else is a bug in one of them rather than a quality tradeoff.
+    if (verify)
+    {
+        int identical = 0, differing = 0, unreadable = 0, skipped = 0;
+        for (auto &f : files)
+        {
+            std::vector<uint8_t> data;
+            try
+            {
+                data = read_file(f);
+            }
+            catch (const std::exception &e)
+            {
+                fprintf(stderr, "%-52.52s SKIP  %s\n", f.filename().string().c_str(), e.what());
+                continue;
+            }
+
+            // Every decoder gets its turn even after one of them fails, because which of them failed is
+            // the whole question: a file the container layer rejects fails identically for all of them
+            // and says nothing, while one decoder failing alone is a real difference between them.
+            std::vector<uint8_t> reference, other;
+            std::vector<bool>    decoded(decoders.size(), false);
+            bool                 mismatch = false, skip = false;
+            std::string          detail, first_error;
+            for (size_t i = 0; i < decoders.size(); ++i)
+            {
+                try
+                {
+                    decode_once(data, decoders[i].c_str(), native, nullptr, i == 0 ? &reference : &other);
+                    decoded[i] = true;
+                }
+                catch (const NotAV1 &)
+                {
+                    skip = true;
+                    break;
+                }
+                catch (const std::exception &e)
+                {
+                    if (first_error.empty())
+                        first_error = e.what();
+                    continue;
+                }
+                if (i == 0 || !decoded[0])
+                    continue;
+
+                if (other.size() != reference.size())
+                {
+                    mismatch = true;
+                    detail   = "size " + std::to_string(other.size()) + " vs " + std::to_string(reference.size());
+                }
+                else if (memcmp(other.data(), reference.data(), reference.size()) != 0)
+                {
+                    size_t n = 0;
+                    for (size_t b = 0; b < reference.size(); ++b) n += reference[b] != other[b];
+                    mismatch = true;
+                    detail   = std::to_string(n) + " of " + std::to_string(reference.size()) + " bytes differ";
+                }
+            }
+
+            const int decoded_count = (int)std::count(decoded.begin(), decoded.end(), true);
+
+            if (skip)
+                ++skipped;
+            else if (decoded_count == 0)
+            {
+                ++unreadable;
+                printf("%-52.52s SKIP  no decoder could open it: %s\n", f.filename().string().c_str(),
+                       first_error.c_str());
+            }
+            else if (decoded_count != (int)decoders.size())
+            {
+                ++differing;
+                for (size_t i = 0; i < decoders.size(); ++i)
+                    if (!decoded[i])
+                        printf("%-52.52s FAIL  %s alone could not decode it: %s\n", f.filename().string().c_str(),
+                               decoders[i].c_str(), first_error.c_str());
+            }
+            else if (mismatch)
+            {
+                ++differing;
+                printf("%-52.52s DIFF  %s\n", f.filename().string().c_str(), detail.c_str());
+            }
+            else
+                ++identical;
+        }
+        printf("\n%d identical, %d differing, %d unreadable by any decoder, %d not AV1 (%s vs %s)\n", identical,
+               differing, unreadable, skipped, decoders.front().c_str(), decoders.back().c_str());
+        return differing == 0 ? 0 : 1;
+    }
+
+    std::vector<Result> results;
+    for (auto &f : files)
+    {
+        std::vector<uint8_t> data;
+        try
+        {
+            data = read_file(f);
+        }
+        catch (const std::exception &e)
+        {
+            fprintf(stderr, "skipping %s: %s\n", f.string().c_str(), e.what());
+            continue;
+        }
+
+        Result r;
+        r.name  = f.filename().string();
+        r.bytes = data.size();
+
+        bool av1 = true;
+        for (auto &id : decoders)
+        {
+            Timing t;
+            try
+            {
+                decode_once(data, id.c_str(), native, &r); // warm up caches and fill in the image info
+                t.best_ms = 1e30;
+                for (int i = 0; i < reps; ++i)
+                {
+                    double ms = decode_once(data, id.c_str(), native, nullptr);
+                    t.best_ms = std::min(t.best_ms, ms);
+                    t.total_ms += ms;
+                    ++t.reps;
+                }
+                t.ok = true;
+            }
+            catch (const NotAV1 &)
+            {
+                av1 = false;
+                break;
+            }
+            catch (const std::exception &e)
+            {
+                // Off to the side so the table stays a table; the cell itself just reads "fail".
+                fprintf(stderr, "%s: %s: %s\n", r.name.c_str(), id.c_str(), e.what());
+            }
+            r.timings[id] = t;
+        }
+        if (av1)
+            results.push_back(std::move(r));
+    }
+
+    // Report. The last decoder in priority order is the baseline every other one is measured against.
+    const std::string &baseline = decoders.back();
+
+    if (csv)
+    {
+        printf("file,bytes,width,height,depth,chroma");
+        for (auto &id : decoders) printf(",%s_best_ms,%s_mean_ms", id.c_str(), id.c_str());
+        printf("\n");
+        for (auto &r : results)
+        {
+            printf("%s,%zu,%d,%d,%d,%s", r.name.c_str(), r.bytes, r.width, r.height, r.depth, r.chroma.c_str());
+            for (auto &id : decoders)
+            {
+                auto &t = r.timings[id];
+                if (t.ok)
+                    printf(",%.3f,%.3f", t.best_ms, t.total_ms / t.reps);
+                else
+                    printf(",,");
+            }
+            printf("\n");
+        }
+        return 0;
+    }
+
+    printf("\n%-44s %11s %6s %7s", "file", "size", "depth", "chroma");
+    for (auto &id : decoders) printf(" %11s", id.c_str());
+    printf("  speedup\n");
+
+    std::map<std::string, double> totals;
+    for (auto &r : results)
+    {
+        char dims[32];
+        snprintf(dims, sizeof(dims), "%dx%d", r.width, r.height);
+        printf("%-44.44s %11s %5db %7s", r.name.c_str(), dims, r.depth, r.chroma.c_str());
+
+        for (auto &id : decoders)
+        {
+            auto &t = r.timings[id];
+            if (t.ok)
+            {
+                printf(" %10.2f", t.best_ms);
+                totals[id] += t.best_ms;
+            }
+            else
+                printf(" %10s", "fail");
+        }
+
+        auto &base = r.timings[baseline];
+        auto &fast = r.timings[decoders.front()];
+        if (base.ok && fast.ok && fast.best_ms > 0)
+            printf("  %6.2fx", base.best_ms / fast.best_ms);
+        printf("\n");
+    }
+
+    printf("%-44s %11s %6s %7s", "TOTAL", "", "", "");
+    for (auto &id : decoders) printf(" %10.2f", totals[id]);
+    if (totals[decoders.front()] > 0)
+        printf("  %6.2fx", totals[baseline] / totals[decoders.front()]);
+    printf("\n(times are the fastest of %d decodes, in ms; speedup is %s vs %s)\n", reps, decoders.front().c_str(),
+           baseline.c_str());
+
+    return 0;
+}


### PR DESCRIPTION
libheif reaches its AV1 decoder through a plugin and ships one for dav1d alongside the one for libaom. Given both, it prefers dav1d on its own — plugin priority 150 against libaom's 100 — so asking for `WITH_DAV1D` is the whole of the change on the decoding side. No decoding code changed.

libaom stays in the build regardless: it is still the AVIF *encoder*, which dav1d cannot be, and its decoder is what runs wherever no dav1d turns up.

## How much faster

Measured on an i7-12700 against libaom 3.13.3 and dav1d 1.5.3, fastest of five decodes per file.

| | dav1d | libaom | |
|---|---|---|---|
| AV1 decode alone, eight 24 MP 10-bit HDR photos | 875 ms | 5295 ms | **6.05×** |
| Same, pinned to one core | 2255 ms | 5100 ms | 2.26× |
| Same, decoded to the 16-bit RGB HDRView asks for | 2896 ms | 7183 ms | 2.48× |
| Every AVIF in the test corpus, ~400 files | 18.0 s | 40.3 s | 2.24× |
| Opening one 24 MP photo, whole loader, in the app | 0.73 s | 1.57 s | 2.15× |

A little over half the 6× is dav1d's per-thread speed; the rest is its tile threading. libheif hands libaom a default configuration, which decodes a still image on one thread, so libaom is no faster on twenty cores than on one.

The 6× falling to 2.5× once the output is converted is libheif's own YCbCr→RGB pass, which both decoders pay identically. It is now the largest single item in an AVIF load, and the obvious next thing to look at.

## Do they agree

AV1 decoding is specified exactly, and they do. Over **407 AVIF files** from the test corpus every decoded pixel is bit-identical. The 16 files neither can open fail in libheif's container parsing, before any decoder runs, exactly as they do today.

## Also here

**A second commit parallelizes the HEIF sample-normalizing loop**, which is unrelated to the decoder choice but sits right behind it. Widening decoded samples to float was the one stage downstream of the codec still running single-threaded. Two things cost more than the arithmetic: the destination `vector` value-initialized 288 MB of zeros the loop immediately overwrote, and the 8-vs-16-bit choice sat in the innermost loop. For one 24 MP AVIF that stage goes 301 ms → 182 ms and the whole load 856 ms → 730 ms, with the normalized buffer hashing identically before and after across interleaved 16-bit, interleaved 8-bit, and monochrome planar inputs.

`tests/bench_heif_decode.cpp`, behind `HDRVIEW_BUILD_BENCHMARKS`, is what produced every number above and re-checks that the decoders agree. It addresses a plugin by name through `heif_decoding_options::decoder_id`, so a single build exercises both. It stays out of ctest, being a measurement rather than a pass/fail.

The Build info panel now names the AV1 decoder libheif actually chose, so which one ran is visible rather than inferred.

## Not covered

dav1d builds only under meson, so unlike libaom there is no CPM fallback to fetch and build one — the CMake block finds a system dav1d or quietly leaves AVIF on libaom.

- **Windows** gets nothing today: its CI builds every dependency through CPM and installs no system packages, so there is no dav1d to find. Closing this means driving a meson build from CMake.
- **The web build** likewise, and it would gain least — its libaom already has no SIMD and no threads, and dav1d's speed is largely x86/ARM assembly wasm cannot use.
- **A system libheif** (the `-local` presets) brings whichever decoders the distribution compiled in, so the option has no say there. Fedora's and Ubuntu's both carry dav1d.

Linux and macOS CI install dav1d; the README lists it as optional but wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)