### PR TITLE
Receive live images from a renderer over tev's IPC protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,13 @@ option(HDRVIEW_ENABLE_LIBWEBP "Enable LIBWEBP support" ON)
 option(HDRVIEW_ENABLE_LIBTIFF "Enable LIBTIFF support" ON)
 option(HDRVIEW_ENABLE_LIBRAW "Enable LibRaw support" ON)
 option(HDRVIEW_ENABLE_X3F "Enable LibRaw X3F support" ON)
+
+# Listening for pixels pushed in by a renderer, over tev's protocol. The listener is off until the user
+# turns it on, so building this in costs nothing at runtime. A browser has no raw sockets to listen on.
+option(HDRVIEW_ENABLE_IPC "Enable receiving live image updates from renderers (tev-compatible)" ON)
+if(EMSCRIPTEN)
+  set(HDRVIEW_ENABLE_IPC OFF)
+endif()
 option(
   HDRVIEW_ENABLE_HDR_DISPLAY
   "Enable true HDR/EDR display output on Windows and Linux/Wayland, via a patched GLFW fork (Tom94/glfw). No effect on macOS, which always uses that fork and gets EDR through Metal."
@@ -1612,6 +1619,7 @@ add_enabled_definition(HDRVIEW_ENABLE_LIBWEBP)
 add_enabled_definition(HDRVIEW_ENABLE_LIBTIFF)
 add_enabled_definition(HDRVIEW_ENABLE_LIBRAW)
 add_enabled_definition(HDRVIEW_ENABLE_X3F)
+add_enabled_definition(HDRVIEW_ENABLE_IPC)
 
 # ============================================================================
 # Compile remainder of the codebase with compiler warnings turned on
@@ -1653,6 +1661,17 @@ if(NOT HDRVIEW_PORTABLE_INSTALL)
       OFF
       CACHE BOOL "" FORCE
   )
+endif()
+
+if(HDRVIEW_ENABLE_IPC)
+  list(APPEND EXTRA_SOURCES src/ipc/ipc_packet.cpp src/ipc/ipc_server.cpp src/app-ipc.cpp)
+  # Only meaningful when the IPC sources are built; left empty otherwise so the test target's source list
+  # does not name a file whose subject was compiled out.
+  set(HDRVIEW_IPC_TESTS tests/test_ipc_packet.cpp tests/test_ipc_server.cpp)
+  if(WIN32)
+    # Winsock is not among the libraries a Windows link pulls in by default.
+    list(APPEND HDRVIEW_DEPENDENCIES ws2_32)
+  endif()
 endif()
 
 set(HDRVIEW_SOURCES
@@ -1768,6 +1787,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_path_helpers.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
                                 tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_xmp.cpp tests/test_exif.cpp
+                                ${HDRVIEW_IPC_TESTS}
   )
   target_include_directories(hdrview_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
   set_target_properties(hdrview_tests PROPERTIES CXX_STANDARD 17)
@@ -1879,15 +1899,13 @@ if(HDRVIEW_BUILD_FUZZERS AND NOT EMSCRIPTEN)
   endif()
 
   list(REMOVE_ITEM HDRVIEW_SOURCES src/hdrview.cpp)
-  add_executable(hdrview_fuzz_load_image ${HDRVIEW_SOURCES} tests/fuzz/fuzz_load_image.cpp)
-  target_include_directories(hdrview_fuzz_load_image PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-  set_target_properties(hdrview_fuzz_load_image PROPERTIES CXX_STANDARD 17)
-  target_compile_definitions(hdrview_fuzz_load_image PRIVATE ${HDRVIEW_ICONSET} ${HDRVIEW_DEFINITIONS})
-  target_compile_definitions(
-    hdrview_fuzz_load_image PRIVATE HDRVIEW_BUILD_TREE_ASSETS_DIR="${CMAKE_CURRENT_BINARY_DIR}/assets"
-  )
-  target_link_libraries(hdrview_fuzz_load_image PRIVATE ${HDRVIEW_DEPENDENCIES} hello_imgui hdrview_version)
-  target_compile_options(hdrview_fuzz_load_image PRIVATE -fsanitize=fuzzer-no-link)
+
+  # One entry per fuzz target: "<target name>|<entry point source>". They differ only in that source, so
+  # everything else below is applied to each in turn.
+  set(HDRVIEW_FUZZERS "hdrview_fuzz_load_image|tests/fuzz/fuzz_load_image.cpp")
+  if(HDRVIEW_ENABLE_IPC)
+    list(APPEND HDRVIEW_FUZZERS "hdrview_fuzz_ipc_packet|tests/fuzz/fuzz_ipc_packet.cpp")
+  endif()
 
   # Apple's clang instruments for libFuzzer but ships no fuzzer runtime, so on macOS one has to be linked
   # explicitly -- from Homebrew's LLVM by default. Everywhere else -fsanitize=fuzzer supplies its own.
@@ -1907,17 +1925,33 @@ if(HDRVIEW_BUILD_FUZZERS AND NOT EMSCRIPTEN)
     endif()
   endif()
 
-  if(HDRVIEW_FUZZER_RUNTIME)
-    target_link_libraries(hdrview_fuzz_load_image PRIVATE "${HDRVIEW_FUZZER_RUNTIME}")
-  else()
-    target_link_options(hdrview_fuzz_load_image PRIVATE -fsanitize=fuzzer)
-  endif()
+  foreach(fuzzer IN LISTS HDRVIEW_FUZZERS)
+    string(REPLACE "|" ";" fuzzer_parts "${fuzzer}")
+    list(GET fuzzer_parts 0 fuzz_target)
+    list(GET fuzzer_parts 1 fuzz_source)
 
-  if(APPLE)
-    target_compile_options(hdrview_fuzz_load_image PRIVATE "-fobjc-arc")
-    target_link_libraries(hdrview_fuzz_load_image PRIVATE "-framework ApplicationServices")
-    target_compile_definitions(hdrview_fuzz_load_image PRIVATE IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
-  endif()
+    add_executable(${fuzz_target} ${HDRVIEW_SOURCES} ${fuzz_source})
+    target_include_directories(${fuzz_target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    set_target_properties(${fuzz_target} PROPERTIES CXX_STANDARD 17)
+    target_compile_definitions(${fuzz_target} PRIVATE ${HDRVIEW_ICONSET} ${HDRVIEW_DEFINITIONS})
+    target_compile_definitions(
+      ${fuzz_target} PRIVATE HDRVIEW_BUILD_TREE_ASSETS_DIR="${CMAKE_CURRENT_BINARY_DIR}/assets"
+    )
+    target_link_libraries(${fuzz_target} PRIVATE ${HDRVIEW_DEPENDENCIES} hello_imgui hdrview_version)
+    target_compile_options(${fuzz_target} PRIVATE -fsanitize=fuzzer-no-link)
+
+    if(HDRVIEW_FUZZER_RUNTIME)
+      target_link_libraries(${fuzz_target} PRIVATE "${HDRVIEW_FUZZER_RUNTIME}")
+    else()
+      target_link_options(${fuzz_target} PRIVATE -fsanitize=fuzzer)
+    endif()
+
+    if(APPLE)
+      target_compile_options(${fuzz_target} PRIVATE "-fobjc-arc")
+      target_link_libraries(${fuzz_target} PRIVATE "-framework ApplicationServices")
+      target_compile_definitions(${fuzz_target} PRIVATE IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
+    endif()
+  endforeach()
 endif()
 
 # GUI regression tests, driven by Dear ImGui Test Engine (https://github.com/ocornut/imgui_test_engine),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1667,7 +1667,7 @@ if(HDRVIEW_ENABLE_IPC)
   list(APPEND EXTRA_SOURCES src/ipc/ipc_packet.cpp src/ipc/ipc_server.cpp src/app-ipc.cpp)
   # Only meaningful when the IPC sources are built; left empty otherwise so the test target's source list
   # does not name a file whose subject was compiled out.
-  set(HDRVIEW_IPC_TESTS tests/test_ipc_packet.cpp tests/test_ipc_server.cpp)
+  set(HDRVIEW_IPC_TESTS tests/test_ipc_packet.cpp tests/test_ipc_server.cpp tests/test_vector_overlay.cpp)
   if(WIN32)
     # Winsock is not among the libraries a Windows link pulls in by default.
     list(APPEND HDRVIEW_DEPENDENCIES ws2_32)
@@ -1720,6 +1720,7 @@ set(HDRVIEW_SOURCES
     src/texture_gl.cpp
     src/texture.cpp
     src/theme.cpp
+    src/vector_overlay.cpp
     ${EXTRA_SOURCES}
 )
 

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -118,7 +118,7 @@ void HDRViewApp::draw_pixel_info() const
     {
         for (int x = bounds.min.x; x < bounds.max.x; ++x)
         {
-            auto   pos        = app_pos_at_pixel(float2(x + 0.5f, y + 0.5f));
+            auto   pos     = app_pos_at_pixel(float2(x + 0.5f, y + 0.5f));
             float4 r_pixel = pixel_value({x, y}, true, m_status_pixel_target);
             float4 t_pixel = linear_to_sRGB(pixel_value({x, y}, false, m_status_pixel_target));
             float4 pixel   = m_status_color_mode == 0 ? r_pixel : t_pixel;

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -202,6 +202,47 @@ void HDRViewApp::draw_image_border() const
     }
 }
 
+void HDRViewApp::draw_vector_overlays() const
+{
+    // The current image and, when one is set, the reference: a renderer can annotate either, and which is
+    // which has to stay readable, so they get different default colors -- matching what tev does.
+    const std::pair<ConstImagePtr, ImU32> targets[] = {{current_image(), IM_COL32(255, 255, 255, 200)},
+                                                       {reference_image(), IM_COL32(255, 128, 0, 200)}};
+
+    VgTransform xform;
+    xform.to_screen = [this](float2 p) { return app_pos_at_pixel(p); };
+    // Screen pixels per image pixel, read off the transform itself so it stays right under a flip, which
+    // mirrors the mapping but must not give a stroke a negative width.
+    xform.scale        = std::abs(app_pos_at_pixel(float2{1.f, 0.f}).x - app_pos_at_pixel(float2{0.f, 0.f}).x);
+    xform.default_font = font("sans regular");
+    xform.font_for     = [this](const std::string &face) -> void *
+    {
+        // NanoVG face names, as tev's own overlay defaults use them, mapped onto the fonts HDRView loads.
+        if (face == "sans-bold" || face == "bold")
+            return font("sans bold");
+        if (face == "mono" || face == "monospace")
+            return font("mono regular");
+        if (face == "mono-bold")
+            return font("mono bold");
+        return font("sans regular");
+    };
+
+    for (const auto &[img, color] : targets)
+    {
+        if (!img || img->vector_overlay.empty())
+            continue;
+
+        draw_vector_overlay(ImGui::GetBackgroundDrawList(), img->vector_overlay, xform, color,
+                            [](const char *what)
+                            {
+                                // Throttled: an overlay is redrawn every frame, so an unsupported command
+                                // in it would otherwise report itself at the frame rate.
+                                if (static LogThrottle throttle{std::chrono::seconds(10)}; throttle)
+                                    spdlog::warn("Vector overlay uses {}, which HDRView does not draw.", what);
+                            });
+    }
+}
+
 void HDRViewApp::draw_tool_decorations() const
 {
     if (!current_image())
@@ -378,6 +419,7 @@ void HDRViewApp::draw_background()
         draw_pixel_info();
         draw_pixel_grid();
         draw_image_border();
+        draw_vector_overlays();
         draw_tool_decorations();
     }
     catch (const exception &e)

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -648,6 +648,10 @@ bool HDRViewApp::can_reload(const ConstImagePtr &image) const
     if (!image)
         return false;
 
+    // A live image's pixels are pushed in by another process; there is no file to read again.
+    if (image->is_live)
+        return false;
+
 #if defined(__EMSCRIPTEN__)
     // A URL can be fetched again. Bytes the browser handed over once -- an upload, or an entry of an
     // uploaded zip -- carry only a display name, with nothing behind it to read.
@@ -810,9 +814,19 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
     j["type"]    = "HDRView session";
     j["version"] = fmt::format("{}.{}.{}", version_major(), version_minor(), version_patch());
 
-    json images = json::array();
-    for (auto &img : m_images)
+    // A live image's pixels come from a running process, so a session -- which records where to find its
+    // images again -- has nothing it could write for it. Leaving it out renumbers the remaining entries,
+    // so keep a map from image index to manifest entry for the current/reference indices below.
+    json             images = json::array();
+    std::vector<int> entry_of_image(m_images.size(), -1);
+    for (size_t i = 0; i < m_images.size(); ++i)
     {
+        const auto &img = m_images[i];
+        if (img->is_live)
+            continue;
+
+        entry_of_image[i] = int(images.size());
+
         json entry;
         entry["path"]                  = path_of(img);
         entry["channel_selector"]      = img->channel_selector;
@@ -824,9 +838,10 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
     j["images"] = images;
     // Indices into "images", not paths: the same file can legitimately be listed more than once (e.g. to
     // compare two channel groups of it side by side), so a path alone can't identify which occurrence is
-    // current/reference.
-    j["current"]   = image_index(current_image());
-    j["reference"] = image_index(reference_image());
+    // current/reference. -1 when there is no such image, or when it was a live one that was left out.
+    auto entry_index = [&](int idx) { return idx >= 0 && idx < (int)entry_of_image.size() ? entry_of_image[idx] : -1; };
+    j["current"]     = entry_index(image_index(current_image()));
+    j["reference"]   = entry_index(image_index(reference_image()));
 
     j["blend_mode"] = enum_to_id(m_blend_mode, g_blend_mode_ids);
 
@@ -928,6 +943,9 @@ void HDRViewApp::export_session_bundle()
         mz_zip_writer_add_mem(&zip, "session.hsess", manifest_text.data(), manifest_text.size(), MZ_DEFAULT_LEVEL);
     for (size_t i = 0; ok && i < m_images.size(); ++i)
     {
+        if (m_images[i]->is_live)
+            continue; // no file behind it, and build_session_manifest() left it out too
+
         string source = m_images[i]->path.u8string();
         string source_zip, entry_path;
         if (split_zip_entry(source, source_zip, entry_path) && !entry_path.empty())

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -583,8 +583,7 @@ void HDRViewApp::draw_top_toolbar()
     ImGui::PopFont();
     ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
     ImGui::SetNextItemWidth(EmSize(8));
-    ImGui::SliderFloat("##ExposureSlider", &m_exposure_live, EXPOSURE_RANGE[0], EXPOSURE_RANGE[1],
-                       "Exposure: %+5.2f");
+    ImGui::SliderFloat("##ExposureSlider", &m_exposure_live, EXPOSURE_RANGE[0], EXPOSURE_RANGE[1], "Exposure: %+5.2f");
     if (ImGui::IsItemDeactivatedAfterEdit())
         m_exposure = m_exposure_live;
     ImGui::EndGroup();
@@ -914,6 +913,56 @@ void HDRViewApp::draw_command_palette(bool &open)
                  "",
                  nullptr,
                  set_background_last_used});
+
+#if HDRVIEW_ENABLE_IPC
+            // A two-step command for the port the image-update listener binds. PromptInt would be the
+            // obvious fit, but its buffer starts empty and nothing can seed it, so the port would have to be
+            // retyped rather than edited. A widget can be handed the current value, which is the point.
+            static int  set_ipc_port_last_used = 0;
+            static bool first_frame_port       = true;
+            ImCmd::AddCommand({{"Set image update port", "Set IPC port", "Set listening port"},
+                               []()
+                               {
+                                   first_frame_port = true;
+                                   // Captures nothing: everything it touches is static or global, and the
+                                   // widget outlives this callback, so a reference capture would dangle.
+                                   ImCmd::PromptWidget(
+                                       []() -> bool
+                                       {
+                                           static int port = 0;
+                                           if (first_frame_port)
+                                           {
+                                               port = int(hdrview()->ipc_port());
+                                               ImGui::SetKeyboardFocusHere();
+                                               first_frame_port = false;
+                                           }
+
+                                           ImGui::SetNextItemWidth(HelloImGui::EmSize(8.f));
+                                           const bool entered = ImGui::InputInt(
+                                               "Port", &port, 0, 0,
+                                               ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_EnterReturnsTrue);
+
+                                           if (ImGui::IsKeyPressed(ImGuiKey_Escape))
+                                               return true; // dismissed; the port is left as it was
+
+                                           if (!entered)
+                                               return false;
+
+                                           hdrview()->set_ipc_port(uint16_t(std::clamp(port, 1, 65535)));
+                                           return true;
+                                       },
+                                       "Enter the port to listen on. 14158 is the one renderers connect to by "
+                                       "default. Press Enter to apply or Escape to cancel.");
+                               },
+                               nullptr,
+                               nullptr,
+                               nullptr,
+                               []() { set_ipc_port_last_used = ++last_used; },
+                               ICON_MY_WATCH_CHANGES,
+                               "",
+                               nullptr,
+                               set_ipc_port_last_used});
+#endif
 
             // add two-step theme selection command
             static int set_theme_last_used = 0;

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -90,6 +90,33 @@ bool HDRViewApp::start_ipc_listening(uint16_t port)
 
 void HDRViewApp::stop_ipc_listening() { m_ipc_server.stop(); }
 
+void HDRViewApp::set_ipc_listening(bool listen)
+{
+    // The one place the toggle's meaning lives, so the panel's checkbox and the command palette's entry
+    // cannot drift apart. Binding can fail -- the port may be held by tev or another HDRView -- so the
+    // request is answered by what the server actually did, not by what was asked for.
+    if (listen)
+        start_ipc_listening(m_ipc_port);
+    else
+        stop_ipc_listening();
+
+    m_ipc_listen_requested = m_ipc_server.is_listening();
+}
+
+void HDRViewApp::set_ipc_port(uint16_t port)
+{
+    if (port == m_ipc_port)
+        return;
+
+    m_ipc_port = port;
+
+    // Rebind straight away when already listening, so the port shown is the port in use. start() stops the
+    // old listener first, so a client connected to it is dropped -- and if the new port turns out to be
+    // taken, nothing is listening and the panel says why.
+    if (m_ipc_server.is_listening())
+        set_ipc_listening(true);
+}
+
 void HDRViewApp::IpcRates::update(const IpcActivity &now, double time)
 {
     // Long enough that the numbers hold still and can be read, short enough that they follow a renderer
@@ -121,28 +148,23 @@ void HDRViewApp::draw_ipc_gui()
 
     const bool listening = m_ipc_server.is_listening();
 
+    // Both this and the "Listen for image updates" command go through set_ipc_listening(); the label differs
+    // because here the sentence continues into the port field beside it.
     bool toggle = listening;
     if (ImGui::Checkbox("Listen for image updates on port:", &toggle))
-    {
-        if (toggle)
-            start_ipc_listening(m_ipc_port);
-        else
-            stop_ipc_listening();
-    }
-    ImGui::Tooltip("Accept images pushed in by a renderer while it works, over the protocol tev uses. "
-                   "Nothing outside this machine can connect. Off unless you turn it on.");
+        set_ipc_listening(toggle);
+    ImGui::Tooltip("Accept images pushed in by a renderer while it works, so a render appears here tile by "
+                   "tile. Nothing outside this machine can connect. Off unless you turn it on.");
 
     // The port reads as the end of the checkbox's sentence, so it carries no label of its own.
     ImGui::SameLine();
-    // It cannot change under a bound socket, and rebinding silently would drop whatever is connected.
-    ImGui::BeginDisabled(listening);
     int port = int(m_ipc_port);
     ImGui::SetNextItemWidth(HelloImGui::EmSize(4.f));
-    if (ImGui::InputInt("##Port", &port, 0, 0, ImGuiInputTextFlags_CharsDecimal))
-        m_ipc_port = uint16_t(std::clamp(port, 1, 65535));
-    ImGui::EndDisabled();
-    ImGui::Tooltip("14158 is what tev listens on, so clients written for it need no changes. Change it to "
-                   "run HDRView and tev side by side.");
+    if (ImGui::InputInt("##Port", &port, 0, 0, ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_EnterReturnsTrue))
+        set_ipc_port(uint16_t(std::clamp(port, 1, 65535)));
+    ImGui::Tooltip("14158 is the port renderers connect to by default, so most need no configuring. Change it "
+                   "if another viewer already holds that port. Changing it while listening rebinds, dropping "
+                   "anything currently connected.");
 
     // Wrapped, not clipped: this panel is usually docked narrow, and both the address and the client count
     // are the point of the line.

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -9,6 +9,7 @@
 
 #include "app.h"
 
+#include "common.h"
 #include "image.h"
 #include "imageio/image_loader.h"
 #include "imgui_ext.h"
@@ -89,6 +90,31 @@ bool HDRViewApp::start_ipc_listening(uint16_t port)
 
 void HDRViewApp::stop_ipc_listening() { m_ipc_server.stop(); }
 
+void HDRViewApp::IpcRates::update(const IpcActivity &now, double time)
+{
+    // Long enough that the numbers hold still and can be read, short enough that they follow a renderer
+    // starting and stopping.
+    static constexpr double k_window = 0.5;
+
+    if (sampled_at == 0.0)
+    {
+        sampled_at   = time;
+        last_packets = now.packets;
+        last_bytes   = now.bytes;
+        return;
+    }
+
+    const double elapsed = time - sampled_at;
+    if (elapsed < k_window)
+        return;
+
+    packets_per_s = double(now.packets - last_packets) / elapsed;
+    bytes_per_s   = double(now.bytes - last_bytes) / elapsed;
+    sampled_at    = time;
+    last_packets  = now.packets;
+    last_bytes    = now.bytes;
+}
+
 void HDRViewApp::draw_ipc_gui()
 {
     ImGui::SeparatorText("Live updates");
@@ -125,6 +151,42 @@ void HDRViewApp::draw_ipc_gui()
         const size_t clients = m_ipc_server.num_connections();
         ImGui::TextWrapped("Listening on 127.0.0.1:%d \xe2\x80\x93 %s connected.", int(m_ipc_server.port()),
                            clients == 1 ? "1 client" : fmt::format("{} clients", clients).c_str());
+
+        const auto activity = m_ipc_server.activity();
+        m_ipc_rates.update(activity, ImGui::GetTime());
+
+        // "Streaming" is anything still arriving; a renderer that pauses between passes should not make the
+        // readout flicker, so the threshold is well above the quarter-second pbrt leaves between updates.
+        static constexpr double k_idle_after = 1.5;
+        const bool streaming = activity.seconds_since_last >= 0.0 && activity.seconds_since_last < k_idle_after;
+
+        if (clients && streaming)
+        {
+            // Indeterminate on purpose. Nothing in the protocol says how much is left, and the two ways
+            // clients stream -- painting each tile once, or resending the frame at rising sample counts --
+            // are indistinguishable from the packets, so any percentage here would be invented.
+            // No overlay text: the strip is deliberately thinner than a line of it, and the rates below say
+            // what it is doing anyway.
+            ImGui::ProgressBar(-1.f * float(ImGui::GetTime()), ImVec2(-FLT_MIN, ImGui::GetFrameHeight() * 0.35f), "");
+            ImGui::TextWrapped("%s",
+                               fmt::format("Receiving {:.1h}/s over {:.0f} updates/s.",
+                                           human_readible{size_t(m_ipc_rates.bytes_per_s)}, m_ipc_rates.packets_per_s)
+                                   .c_str());
+        }
+        else if (clients)
+            // How long a connected client has been quiet is worth watching -- it separates a renderer
+            // between passes from one that has stalled.
+            ImGui::TextWrapped("Connected, but nothing received for %.0fs.", activity.seconds_since_last);
+        else if (!activity.packets)
+            ImGui::TextUnformatted("Waiting for a renderer to connect.");
+        // With nobody connected there is nothing left to wait for, so the time since the last update stops
+        // being information and just climbs. The totals below say what arrived; that is the whole story.
+
+        if (activity.packets)
+            ImGui::TextWrapped("%s", fmt::format("{:.1h} in {} total.", human_readible{size_t(activity.bytes)},
+                                                 activity.packets == 1 ? std::string{"1 update"}
+                                                                       : fmt::format("{} updates", activity.packets))
+                                         .c_str());
     }
     else if (auto error = m_ipc_server.last_error(); !error.empty())
     {

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -1,0 +1,254 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+// Turning packets received from a renderer into changes to the loaded images. The socket and the wire
+// format live in src/ipc/; everything here is HDRViewApp's side of them.
+
+#include "app.h"
+
+#include "image.h"
+#include "imageio/image_loader.h"
+#include "imgui_ext.h"
+
+#include <hello_imgui/dpi_aware.h>
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+
+#if HDRVIEW_ENABLE_IPC
+
+int HDRViewApp::image_index_by_name(std::string_view name) const
+{
+    for (int i = 0; i < num_images(); ++i)
+        if (m_images[size_t(i)]->filename == name)
+            return i;
+    return -1;
+}
+
+bool HDRViewApp::start_ipc_listening(uint16_t port)
+{
+    // Decode on the receive thread and hand the main thread only the result: parsing a tile means copying
+    // its samples, which is the bulk of the work and has no reason to happen on the frame.
+    return m_ipc_server.start(
+        port,
+        [this](const IpcPacket &packet)
+        {
+            try
+            {
+                switch (packet.type())
+                {
+                case IpcPacketType::OpenImage:
+                case IpcPacketType::OpenImageV2:
+                    post_to_main_thread([this, info = packet.as_open_image()] { apply_ipc_open(info); });
+                    break;
+
+                case IpcPacketType::ReloadImage:
+                    post_to_main_thread([this, info = packet.as_reload_image()] { apply_ipc_reload(info); });
+                    break;
+
+                case IpcPacketType::CloseImage:
+                    post_to_main_thread([this, info = packet.as_close_image()] { apply_ipc_close(info); });
+                    break;
+
+                case IpcPacketType::CreateImage:
+                    post_to_main_thread([this, info = packet.as_create_image()] { apply_ipc_create(info); });
+                    break;
+
+                case IpcPacketType::UpdateImage:
+                case IpcPacketType::UpdateImageV2:
+                case IpcPacketType::UpdateImageV3:
+                    post_to_main_thread([this, info = packet.as_update_image()] { apply_ipc_update(info); });
+                    break;
+
+                case IpcPacketType::VectorGraphics:
+                    // Overlay drawing, which HDRView has nothing to draw with. Ignoring it costs the sender
+                    // nothing: the protocol expects no reply, so a client that draws debug overlays still
+                    // streams its pixels normally.
+                    spdlog::debug("Ignoring a VectorGraphics packet: HDRView does not draw overlays.");
+                    break;
+
+                default: spdlog::warn("Ignoring an IPC packet of unknown type {}.", int(packet.type())); break;
+                }
+            }
+            catch (const std::exception &e)
+            {
+                // One unreadable packet is not grounds to drop the connection -- the framing was intact, so
+                // the stream is still in sync and the next packet may well be fine.
+                spdlog::warn("Could not read an IPC packet: {}", e.what());
+            }
+
+            // The frame loop idles by waiting on window events, so without a nudge a tile can sit undrawn
+            // for as long as the idle timeout. See wake_event_loop().
+            wake_event_loop();
+        });
+}
+
+void HDRViewApp::stop_ipc_listening() { m_ipc_server.stop(); }
+
+void HDRViewApp::draw_ipc_gui()
+{
+    ImGui::SeparatorText("Live updates");
+
+    const bool listening = m_ipc_server.is_listening();
+
+    bool toggle = listening;
+    if (ImGui::Checkbox("Listen for image updates on port:", &toggle))
+    {
+        if (toggle)
+            start_ipc_listening(m_ipc_port);
+        else
+            stop_ipc_listening();
+    }
+    ImGui::Tooltip("Accept images pushed in by a renderer while it works, over the protocol tev uses. "
+                   "Nothing outside this machine can connect. Off unless you turn it on.");
+
+    // The port reads as the end of the checkbox's sentence, so it carries no label of its own.
+    ImGui::SameLine();
+    // It cannot change under a bound socket, and rebinding silently would drop whatever is connected.
+    ImGui::BeginDisabled(listening);
+    int port = int(m_ipc_port);
+    ImGui::SetNextItemWidth(HelloImGui::EmSize(4.f));
+    if (ImGui::InputInt("##Port", &port, 0, 0, ImGuiInputTextFlags_CharsDecimal))
+        m_ipc_port = uint16_t(std::clamp(port, 1, 65535));
+    ImGui::EndDisabled();
+    ImGui::Tooltip("14158 is what tev listens on, so clients written for it need no changes. Change it to "
+                   "run HDRView and tev side by side.");
+
+    // Wrapped, not clipped: this panel is usually docked narrow, and both the address and the client count
+    // are the point of the line.
+    if (listening)
+    {
+        const size_t clients = m_ipc_server.num_connections();
+        ImGui::TextWrapped("Listening on 127.0.0.1:%d \xe2\x80\x93 %s connected.", int(m_ipc_server.port()),
+                           clients == 1 ? "1 client" : fmt::format("{} clients", clients).c_str());
+    }
+    else if (auto error = m_ipc_server.last_error(); !error.empty())
+    {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+        ImGui::TextWrapped("%s", error.c_str());
+        ImGui::PopStyleColor();
+    }
+
+    ImGui::Dummy(ImVec2(0, HelloImGui::EmSize(0.5f)));
+    ImGui::SeparatorText("Watched folders");
+}
+
+void HDRViewApp::apply_ipc_open(const IpcOpenImage &info)
+{
+    auto opts             = load_image_options();
+    opts.channel_selector = info.channel_selector;
+    load_image(info.path, std::nullopt, info.grab_focus, opts);
+}
+
+void HDRViewApp::apply_ipc_reload(const IpcReloadImage &info)
+{
+    const int idx = image_index_by_name(info.name);
+    if (!is_valid(idx))
+    {
+        spdlog::warn("Cannot reload '{}': no such image is open.", info.name);
+        return;
+    }
+    reload_image(m_images[size_t(idx)], info.grab_focus);
+}
+
+void HDRViewApp::apply_ipc_close(const IpcCloseImage &info)
+{
+    const int idx = image_index_by_name(info.name);
+    if (!is_valid(idx))
+    {
+        spdlog::warn("Cannot close '{}': no such image is open.", info.name);
+        return;
+    }
+    close_image(idx);
+}
+
+void HDRViewApp::apply_ipc_create(const IpcCreateImage &info)
+{
+    ImagePtr image;
+    try
+    {
+        image = std::make_shared<Image>(info.size, info.channel_names);
+
+        image->filename   = info.name;
+        image->short_name = info.name;
+        image->is_live    = true;
+
+        // The samples a renderer sends are its own; nothing here should reinterpret them. Leaving alpha_type
+        // at AlphaType_None keeps finalize() from premultiplying, which would otherwise scale every tile by
+        // an alpha channel that may not have been sent yet.
+        image->finalize();
+    }
+    catch (const std::exception &e)
+    {
+        // A name and a channel list chosen by another process, so this is reachable: duplicate channel
+        // names, or dimensions past what the GPU can hold, both land here.
+        spdlog::error("Could not create '{}' over IPC: {}", info.name, e.what());
+        return;
+    }
+
+    // Recreating an existing name replaces it in place, which is what a renderer restarting a render means
+    // by it -- and matches tev, whose CreateImage is documented to overwrite.
+    const int existing = image_index_by_name(info.name);
+    if (is_valid(existing))
+        m_images[size_t(existing)] = image;
+    else
+        m_images.push_back(image);
+
+    if (info.grab_focus)
+        set_current_image_index(is_valid(existing) ? existing : num_images() - 1, true);
+
+    update_visibility(); // also sets the image textures
+    m_request_sort = true;
+
+    spdlog::info("Created live image '{}' ({}x{}, {} channels).", info.name, info.size.x, info.size.y,
+                 info.channel_names.size());
+}
+
+void HDRViewApp::apply_ipc_update(const IpcUpdateImage &info)
+{
+    const int idx = image_index_by_name(info.name);
+    if (!is_valid(idx))
+    {
+        spdlog::warn("Cannot update '{}': no such image is open. Send a CreateImage first.", info.name);
+        return;
+    }
+
+    auto &image = *m_images[size_t(idx)];
+
+    // The packet addresses its samples in the image's pixel coordinates; a channel is indexed from its own
+    // top-left corner, which for an image with a non-zero data window is somewhere else.
+    const Box2i bounds{info.bounds.min - image.data_window.min, info.bounds.max - image.data_window.min};
+
+    bool any = false;
+    for (int c = 0; c < info.num_channels(); ++c)
+    {
+        const auto &name = info.channel_names[size_t(c)];
+
+        auto found = std::find_if(image.channels.begin(), image.channels.end(),
+                                  [&name](const Channel &ch) { return ch.name == name; });
+        if (found == image.channels.end())
+        {
+            spdlog::warn("Cannot update channel '{}' of '{}': it has no such channel.", name, info.name);
+            continue;
+        }
+
+        found->upload_tile(bounds, info.data.data() + info.channel_offsets[size_t(c)], info.channel_strides[size_t(c)],
+                           info.row_stride(c));
+        any = true;
+    }
+
+    if (!any)
+        return;
+
+    // Statistics and histograms are cached against this; see Image::content_version.
+    ++image.content_version;
+
+    if (info.grab_focus)
+        set_current_image_index(idx, true);
+}
+
+#endif // HDRVIEW_ENABLE_IPC

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -66,10 +66,8 @@ bool HDRViewApp::start_ipc_listening(uint16_t port)
                     break;
 
                 case IpcPacketType::VectorGraphics:
-                    // Overlay drawing, which HDRView has nothing to draw with. Ignoring it costs the sender
-                    // nothing: the protocol expects no reply, so a client that draws debug overlays still
-                    // streams its pixels normally.
-                    spdlog::debug("Ignoring a VectorGraphics packet: HDRView does not draw overlays.");
+                    post_to_main_thread([this, info = packet.as_vector_graphics()]
+                                        { apply_ipc_vector_graphics(info); });
                     break;
 
                 default: spdlog::warn("Ignoring an IPC packet of unknown type {}.", int(packet.type())); break;
@@ -290,6 +288,25 @@ void HDRViewApp::apply_ipc_create(const IpcCreateImage &info)
 
     spdlog::info("Created live image '{}' ({}x{}, {} channels).", info.name, info.size.x, info.size.y,
                  info.channel_names.size());
+}
+
+void HDRViewApp::apply_ipc_vector_graphics(const IpcVectorGraphics &info)
+{
+    const int idx = image_index_by_name(info.name);
+    if (!is_valid(idx))
+    {
+        spdlog::warn("Cannot draw over '{}': no such image is open.", info.name);
+        return;
+    }
+
+    auto &overlay = m_images[size_t(idx)]->vector_overlay;
+    if (info.append)
+        overlay.insert(overlay.end(), info.commands.begin(), info.commands.end());
+    else
+        overlay = info.commands;
+
+    if (info.grab_focus)
+        set_current_image_index(idx, true);
 }
 
 void HDRViewApp::apply_ipc_update(const IpcUpdateImage &info)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -639,6 +639,11 @@ void HDRViewApp::setup_frame_callbacks()
     {
         drain_main_thread_queue();
 
+#if HDRVIEW_ENABLE_IPC
+        // See m_ipc_listen_requested: the toggle's Action needs a bool, but the socket is the truth.
+        m_ipc_listen_requested = m_ipc_server.is_listening();
+#endif
+
         process_shortcuts();
 
         for (auto &d : m_dialogs) d->draw(d->open);
@@ -1333,6 +1338,20 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                    &m_watch_files_for_changes,
                    "Regularly monitor opened files and folders, loading new files, and reloading existing files when "
                    "changes are detected."});
+#if HDRVIEW_ENABLE_IPC
+        // The generic action-to-palette mapping flips p_selected and then calls this, so the callback acts
+        // on the flipped value and set_ipc_listening() settles it back if the port could not be bound.
+        add(Action{{"Listen for image updates"},
+                   ICON_MY_WATCH_CHANGES,
+                   ImGuiKey_None,
+                   0,
+                   [this]() { set_ipc_listening(m_ipc_listen_requested); },
+                   always_enabled,
+                   false,
+                   &m_ipc_listen_requested,
+                   "Accept images pushed in by a renderer while it works, so a render appears here tile by "
+                   "tile. Nothing outside this machine can connect."});
+#endif
         add(Action{{"Add watched folder..."},
                    ICON_MY_ADD_WATCHED_FOLDER,
                    ImGuiKey_None,

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -239,8 +239,15 @@ HDRViewApp::WindowSetupInfo HDRViewApp::setup_dockable_windows()
         [this] { ImGui::GlobalSpdLogWindow().draw(font("mono regular"), ImGui::GetStyle().FontSizeBase); }, false};
 
 #if !defined(__EMSCRIPTEN__)
-    DockableWindow watched_folders_window{"Watched Folders", "WatchedFoldersSpace",
-                                          [this] { m_image_loader.draw_gui(); }};
+    // Both halves of this window are images that arrive without being opened: a folder being watched, and a
+    // renderer pushing pixels in. The window keeps its name so existing saved layouts still place it.
+    DockableWindow watched_folders_window{"Watched Folders", "WatchedFoldersSpace", [this]
+                                          {
+#if HDRVIEW_ENABLE_IPC
+                                              draw_ipc_gui();
+#endif
+                                              m_image_loader.draw_gui();
+                                          }};
 #endif
 
 #ifdef _WIN32
@@ -579,10 +586,59 @@ void HDRViewApp::setup_imgui_style_callbacks()
     };
 }
 
+void HDRViewApp::wake_event_loop()
+{
+    // glfwPostEmptyEvent() is the one GLFW entry point documented as callable from any thread, which is
+    // what makes this usable from the IPC receive thread. Every desktop backend HDRView builds is GLFW --
+    // Metal on macOS, OpenGL elsewhere -- so the only build without it is the web one, whose frame loop is
+    // driven by the browser and never waits on events anyway.
+#if defined(HELLOIMGUI_USE_GLFW3)
+    // Nothing to wake before the window exists, and calling into GLFW that early is an error in its own
+    // right. Work posted then simply waits for the first frame, which is already on its way.
+    if (m_params.backendPointers.glfwWindow)
+        glfwPostEmptyEvent();
+#endif
+}
+
+void HDRViewApp::post_to_main_thread(std::function<void()> f)
+{
+    if (!f)
+        return;
+
+    std::lock_guard lock{m_main_thread_mutex};
+    m_main_thread_queue.push_back(std::move(f));
+}
+
+void HDRViewApp::drain_main_thread_queue()
+{
+    // Swap the queue out under the lock and run the callables without it: they reach back into the app and
+    // are free to post further work, which belongs to the next frame rather than to this drain.
+    std::vector<std::function<void()>> todo;
+    {
+        std::lock_guard lock{m_main_thread_mutex};
+        todo.swap(m_main_thread_queue);
+    }
+
+    for (auto &f : todo)
+    {
+        try
+        {
+            f();
+        }
+        catch (const std::exception &e)
+        {
+            // One bad task must not take the frame -- and with it the whole app -- down with it.
+            spdlog::error("Exception while running main-thread task: {}", e.what());
+        }
+    }
+}
+
 void HDRViewApp::setup_frame_callbacks()
 {
     m_params.callbacks.ShowGui = [this]()
     {
+        drain_main_thread_queue();
+
         process_shortcuts();
 
         for (auto &d : m_dialogs) d->draw(d->open);
@@ -661,8 +717,8 @@ void HDRViewApp::setup_frame_callbacks()
         draw_tweak_window();
         draw_developer_windows();
     };
-    m_params.callbacks.CustomBackground        = [this]() { draw_background(); };
-    m_params.callbacks.BeforeSwap              = [this]() { end_colorpass_frame(); };
+    m_params.callbacks.CustomBackground = [this]() { draw_background(); };
+    m_params.callbacks.BeforeSwap       = [this]() { end_colorpass_frame(); };
 }
 
 auto HDRViewApp::dialog(const string &title) -> PopupDialog &
@@ -922,11 +978,10 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                    always_enabled,
                    false,
                    &dialog("About").open});
-        add(Action{{"Quit"},
-                   ICON_MY_QUIT,
-                   k_browser_reserved ? ImGuiKey_None : (ImGuiMod_Ctrl | ImGuiKey_Q),
-                   0,
-                   [this]() { m_params.appShallExit = true; }});
+        add(Action{
+            {"Quit"}, ICON_MY_QUIT, k_browser_reserved ? ImGuiKey_None : (ImGuiMod_Ctrl | ImGuiKey_Q), 0, [this]() {
+                m_params.appShallExit = true;
+            }});
 
         add(Action{{"Command palette..."},
                    ICON_MY_COMMAND_PALETTE,
@@ -1246,7 +1301,7 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                        false,
                        &m_mouse_mode_enabled[i]});
 
-            // below actions are only available if there is an image
+        // below actions are only available if there is an image
 
         add(Action{{"Reload image"},
                    ICON_MY_RELOAD,
@@ -1262,8 +1317,7 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                    {
                        for (auto &i : m_images) reload_image(i);
                    },
-                   [this]()
-                   {
+                   [this]() {
                        return std::any_of(m_images.begin(), m_images.end(),
                                           [this](const ImagePtr &i) { return can_reload(i); });
                    }});

--- a/src/app.h
+++ b/src/app.h
@@ -9,15 +9,20 @@
 #include "display_colorspace.h"
 #include "imageio/image_loader.h"
 #include "imgui_ext.h"
+#if HDRVIEW_ENABLE_IPC
+#include "ipc/ipc_server.h"
+#endif
 #include "json.h"
 #include "renderpass.h"
 #include "shader.h"
 #include "theme.h"
 #include <deque>
 #include <filesystem>
+#include <functional>
 #include <hello_imgui/runner_callbacks.h>
 #include <hello_imgui/runner_params.h>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -112,6 +117,50 @@ public:
     // the caller can fall back to treating the zip as a plain multi-image archive. Works on native and web.
     bool try_load_zip_as_session(string_view zip_bytes, const string &zip_name);
     //-----------------------------------------------------------------------------
+
+    //-----------------------------------------------------------------------------
+    // running work on the main thread
+    //-----------------------------------------------------------------------------
+    /*!
+        Queue \p f to run on the main thread near the start of the next frame.
+
+        The image list, the images themselves, and the graphics API are all main-thread-only, so anything
+        arriving on another thread -- pixels pushed in by a renderer, say -- has to come through here rather
+        than touch them directly. Safe to call from any thread, including the main one.
+
+        Queued work runs before the frame's GUI is drawn, so a batch of it lands atomically as far as the
+        drawn frame is concerned. Keep each callable short: it runs inline on the frame.
+    */
+    void post_to_main_thread(std::function<void()> f);
+
+    /*!
+        Nudge the frame loop into drawing, from any thread.
+
+        The runner idles by waiting on window events, so when nothing is moving on screen a frame can be up
+        to the idle timeout away. Work that arrives from outside the window system -- pixels pushed in over
+        a socket -- produces no such event, and without this would be drawn whenever the next frame happened
+        to come around.
+    */
+    void wake_event_loop();
+    //-----------------------------------------------------------------------------
+
+#if HDRVIEW_ENABLE_IPC
+    //-----------------------------------------------------------------------------
+    // receiving live images from a renderer (see src/app-ipc.cpp and src/ipc/)
+    //-----------------------------------------------------------------------------
+    /// Begin accepting connections on 127.0.0.1:`port`. False if the port could not be bound.
+    bool             start_ipc_listening(uint16_t port);
+    void             stop_ipc_listening();
+    const IpcServer &ipc_server() const { return m_ipc_server; }
+    /// The port the GUI toggle and the CLI flag listen on. Settable so a second HDRView can coexist.
+    uint16_t  ipc_port() const { return m_ipc_port; }
+    uint16_t &ipc_port() { return m_ipc_port; }
+    /// Index of the image whose `filename` is `name`, or -1. How the protocol identifies images.
+    int image_index_by_name(std::string_view name) const;
+    /// The listener's controls and status, drawn above the watched-folder list they sit alongside.
+    void draw_ipc_gui();
+    //-----------------------------------------------------------------------------
+#endif
 
     //-----------------------------------------------------------------------------
     // access to images
@@ -427,6 +476,24 @@ private:
     int              m_current = -1, m_reference = -1;
 
     BackgroundImageLoader m_image_loader;
+
+    //! Work posted from other threads by post_to_main_thread(), drained once per frame.
+    std::mutex                         m_main_thread_mutex;
+    std::vector<std::function<void()>> m_main_thread_queue;
+    void                               drain_main_thread_queue();
+
+#if HDRVIEW_ENABLE_IPC
+    IpcServer m_ipc_server;
+    uint16_t  m_ipc_port = k_default_ipc_port;
+
+    // Each applies one already-decoded packet, on the main thread. Decoding happens on the receive thread;
+    // see start_ipc_listening().
+    void apply_ipc_open(const IpcOpenImage &info);
+    void apply_ipc_reload(const IpcReloadImage &info);
+    void apply_ipc_close(const IpcCloseImage &info);
+    void apply_ipc_create(const IpcCreateImage &info);
+    void apply_ipc_update(const IpcUpdateImage &info);
+#endif
 
     int m_remaining_download = 0;
 

--- a/src/app.h
+++ b/src/app.h
@@ -418,6 +418,8 @@ private:
     void draw_image() const;
     void draw_image_border() const;
     void draw_tool_decorations() const;
+    /// Draws the current and reference images' vector overlays, if either has one.
+    void draw_vector_overlays() const;
     void draw_file_window();
     void draw_top_toolbar();
     void draw_tool_palette();
@@ -523,6 +525,7 @@ private:
     void apply_ipc_close(const IpcCloseImage &info);
     void apply_ipc_create(const IpcCreateImage &info);
     void apply_ipc_update(const IpcUpdateImage &info);
+    void apply_ipc_vector_graphics(const IpcVectorGraphics &info);
 #endif
 
     int m_remaining_download = 0;

--- a/src/app.h
+++ b/src/app.h
@@ -486,6 +486,23 @@ private:
     IpcServer m_ipc_server;
     uint16_t  m_ipc_port = k_default_ipc_port;
 
+    //! Turns the listener's running totals into the rates the activity readout shows.
+    /*!
+        Sampled over a window rather than per frame: at 60 fps the per-frame deltas are one or two packets
+        and the number would be unreadable noise.
+    */
+    struct IpcRates
+    {
+        double   sampled_at    = 0.0; //!< ImGui::GetTime() of the last sample
+        uint64_t last_packets  = 0;
+        uint64_t last_bytes    = 0;
+        double   packets_per_s = 0.0;
+        double   bytes_per_s   = 0.0;
+
+        void update(const IpcActivity &now, double time);
+    };
+    IpcRates m_ipc_rates;
+
     // Each applies one already-decoded packet, on the main thread. Decoding happens on the receive thread;
     // see start_ipc_listening().
     void apply_ipc_open(const IpcOpenImage &info);

--- a/src/app.h
+++ b/src/app.h
@@ -152,6 +152,10 @@ public:
     bool             start_ipc_listening(uint16_t port);
     void             stop_ipc_listening();
     const IpcServer &ipc_server() const { return m_ipc_server; }
+    /// Start or stop listening, and settle `m_ipc_listen_requested` on whatever actually happened.
+    void set_ipc_listening(bool listen);
+    /// Change the port, rebinding if already listening.
+    void set_ipc_port(uint16_t port);
     /// The port the GUI toggle and the CLI flag listen on. Settable so a second HDRView can coexist.
     uint16_t  ipc_port() const { return m_ipc_port; }
     uint16_t &ipc_port() { return m_ipc_port; }
@@ -485,6 +489,15 @@ private:
 #if HDRVIEW_ENABLE_IPC
     IpcServer m_ipc_server;
     uint16_t  m_ipc_port = k_default_ipc_port;
+
+    //! What the "Listen for image updates" toggle shows, mirrored from the server once per frame.
+    /*!
+        An Action needs a bool to point p_selected at, but the truth is whether the socket is bound -- which
+        the toggle does not decide on its own, since binding can fail and --listen can turn it on at
+        startup. Mirroring it every frame (rather than in draw_ipc_gui, which does not run while the panel
+        is collapsed) keeps the palette's checkmark honest.
+    */
+    bool m_ipc_listen_requested = false;
 
     //! Turns the listener's running totals into the rates the activity readout shows.
     /*!

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -299,21 +299,6 @@ vector<string> shorten_names(const vector<string> &names)
     return short_names;
 }
 
-pair<float, std::string> human_readable_size(size_t bytes)
-{
-    float              size       = static_cast<float>(bytes);
-    static const char *units[]    = {"B", "kB", "MiB", "GiB", "TiB", "PiB"};
-    int                unit_index = 0;
-
-    while (size >= 1024 && unit_index < 5)
-    {
-        size /= 1024;
-        ++unit_index;
-    }
-
-    return {size, units[unit_index]};
-}
-
 bool natural_less(const string_view a, const string_view b)
 {
     // isdigit() is only defined for values representable as unsigned char, and a byte of a multi-byte UTF-8

--- a/src/common.h
+++ b/src/common.h
@@ -418,7 +418,6 @@ std::string_view              get_basename(std::string_view path);
 std::vector<std::string_view> split(std::string_view text, std::string_view delim);
 std::string                   to_lower(std::string_view str);
 std::string                   to_upper(std::string_view str);
-std::pair<float, std::string> human_readable_size(size_t bytes);
 // Helper to split "archive.zip/entry.png" into zip and entry
 bool split_zip_entry(std::string_view filename, std::string &zip_path, std::string &entry_path);
 //! Whether `path` names an http(s) URL rather than something on the filesystem.

--- a/src/hdrview.cpp
+++ b/src/hdrview.cpp
@@ -73,6 +73,11 @@ int main(int argc, char **argv)
     std::optional<bool>  dither, force_sdr, apple_keys;
     string               url;
 
+#if HDRVIEW_ENABLE_IPC
+    bool listen   = false;
+    int  ipc_port = k_default_ipc_port;
+#endif
+
     vector<string> in_files;
 
     try
@@ -106,6 +111,22 @@ is freely available under a 3-clause BSD license.
 
         app.add_flag("--sdr", force_sdr, "Force standard dynamic range (8-bit per channel) display.")
             ->group("Tone mapping and display");
+
+#if HDRVIEW_ENABLE_IPC
+        app.add_flag("--listen", listen,
+                     R"(Start listening for live image updates from a renderer, over
+the same protocol tev uses. Only accepts connections from this
+machine. Can also be turned on from the Watched Folders panel.)")
+            ->group("Live updates");
+
+        app.add_option("--ipc-port", ipc_port,
+                       R"(Port to listen on for live image updates. The default is what
+tev uses, so existing clients need no changes; change it to run
+HDRView and tev at the same time.)")
+            ->capture_default_str()
+            ->check(CLI::Range(1, 65535))
+            ->group("Live updates");
+#endif
 
         app.add_option("-v,--verbosity", verbosity,
                        R"(Set verbosity threshold T with lower values meaning more
@@ -202,6 +223,15 @@ until another channel selector is encountered.)")
             spdlog::info("Turning Apple-style keyboard behavior {}.", *apple_keys ? "ON" : "OFF");
 
         init_hdrview(exposure, gamma, dither, force_sdr, apple_keys, in_files);
+
+#if HDRVIEW_ENABLE_IPC
+        hdrview()->ipc_port() = uint16_t(ipc_port);
+        // Failing to bind is reported and left at that: the port being taken is a reason not to listen, not
+        // a reason to refuse to show the images the user asked for.
+        if (listen)
+            hdrview()->start_ipc_listening(uint16_t(ipc_port));
+#endif
+
         hdrview()->load_url(url);
         hdrview()->run();
     }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -628,17 +628,69 @@ Texture *Channel::get_texture()
 #else
         auto min_mode = Texture::InterpolationMode::Trilinear;
 #endif
+        // Mipmapping is driven from here rather than from each upload: upload_tile() writes a rectangle at
+        // a time, and letting every one of those rebuild the whole mip chain would cost far more than the
+        // tile itself.
         texture = std::make_unique<Texture>(Texture::PixelFormat::R, Texture::ComponentFormat::Float32, size(),
                                             min_mode, Texture::InterpolationMode::Nearest,
-                                            Texture::WrapMode::ClampToEdge, 1, Texture::TextureFlags::ShaderRead);
+                                            Texture::WrapMode::ClampToEdge, 1, Texture::TextureFlags::ShaderRead,
+                                            /* manual_mipmapping */ true);
         if (texture->pixel_format() != Texture::PixelFormat::R)
             throw std::invalid_argument("Pixel format not supported by the hardware!");
 
         texture->upload((const uint8_t *)data());
         texture_is_dirty = false;
+        mipmap_is_dirty  = true;
+    }
+
+    // Once per draw, whatever landed since the last one. Trilinear minification samples the mip chain, so
+    // this has to happen before the texture is used, not lazily at the next upload.
+    if (mipmap_is_dirty)
+    {
+        if (texture->min_interpolation_mode() == Texture::InterpolationMode::Trilinear ||
+            texture->mag_interpolation_mode() == Texture::InterpolationMode::Trilinear)
+            texture->generate_mipmap();
+        mipmap_is_dirty = false;
     }
 
     return texture.get();
+}
+
+void Channel::upload_tile(const Box2i &bounds, const float *data, int64_t x_stride, int64_t y_stride)
+{
+    // Boxes here are half-open, so a clip that collapses a dimension leaves max == min rather than
+    // max < min, and is_empty() would not call that empty.
+    Box2i clipped = bounds;
+    clipped.intersect(Box2i{int2{0}, size()});
+    const int2 extent = clipped.size();
+    if (extent.x <= 0 || extent.y <= 0)
+        return;
+
+    if (y_stride == 0)
+        y_stride = int64_t(bounds.size().x) * x_stride;
+
+    // A statistics task reads these pixels from a worker thread, so it has to be off them before the write.
+    cancel_stats();
+
+    const int2 offset = clipped.min - bounds.min;
+
+    for (int y = 0; y < extent.y; ++y)
+    {
+        const float *src = data + (int64_t(y + offset.y) * y_stride) + (int64_t(offset.x) * x_stride);
+        float       *dst = &operator()(clipped.min.x, clipped.min.y + y);
+        for (int x = 0; x < extent.x; ++x) dst[x] = src[int64_t(x) * x_stride];
+    }
+
+    if (!texture || texture_is_dirty)
+        return; // no texture yet, or one that is about to be rebuilt from the channel wholesale
+
+    // glTexSubImage2D wants the rectangle packed on its own, and the channel's rows are the full width.
+    std::vector<float> staging(size_t(extent.x) * size_t(extent.y));
+    for (int y = 0; y < extent.y; ++y)
+        std::copy_n(&operator()(clipped.min.x, clipped.min.y + y), extent.x, &staging[size_t(y) * extent.x]);
+
+    texture->upload_sub_region((const uint8_t *)staging.data(), clipped.min, extent);
+    mipmap_is_dirty = true;
 }
 
 bool PixelStats::Settings::match(const Settings &other) const
@@ -646,7 +698,8 @@ bool PixelStats::Settings::match(const Settings &other) const
     // Only what changes the computed values counts. exposure never reaches the computation, every x_scale
     // is binned, and y_scale only picks which stored histogram the plot draws.
     return (blend_mode == other.blend_mode && ref_id == other.ref_id && ref_group == other.ref_group) &&
-           other.roi == roi;
+           other.roi == roi && content_version == other.content_version &&
+           ref_content_version == other.ref_content_version;
 }
 
 PixelStats *Channel::get_stats()
@@ -657,8 +710,7 @@ PixelStats *Channel::get_stats()
     if (async_tracker.ready() && async_stats->computed)
     {
         spdlog::trace("Replacing cached channel stats with async computation");
-        cached_stats = async_stats;
-        async_stats  = make_shared<PixelStats>();
+        adopt_async_stats();
     }
 
     return cached_stats.get();
@@ -668,9 +720,26 @@ void Channel::update_stats(int c, ConstImagePtr img1, ConstImagePtr img2)
 {
     MY_ASSERT(cached_stats, "PixelStats::cached_stats should never be null");
 
-    PixelStats::Settings desired_settings{
-        hdrview()->exposure(),   hdrview()->histogram_x_scale(), hdrview()->histogram_y_scale(),   hdrview()->roi(),
-        hdrview()->blend_mode(), img2 ? img2->id : -1,           img2 ? img2->reference_group : -1};
+    PixelStats::Settings desired_settings{hdrview()->exposure(),
+                                          hdrview()->histogram_x_scale(),
+                                          hdrview()->histogram_y_scale(),
+                                          hdrview()->roi(),
+                                          hdrview()->blend_mode(),
+                                          img2 ? img2->id : -1,
+                                          img2 ? img2->reference_group : -1,
+                                          img1->content_version,
+                                          img2 ? img2->content_version : 0};
+
+    // Pixels streaming in from a renderer change the content version faster than a full pass over the image
+    // can finish, and chasing every version would cancel each computation partway and show no statistics at
+    // all. So a newer version is only picked up once the cache has stood as a finished result for a moment:
+    // the histogram then refreshes at a bounded rate instead of never.
+    static constexpr auto k_min_stats_age = std::chrono::milliseconds{200};
+    if (cached_stats->computed && std::chrono::steady_clock::now() - stats_ready_at < k_min_stats_age)
+    {
+        desired_settings.content_version     = cached_stats->settings.content_version;
+        desired_settings.ref_content_version = cached_stats->settings.ref_content_version;
+    }
 
     // The group's alpha channel, when this channel needs dividing by it to report the file's values.
     // Null for the alpha channel itself, which is stored as the file had it.
@@ -734,8 +803,7 @@ void Channel::update_stats(int c, ConstImagePtr img1, ConstImagePtr img2)
     {
         spdlog::trace("Replacing cached channel stats with async computation");
         // replace cache with newer async stats
-        cached_stats = async_stats;
-        async_stats  = make_shared<PixelStats>();
+        adopt_async_stats();
 
         // if these newer stats are still outdated, schedule a new async computation
         if (!cached_stats->settings.match(desired_settings))
@@ -812,6 +880,17 @@ Image::Image(int2 size, int num_channels) : Image()
         }
     }
     display_window = data_window = Box2i{int2{0}, channels.front().size()};
+}
+
+Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
+{
+    if (channel_names.empty())
+        throw std::invalid_argument("An image must have at least one channel.");
+
+    channels.reserve(channel_names.size());
+    for (const auto &name : channel_names) channels.emplace_back(name, size);
+
+    display_window = data_window = Box2i{int2{0}, size};
 }
 
 map<string, int> Image::channels_in_layer(const string &layer) const

--- a/src/image.h
+++ b/src/image.h
@@ -14,6 +14,7 @@
 #include "imageio/exif.h"
 #include "json.h"
 #include "texture.h"
+#include "vector_overlay.h"
 #include <algorithm>
 #include <cfloat>
 #include <chrono>
@@ -473,6 +474,13 @@ public:
         ordinary image.
     */
     bool is_live = false;
+
+    //! Drawing commands laid over this image, in its pixel coordinates; empty for almost every image.
+    /*!
+        Only a renderer streaming over IPC sets these, to annotate what it is producing -- box the tile it
+        just finished, label a value. Drawn by the viewport after the image itself; see vector_overlay.h.
+    */
+    std::vector<VgCommand> vector_overlay;
 
     //! Bumped whenever any of this image's pixels change after loading.
     /*!

--- a/src/image.h
+++ b/src/image.h
@@ -16,6 +16,8 @@
 #include "texture.h"
 #include <algorithm>
 #include <cfloat>
+#include <chrono>
+#include <cstdint>
 #include <half.h>
 #include <map>
 #include <optional>
@@ -119,6 +121,15 @@ struct PixelStats
         BlendMode_ blend_mode = BlendMode_Normal;
         int        ref_id     = -1;
         int        ref_group  = -1;
+
+        //! Image::content_version of the measured image, and of the reference when one is blended in.
+        /*!
+            Everything else here describes how the image is being looked at; these two describe the pixels
+            themselves. A statistic computed from pixels that have since been overwritten is stale no matter
+            how well the rest of the settings match, which is what these catch.
+        */
+        int content_version     = 0;
+        int ref_content_version = 0;
 
         bool match(const Settings &other) const;
     };
@@ -242,6 +253,17 @@ private:
     PixelStats::Ptr      async_stats;
     PixelStats::Settings async_settings{};
 
+    //! When cached_stats last became a finished computation, for update_stats()'s streaming throttle.
+    std::chrono::steady_clock::time_point stats_ready_at{};
+
+    //! Take the finished async statistics as the cache and start a fresh slot for the next computation.
+    void adopt_async_stats()
+    {
+        cached_stats   = async_stats;
+        async_stats    = std::make_shared<PixelStats>();
+        stats_ready_at = std::chrono::steady_clock::now();
+    }
+
 public:
     static std::pair<std::string, std::string> split(const std::string &full_name);
     static std::vector<std::string>            split_to_path(const std::string &str, char delimiter = '.');
@@ -252,6 +274,14 @@ public:
 
     std::unique_ptr<Texture> texture;
     bool                     texture_is_dirty = true;
+
+    //! Set when the texture's level 0 has changed but its mip chain has not been rebuilt from it yet.
+    /*!
+        Channel textures are created with manual mipmapping so that streaming a tile costs one
+        glTexSubImage2D rather than a full mip-chain rebuild per tile. get_texture() does the rebuild
+        instead, which folds any number of tiles that landed since the last draw into a single one.
+    */
+    bool mipmap_is_dirty = true;
 
     Channel() = delete;
     Channel(const std::string &name, int2 size);
@@ -311,6 +341,29 @@ public:
                              for (int x = 0; x < w; ++x) this->operator()(x, y) = func(data[n * x + c + y * y_stride]);
                      });
     }
+
+    /*!
+        Overwrite a rectangle of this channel's pixels and push just that rectangle to the GPU.
+
+        The counterpart to loading: pixels arriving after the image exists, a tile at a time, as a renderer
+        produces them. \p bounds is in channel-local coordinates (the caller subtracts the data window's
+        origin) and is clipped to the channel, so a tile that hangs off the edge writes the part that lands.
+
+        Any in-flight statistics computation is canceled first -- it reads these very pixels from a worker
+        thread -- so callers should batch a frame's worth of tiles rather than interleaving them with
+        get_stats(). Must be called from the main thread when the channel has a texture, since it touches
+        the graphics API; see HDRViewApp::post_to_main_thread().
+
+        A channel does not know which image owns it, so the caller is the one that has to bump that image's
+        content_version afterwards; without it the histogram keeps describing the pixels this overwrote.
+
+        \param [] bounds   Rectangle to overwrite, in channel-local coordinates
+        \param [] data     Source samples, row-major within \p bounds
+        \param [] x_stride Distance in floats between consecutive samples in a row; >1 reads one channel
+                           out of an interleaved payload without deinterleaving it first
+        \param [] y_stride Distance in floats between consecutive rows, or 0 for tightly packed rows
+    */
+    void upload_tile(const Box2i &bounds, const float *data, int64_t x_stride = 1, int64_t y_stride = 0);
 
     Texture *get_texture();
 
@@ -399,11 +452,11 @@ public:
     AdaptationMethod              adaptation_method = AdaptationMethod_Bradford;
     ColorGamut_                   color_space       = ColorGamut_Unspecified;
     WhitePoint_                   white_point       = WhitePoint_Unspecified;
-    AlphaType            alpha_type = AlphaType_None; //!< Does the image have straight (unpremultiplied) alpha?
-    bool alpha_is_transparency = true; //!< When false, an 'A' channel is grouped on its own as ordinary data
-                                       //!< instead of joining an RGBA/YA/YCA/XYZA group, so nothing is
-                                       //!< premultiplied by it. Read by finalize(), so set it before calling.
-    json                 metadata   = json::object();
+    AlphaType alpha_type            = AlphaType_None; //!< Does the image have straight (unpremultiplied) alpha?
+    bool      alpha_is_transparency = true; //!< When false, an 'A' channel is grouped on its own as ordinary data
+                                            //!< instead of joining an RGBA/YA/YCA/XYZA group, so nothing is
+                                            //!< premultiplied by it. Read by finalize(), so set it before calling.
+    json                 metadata = json::object();
     Exif                 exif;     //!< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; //!< The raw XMP data from the file, if any
     std::vector<uint8_t> icc_data; //!< The raw ICC profile data from the file, if any
@@ -412,6 +465,21 @@ public:
     fs::path           path;
     fs::file_time_type last_modified;
     size_t             size_bytes = 0;
+
+    //! True for an image whose pixels arrive from a running process rather than from a file.
+    /*!
+        Nothing on disk backs it, so it cannot be reloaded and is left out of a saved session -- a session
+        records where to find its images again, and there is nowhere to find this one. It is otherwise an
+        ordinary image.
+    */
+    bool is_live = false;
+
+    //! Bumped whenever any of this image's pixels change after loading.
+    /*!
+        Statistics and histograms are cached against it (see PixelStats::Settings), so anything that writes
+        pixels must bump it or the cache will keep serving measurements of pixels that are gone.
+    */
+    int content_version = 0;
 
     //
     // Layers, groups, and the layer node tree are built from the loaded channels in finalize().
@@ -438,6 +506,13 @@ public:
     int         reference_group = 0;
 
     Image(int2 size, int num_channels);
+    //! An image with exactly these channels, in this order, named as given.
+    /*!
+        The channel-count constructor names channels itself, which only suits an image whose channels are a
+        plain R,G,B,A or Y,A. A renderer names its own -- `albedo.R`, `variance` -- and the layer and group
+        machinery build themselves out of those names in finalize().
+    */
+    Image(int2 size, const std::vector<std::string> &channel_names);
     Image();
     Image(const Image &) = delete;
     Image(Image &&)      = default;

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -750,6 +750,9 @@ void BackgroundImageLoader::load_new_and_modified_files()
     {
         auto img = hdrview()->image(i);
 
+        if (img->is_live)
+            continue; // its pixels are pushed in by another process; no file to watch
+
         std::error_code ec;
         if (!fs::exists(img->path, ec) || ec)
         {

--- a/src/ipc/ipc_packet.cpp
+++ b/src/ipc/ipc_packet.cpp
@@ -1,0 +1,422 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include "ipc/ipc_packet.h"
+
+#include "endian-utils.h"
+
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <spdlog/fmt/fmt.h>
+
+namespace
+{
+
+//! Reads fields out of a packet's bytes, refusing to run off the end of them.
+/*!
+    Every read is checked rather than the length being validated once up front, because the payload's own
+    contents decide how much follows: a channel count says how many strings come next, and a string ends
+    wherever its NUL is.
+*/
+class PacketReader
+{
+public:
+    PacketReader(const std::vector<char> &data) : m_data(data)
+    {
+        // The length prefix is part of the framing and was checked when the packet was framed; step over it.
+        m_index = sizeof(uint32_t);
+    }
+
+    template <typename T>
+    T read()
+    {
+        static_assert(std::is_trivially_copyable_v<T>, "read() needs a trivially copyable type");
+        require(sizeof(T), "a value");
+        T value = read_as<T>(reinterpret_cast<const unsigned char *>(m_data.data()) + m_index, Endian::Little);
+        m_index += sizeof(T);
+        return value;
+    }
+
+    bool read_bool() { return read<uint8_t>() != 0; }
+
+    std::string read_string()
+    {
+        const size_t start = m_index;
+        while (m_index < m_data.size() && m_data[m_index] != '\0') ++m_index;
+
+        if (m_index >= m_data.size())
+            throw std::runtime_error{"IPC packet ended inside a string."};
+
+        std::string value{m_data.data() + start, m_index - start};
+        ++m_index; // the NUL
+        return value;
+    }
+
+    //! Number of bytes not yet read.
+    size_t remaining() const { return m_data.size() - m_index; }
+
+    //! Read `count` floats, which must be the whole of what is left.
+    std::vector<float> read_floats(size_t count)
+    {
+        require(count * sizeof(float), "sample data");
+
+        std::vector<float> values(count);
+        // An empty vector's data() may be null, and memcpy is not allowed one even for zero bytes -- which
+        // every drawing command that takes no arguments would otherwise do.
+        if (count == 0)
+            return values;
+
+        read_array(values.data(), reinterpret_cast<const unsigned char *>(m_data.data()) + m_index, count,
+                   Endian::Little);
+        m_index += count * sizeof(float);
+        return values;
+    }
+
+private:
+    void require(size_t n, const char *what) const
+    {
+        if (n > m_data.size() - m_index)
+            throw std::runtime_error{fmt::format("IPC packet ended before {} it declared ({} bytes needed, {} left).",
+                                                 what, n, m_data.size() - m_index)};
+    }
+
+    const std::vector<char> &m_data;
+    size_t                   m_index = 0;
+};
+
+//! Builds a packet's bytes, keeping the length prefix up to date as it grows.
+class PacketWriter
+{
+public:
+    PacketWriter(IpcPacketType type)
+    {
+        m_bytes.resize(sizeof(uint32_t)); // reserved for the length, filled in by bytes()
+        write<uint8_t>(uint8_t(type));
+    }
+
+    template <typename T>
+    void write(T value)
+    {
+        const size_t at = m_bytes.size();
+        m_bytes.resize(at + sizeof(T));
+        write_as(reinterpret_cast<unsigned char *>(m_bytes.data()) + at, value, Endian::Little);
+    }
+
+    void write_bool(bool value) { write<uint8_t>(value ? 1 : 0); }
+
+    void write_string(std::string_view value)
+    {
+        m_bytes.insert(m_bytes.end(), value.begin(), value.end());
+        m_bytes.push_back('\0');
+    }
+
+    void write_floats(const std::vector<float> &values)
+    {
+        const size_t at = m_bytes.size();
+        m_bytes.resize(at + values.size() * sizeof(float));
+        write_array(reinterpret_cast<unsigned char *>(m_bytes.data()) + at, values.data(), values.size(),
+                    Endian::Little);
+    }
+
+    std::vector<char> bytes() &&
+    {
+        if (m_bytes.size() > k_max_ipc_packet_size)
+            throw std::runtime_error{fmt::format("IPC packet of {} bytes exceeds the {} byte limit.", m_bytes.size(),
+                                                 k_max_ipc_packet_size)};
+
+        write_as(reinterpret_cast<unsigned char *>(m_bytes.data()), uint32_t(m_bytes.size()), Endian::Little);
+        return std::move(m_bytes);
+    }
+
+private:
+    std::vector<char> m_bytes;
+};
+
+//! Reads a channel-name list preceded by its count, bounded so a count cannot become an allocation.
+std::vector<std::string> read_channel_names(PacketReader &r, int32_t count)
+{
+    if (count <= 0 || count > k_max_ipc_channels)
+        throw std::runtime_error{
+            fmt::format("IPC packet declares {} channels; expected 1 to {}.", count, k_max_ipc_channels)};
+
+    std::vector<std::string> names;
+    names.reserve(size_t(count));
+    for (int32_t i = 0; i < count; ++i) names.push_back(r.read_string());
+    return names;
+}
+
+//! The half-open rectangle an update packet covers, rejecting dimensions no tile has.
+Box2i read_bounds(PacketReader &r)
+{
+    const int32_t x = r.read<int32_t>();
+    const int32_t y = r.read<int32_t>();
+    const int32_t w = r.read<int32_t>();
+    const int32_t h = r.read<int32_t>();
+
+    // Width and height multiply into a pixel count and then index the payload, so a negative or absurd one
+    // has to be refused here rather than wrapping into a plausible-looking size later.
+    if (w <= 0 || h <= 0 || int64_t(w) * h > int64_t(k_max_ipc_packet_size / sizeof(float)))
+        throw std::runtime_error{fmt::format("IPC update packet has implausible dimensions {}x{}.", w, h)};
+
+    return Box2i{int2{x, y}, int2{x + w, y + h}};
+}
+
+/*!
+    Highest index into the sample payload that `offsets`/`strides` can reach, or none if they overflow.
+
+    Every access this addressing performs is `offset[c] + px * stride[c]` for px in [0, n_pixels), so
+    bounding the largest of them bounds all of them -- but only once negative offsets and strides are ruled
+    out, since with those the largest index is no longer the last pixel's.
+*/
+std::optional<int64_t> max_sample_index(const std::vector<int64_t> &offsets, const std::vector<int64_t> &strides,
+                                        int64_t n_pixels)
+{
+    int64_t highest = 0;
+    for (size_t c = 0; c < offsets.size(); ++c)
+    {
+        if (offsets[c] < 0 || strides[c] < 0)
+            return std::nullopt;
+
+        // (n_pixels - 1) * stride + offset, refusing to wrap rather than computing a wrapped answer.
+        constexpr int64_t k_max = std::numeric_limits<int64_t>::max();
+        if (strides[c] != 0 && (n_pixels - 1) > k_max / strides[c])
+            return std::nullopt;
+        const int64_t span = (n_pixels - 1) * strides[c];
+        if (offsets[c] > k_max - span)
+            return std::nullopt;
+
+        highest = std::max(highest, offsets[c] + span);
+    }
+    return highest;
+}
+
+} // namespace
+
+IpcPacket::IpcPacket(const char *data, size_t length)
+{
+    if (length < sizeof(uint32_t) + 1)
+        throw std::runtime_error{fmt::format("IPC packet of {} bytes is too short to hold a type.", length)};
+
+    const uint32_t declared = read_as<uint32_t>(reinterpret_cast<const unsigned char *>(data), Endian::Little);
+    if (declared != length)
+        throw std::runtime_error{fmt::format("IPC packet declares {} bytes but {} were given.", declared, length)};
+
+    m_bytes.assign(data, data + length);
+}
+
+IpcPacketType IpcPacket::type() const
+{
+    if (m_bytes.size() < sizeof(uint32_t) + 1)
+        throw std::runtime_error{"IPC packet has no type byte."};
+    return IpcPacketType(uint8_t(m_bytes[sizeof(uint32_t)]));
+}
+
+IpcOpenImage IpcPacket::as_open_image() const
+{
+    PacketReader r{m_bytes};
+    const auto   t = IpcPacketType(r.read<uint8_t>());
+    if (t != IpcPacketType::OpenImage && t != IpcPacketType::OpenImageV2)
+        throw std::runtime_error{"IPC packet is not an OpenImage."};
+
+    IpcOpenImage result;
+    result.grab_focus = r.read_bool();
+    result.path       = r.read_string();
+    // v1 packed the channel selector into the path, and left it to the receiver to split; v2 sends it
+    // separately. Nothing here splits a v1 path -- HDRView's own loader takes a selector alongside a path.
+    if (t == IpcPacketType::OpenImageV2)
+        result.channel_selector = r.read_string();
+    return result;
+}
+
+IpcReloadImage IpcPacket::as_reload_image() const
+{
+    PacketReader r{m_bytes};
+    if (IpcPacketType(r.read<uint8_t>()) != IpcPacketType::ReloadImage)
+        throw std::runtime_error{"IPC packet is not a ReloadImage."};
+
+    IpcReloadImage result;
+    result.grab_focus = r.read_bool();
+    result.name       = r.read_string();
+    return result;
+}
+
+IpcCloseImage IpcPacket::as_close_image() const
+{
+    PacketReader r{m_bytes};
+    if (IpcPacketType(r.read<uint8_t>()) != IpcPacketType::CloseImage)
+        throw std::runtime_error{"IPC packet is not a CloseImage."};
+
+    IpcCloseImage result;
+    result.name = r.read_string();
+    return result;
+}
+
+IpcCreateImage IpcPacket::as_create_image() const
+{
+    PacketReader r{m_bytes};
+    if (IpcPacketType(r.read<uint8_t>()) != IpcPacketType::CreateImage)
+        throw std::runtime_error{"IPC packet is not a CreateImage."};
+
+    IpcCreateImage result;
+    result.grab_focus = r.read_bool();
+    result.name       = r.read_string();
+
+    const int32_t w = r.read<int32_t>();
+    const int32_t h = r.read<int32_t>();
+    if (w <= 0 || h <= 0)
+        throw std::runtime_error{fmt::format("IPC CreateImage has implausible dimensions {}x{}.", w, h)};
+    result.size = int2{w, h};
+
+    result.channel_names = read_channel_names(r, r.read<int32_t>());
+    return result;
+}
+
+IpcUpdateImage IpcPacket::as_update_image() const
+{
+    PacketReader r{m_bytes};
+    const auto   t = IpcPacketType(r.read<uint8_t>());
+    if (t != IpcPacketType::UpdateImage && t != IpcPacketType::UpdateImageV2 && t != IpcPacketType::UpdateImageV3)
+        throw std::runtime_error{"IPC packet is not an UpdateImage."};
+
+    IpcUpdateImage result;
+    result.grab_focus = r.read_bool();
+    result.name       = r.read_string();
+
+    // v1 carried exactly one channel and did not say so.
+    const int32_t n_channels = t >= IpcPacketType::UpdateImageV2 ? r.read<int32_t>() : 1;
+    result.channel_names     = read_channel_names(r, n_channels);
+
+    result.bounds          = read_bounds(r);
+    const int64_t n_pixels = int64_t(result.bounds.size().x) * result.bounds.size().y;
+
+    result.channel_offsets.resize(size_t(n_channels));
+    result.channel_strides.resize(size_t(n_channels));
+    if (t >= IpcPacketType::UpdateImageV3)
+    {
+        for (auto &o : result.channel_offsets) o = r.read<int64_t>();
+        for (auto &s : result.channel_strides) s = r.read<int64_t>();
+    }
+    else
+    {
+        // Before v3 the channels were simply concatenated, one contiguous plane after another.
+        for (int32_t c = 0; c < n_channels; ++c)
+        {
+            result.channel_offsets[size_t(c)] = n_pixels * c;
+            result.channel_strides[size_t(c)] = 1;
+        }
+    }
+
+    const auto highest = max_sample_index(result.channel_offsets, result.channel_strides, n_pixels);
+    if (!highest)
+        throw std::runtime_error{"IPC UpdateImage has channel offsets/strides that do not address a buffer."};
+
+    const int64_t needed = *highest + 1;
+    if (uint64_t(needed) * sizeof(float) > r.remaining())
+        throw std::runtime_error{
+            fmt::format("IPC UpdateImage needs {} samples but only {} bytes of data follow.", needed, r.remaining())};
+
+    result.data = r.read_floats(size_t(needed));
+    return result;
+}
+
+IpcPacket IpcPacket::open_image(std::string_view path, std::string_view channel_selector, bool grab_focus)
+{
+    PacketWriter w{IpcPacketType::OpenImageV2};
+    w.write_bool(grab_focus);
+    w.write_string(path);
+    w.write_string(channel_selector);
+
+    IpcPacket p;
+    p.m_bytes = std::move(w).bytes();
+    return p;
+}
+
+IpcPacket IpcPacket::reload_image(std::string_view name, bool grab_focus)
+{
+    PacketWriter w{IpcPacketType::ReloadImage};
+    w.write_bool(grab_focus);
+    w.write_string(name);
+
+    IpcPacket p;
+    p.m_bytes = std::move(w).bytes();
+    return p;
+}
+
+IpcPacket IpcPacket::close_image(std::string_view name)
+{
+    PacketWriter w{IpcPacketType::CloseImage};
+    w.write_string(name);
+
+    IpcPacket p;
+    p.m_bytes = std::move(w).bytes();
+    return p;
+}
+
+IpcPacket IpcPacket::create_image(std::string_view name, bool grab_focus, int2 size,
+                                  const std::vector<std::string> &channel_names)
+{
+    PacketWriter w{IpcPacketType::CreateImage};
+    w.write_bool(grab_focus);
+    w.write_string(name);
+    w.write<int32_t>(size.x);
+    w.write<int32_t>(size.y);
+    w.write<int32_t>(int32_t(channel_names.size()));
+    for (const auto &n : channel_names) w.write_string(n);
+
+    IpcPacket p;
+    p.m_bytes = std::move(w).bytes();
+    return p;
+}
+
+IpcPacket IpcPacket::update_image(std::string_view name, bool grab_focus, const std::vector<std::string> &channel_names,
+                                  const std::vector<int64_t> &offsets, const std::vector<int64_t> &strides,
+                                  const Box2i &bounds, const std::vector<float> &data)
+{
+    if (channel_names.size() != offsets.size() || channel_names.size() != strides.size())
+        throw std::runtime_error{"UpdateImage needs one offset and one stride per channel."};
+
+    PacketWriter w{IpcPacketType::UpdateImageV3};
+    w.write_bool(grab_focus);
+    w.write_string(name);
+    w.write<int32_t>(int32_t(channel_names.size()));
+    for (const auto &n : channel_names) w.write_string(n);
+    w.write<int32_t>(bounds.min.x);
+    w.write<int32_t>(bounds.min.y);
+    w.write<int32_t>(bounds.size().x);
+    w.write<int32_t>(bounds.size().y);
+    for (auto o : offsets) w.write<int64_t>(o);
+    for (auto s : strides) w.write<int64_t>(s);
+    w.write_floats(data);
+
+    IpcPacket p;
+    p.m_bytes = std::move(w).bytes();
+    return p;
+}
+
+void extract_ipc_packets(std::vector<char> &buffer, const std::function<void(const IpcPacket &)> &on_packet)
+{
+    size_t consumed = 0;
+    while (buffer.size() - consumed >= sizeof(uint32_t))
+    {
+        const uint32_t declared =
+            read_as<uint32_t>(reinterpret_cast<const unsigned char *>(buffer.data()) + consumed, Endian::Little);
+
+        // A length that could never frame a packet means the stream is not carrying this protocol, or has
+        // lost sync. Nothing marks a packet boundary, so there is nothing to resynchronize to.
+        if (declared < sizeof(uint32_t) + 1 || declared > k_max_ipc_packet_size)
+            throw std::runtime_error{fmt::format("IPC stream declares a {} byte packet.", declared)};
+
+        if (buffer.size() - consumed < declared)
+            break; // the rest is still in flight
+
+        on_packet(IpcPacket{buffer.data() + consumed, declared});
+        consumed += declared;
+    }
+
+    buffer.erase(buffer.begin(), buffer.begin() + consumed);
+}

--- a/src/ipc/ipc_packet.cpp
+++ b/src/ipc/ipc_packet.cpp
@@ -324,6 +324,45 @@ IpcUpdateImage IpcPacket::as_update_image() const
     return result;
 }
 
+IpcVectorGraphics IpcPacket::as_vector_graphics() const
+{
+    PacketReader r{m_bytes};
+    if (IpcPacketType(r.read<uint8_t>()) != IpcPacketType::VectorGraphics)
+        throw std::runtime_error{"IPC packet is not a VectorGraphics."};
+
+    IpcVectorGraphics result;
+    result.grab_focus = r.read_bool();
+    result.name       = r.read_string();
+    result.append     = r.read_bool();
+
+    const int32_t count = r.read<int32_t>();
+    if (count < 0 || count > k_max_ipc_vg_commands)
+        throw std::runtime_error{
+            fmt::format("IPC VectorGraphics declares {} commands; expected 0 to {}.", count, k_max_ipc_vg_commands)};
+
+    result.commands.reserve(size_t(count));
+    for (int32_t i = 0; i < count; ++i)
+    {
+        VgCommand cmd;
+        cmd.type = VgCommand::Type(r.read<int8_t>());
+
+        // Nothing in the stream says how long a command is; its type does, via this table. So an
+        // unrecognized type is not a command to skip -- it leaves us with no idea where the next one
+        // starts, and the rest of the packet is unreadable.
+        const int n = VgCommand::num_floats(cmd.type);
+        if (n < 0)
+            throw std::runtime_error{fmt::format("IPC VectorGraphics has an unknown command type {}.", int(cmd.type))};
+
+        cmd.data = r.read_floats(size_t(n));
+        if (VgCommand::has_text(cmd.type))
+            cmd.text = r.read_string();
+
+        result.commands.push_back(std::move(cmd));
+    }
+
+    return result;
+}
+
 IpcPacket IpcPacket::open_image(std::string_view path, std::string_view channel_selector, bool grab_focus)
 {
     PacketWriter w{IpcPacketType::OpenImageV2};
@@ -392,6 +431,32 @@ IpcPacket IpcPacket::update_image(std::string_view name, bool grab_focus, const 
     for (auto o : offsets) w.write<int64_t>(o);
     for (auto s : strides) w.write<int64_t>(s);
     w.write_floats(data);
+
+    IpcPacket p;
+    p.m_bytes = std::move(w).bytes();
+    return p;
+}
+
+IpcPacket IpcPacket::vector_graphics(std::string_view name, bool grab_focus, bool append,
+                                     const std::vector<VgCommand> &commands)
+{
+    PacketWriter w{IpcPacketType::VectorGraphics};
+    w.write_bool(grab_focus);
+    w.write_string(name);
+    w.write_bool(append);
+    w.write<int32_t>(int32_t(commands.size()));
+    for (const auto &c : commands)
+    {
+        const int n = VgCommand::num_floats(c.type);
+        if (n < 0 || int(c.data.size()) != n)
+            throw std::runtime_error{
+                fmt::format("VgCommand of type {} needs {} floats but has {}.", int(c.type), n, c.data.size())};
+
+        w.write<int8_t>(int8_t(c.type));
+        for (float v : c.data) w.write<float>(v);
+        if (VgCommand::has_text(c.type))
+            w.write_string(c.text);
+    }
 
     IpcPacket p;
     p.m_bytes = std::move(w).bytes();

--- a/src/ipc/ipc_packet.h
+++ b/src/ipc/ipc_packet.h
@@ -8,6 +8,7 @@
 
 #include "box.h"
 #include "fwd.h"
+#include "vector_overlay.h"
 
 #include <cstdint>
 #include <functional>
@@ -51,7 +52,7 @@ enum class IpcPacketType : uint8_t
     UpdateImageV2  = 5, //!< adds multiple channels per packet
     UpdateImageV3  = 6, //!< adds per-channel offset/stride into one shared payload
     OpenImageV2    = 7, //!< separates the image name from the channel selector
-    VectorGraphics = 8, //!< overlay drawing commands; recognized but not supported
+    VectorGraphics = 8, //!< overlay drawing commands; see vector_overlay.h
 };
 
 //! Largest packet we are willing to hold, since the sender chooses the length.
@@ -114,6 +115,22 @@ struct IpcUpdateImage
     int64_t row_stride(int c) const { return int64_t(bounds.size().x) * channel_strides[c]; }
 };
 
+//! Drawing commands to lay over an image, in its pixel coordinates.
+/*!
+    `append` is how a renderer accumulates an overlay as it works -- one packet per finished tile, each
+    adding to what is already there -- rather than resending the whole program every time.
+*/
+struct IpcVectorGraphics
+{
+    std::string            name;
+    bool                   grab_focus = false;
+    bool                   append     = false;
+    std::vector<VgCommand> commands;
+};
+
+//! Most drawing commands one packet may carry, so a length field cannot become an allocation.
+inline constexpr int32_t k_max_ipc_vg_commands = 1 << 20;
+
 //! A framed packet: the bytes as they travel, plus typed readers for the payload.
 class IpcPacket
 {
@@ -138,11 +155,12 @@ public:
 
     //@{ \name Payload readers. Each throws std::runtime_error if the packet is not that type, or if its
     //! contents do not describe the bytes present.
-    IpcOpenImage   as_open_image() const;
-    IpcReloadImage as_reload_image() const;
-    IpcCloseImage  as_close_image() const;
-    IpcCreateImage as_create_image() const;
-    IpcUpdateImage as_update_image() const;
+    IpcOpenImage      as_open_image() const;
+    IpcReloadImage    as_reload_image() const;
+    IpcCloseImage     as_close_image() const;
+    IpcCreateImage    as_create_image() const;
+    IpcUpdateImage    as_update_image() const;
+    IpcVectorGraphics as_vector_graphics() const;
     //@}
 
     //@{ \name Builders, which produce exactly what tev's own client would send.
@@ -155,6 +173,8 @@ public:
     static IpcPacket update_image(std::string_view name, bool grab_focus, const std::vector<std::string> &channel_names,
                                   const std::vector<int64_t> &offsets, const std::vector<int64_t> &strides,
                                   const Box2i &bounds, const std::vector<float> &data);
+    static IpcPacket vector_graphics(std::string_view name, bool grab_focus, bool append,
+                                     const std::vector<VgCommand> &commands);
     //@}
 
 private:

--- a/src/ipc/ipc_packet.h
+++ b/src/ipc/ipc_packet.h
@@ -1,0 +1,177 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#pragma once
+
+#include "box.h"
+#include "fwd.h"
+
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+/*!
+    tev's remote-control protocol: how a renderer hands a viewer its pixels while it is still producing them.
+
+    One operation per packet, framed as
+
+        [uint32 total_length_in_bytes][uint8 type][type-specific payload]
+
+    with every integer little-endian and every string NUL-terminated. The length counts its own four bytes.
+    The layout matches tev's byte for byte, so the clients that already exist for it (the C++, Python and
+    Rust `tevclient` libraries, pbrt-v4's display server) work against HDRView unchanged.
+
+    An independent reimplementation of the format tev documents, rather than a port of its code.
+
+    Everything here treats its input as hostile: a packet arrives over a socket from a process that is not
+    this one, so every count, offset and stride is checked against the bytes actually present rather than
+    trusted to describe them.
+*/
+
+//! Which operation a packet carries. The numbering is the protocol's, not ours.
+/*!
+    The versioned duplicates are tev's backwards compatibility: V2 added multiple channels per packet and V3
+    added per-channel offset/stride, so a client can hand over an interleaved tile without deinterleaving it
+    first. A newer type is a superset of the older one it shadows, and all of them are still sent in
+    practice, so all of them are read.
+*/
+enum class IpcPacketType : uint8_t
+{
+    OpenImage      = 0,
+    ReloadImage    = 1,
+    CloseImage     = 2,
+    UpdateImage    = 3,
+    CreateImage    = 4,
+    UpdateImageV2  = 5, //!< adds multiple channels per packet
+    UpdateImageV3  = 6, //!< adds per-channel offset/stride into one shared payload
+    OpenImageV2    = 7, //!< separates the image name from the channel selector
+    VectorGraphics = 8, //!< overlay drawing commands; recognized but not supported
+};
+
+//! Largest packet we are willing to hold, since the sender chooses the length.
+/*!
+    A tile is pixels times channels times four bytes, so a whole 8K RGBA frame in one packet is around
+    530 MB and legitimate. The cap exists so that a bad or hostile length field cannot ask for an
+    unbounded allocation, not because any real packet approaches it.
+*/
+inline constexpr uint32_t k_max_ipc_packet_size = 1u << 30; // 1 GiB
+
+//! Most channels one packet may name, well past any real layer count and short of an allocation attack.
+inline constexpr int32_t k_max_ipc_channels = 4096;
+
+struct IpcOpenImage
+{
+    std::string path;             //!< Path on the machine HDRView is running on
+    std::string channel_selector; //!< Empty for OpenImage v1, which had no separate selector
+    bool        grab_focus = false;
+};
+
+struct IpcReloadImage
+{
+    std::string name;
+    bool        grab_focus = false;
+};
+
+struct IpcCloseImage
+{
+    std::string name;
+};
+
+struct IpcCreateImage
+{
+    std::string              name;
+    bool                     grab_focus = false;
+    int2                     size{0};
+    std::vector<std::string> channel_names;
+};
+
+//! A rectangle of pixels for channels that already exist, as a renderer finishes them.
+/*!
+    The samples stay in the one interleaved block the sender wrote, addressed per channel as
+    `data[offset[c] + px * stride[c]]` for `px` running row-major over `bounds`. Keeping them that way
+    rather than deinterleaving into a buffer per channel costs nothing to read -- Channel::upload_tile()
+    takes a stride for exactly this -- and avoids a second copy of every tile.
+*/
+struct IpcUpdateImage
+{
+    std::string              name;
+    bool                     grab_focus = false;
+    std::vector<std::string> channel_names;
+    std::vector<int64_t>     channel_offsets; //!< index into `data` of each channel's first sample
+    std::vector<int64_t>     channel_strides; //!< distance in samples between consecutive pixels
+    Box2i                    bounds;          //!< half-open, in the image's pixel coordinates
+    std::vector<float>       data;
+
+    int num_channels() const { return int(channel_names.size()); }
+
+    //! Distance in samples between consecutive rows of channel `c`; pairs with channel_strides[c].
+    int64_t row_stride(int c) const { return int64_t(bounds.size().x) * channel_strides[c]; }
+};
+
+//! A framed packet: the bytes as they travel, plus typed readers for the payload.
+class IpcPacket
+{
+public:
+    IpcPacket() = default;
+
+    /*!
+        Take ownership of one framed packet, starting at its length prefix.
+
+        Checks only the framing -- that a length is present, that it is sane, and that it matches the bytes
+        handed over. What the payload says is checked by whichever as_*() reads it, since only that knows
+        which fields should be there.
+
+        \throws std::runtime_error if the framing is not intact
+    */
+    IpcPacket(const char *data, size_t length);
+
+    IpcPacketType type() const;
+
+    const std::vector<char> &bytes() const { return m_bytes; }
+    size_t                   size() const { return m_bytes.size(); }
+
+    //@{ \name Payload readers. Each throws std::runtime_error if the packet is not that type, or if its
+    //! contents do not describe the bytes present.
+    IpcOpenImage   as_open_image() const;
+    IpcReloadImage as_reload_image() const;
+    IpcCloseImage  as_close_image() const;
+    IpcCreateImage as_create_image() const;
+    IpcUpdateImage as_update_image() const;
+    //@}
+
+    //@{ \name Builders, which produce exactly what tev's own client would send.
+    static IpcPacket open_image(std::string_view path, std::string_view channel_selector, bool grab_focus);
+    static IpcPacket reload_image(std::string_view name, bool grab_focus);
+    static IpcPacket close_image(std::string_view name);
+    static IpcPacket create_image(std::string_view name, bool grab_focus, int2 size,
+                                  const std::vector<std::string> &channel_names);
+    //! Builds a V3 update. `offsets`/`strides` address `data` as IpcUpdateImage documents.
+    static IpcPacket update_image(std::string_view name, bool grab_focus, const std::vector<std::string> &channel_names,
+                                  const std::vector<int64_t> &offsets, const std::vector<int64_t> &strides,
+                                  const Box2i &bounds, const std::vector<float> &data);
+    //@}
+
+private:
+    std::vector<char> m_bytes;
+};
+
+/*!
+    Pull whole packets off a stream of received bytes.
+
+    A TCP recv() returns whatever has arrived, which may be half a packet or several, so a connection has to
+    accumulate until a length prefix and the bytes it promises are both present. Consumed bytes are dropped
+    from the front and any partial remainder is kept for the next call.
+
+    \param [in,out] buffer  Received bytes; whatever is left over on return is the start of the next packet
+    \param [] on_packet     Invoked for each complete packet, in arrival order
+    \throws std::runtime_error if the stream is unusable (a length no packet could have), which a caller
+            should treat as grounds to drop the connection rather than resynchronize -- there is no framing
+            marker to resynchronize to.
+*/
+void extract_ipc_packets(std::vector<char> &buffer, const std::function<void(const IpcPacket &)> &on_packet);

--- a/src/ipc/ipc_server.cpp
+++ b/src/ipc/ipc_server.cpp
@@ -12,6 +12,7 @@
 #include <spdlog/spdlog.h>
 
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 
 #if defined(_WIN32)
@@ -164,6 +165,11 @@ bool IpcServer::start(uint16_t port, PacketHandler on_packet)
     m_stopping      = false;
     m_listening     = true;
 
+    // The readout counts one listening session, not the lifetime of the app.
+    m_packets_received = 0;
+    m_bytes_received   = 0;
+    m_last_packet_ns   = 0;
+
     {
         std::lock_guard lock{m_mutex};
         m_last_error.clear();
@@ -207,6 +213,20 @@ size_t IpcServer::num_connections() const
 {
     std::lock_guard lock{m_mutex};
     return m_num_connections;
+}
+
+IpcActivity IpcServer::activity() const
+{
+    IpcActivity a;
+    a.packets = m_packets_received.load();
+    a.bytes   = m_bytes_received.load();
+
+    if (const int64_t last = m_last_packet_ns.load(); last != 0)
+    {
+        const int64_t now    = std::chrono::steady_clock::now().time_since_epoch().count();
+        a.seconds_since_last = double(now - last) * 1e-9;
+    }
+    return a;
 }
 
 std::string IpcServer::last_error() const
@@ -279,12 +299,16 @@ void IpcServer::run()
 
             auto &buffer = connections[i].buffer;
             buffer.insert(buffer.end(), chunk.begin(), chunk.begin() + received);
+            m_bytes_received += uint64_t(received);
 
             try
             {
                 extract_ipc_packets(buffer,
                                     [this](const IpcPacket &packet)
                                     {
+                                        ++m_packets_received;
+                                        m_last_packet_ns = std::chrono::steady_clock::now().time_since_epoch().count();
+
                                         if (m_on_packet)
                                             m_on_packet(packet);
                                     });

--- a/src/ipc/ipc_server.cpp
+++ b/src/ipc/ipc_server.cpp
@@ -1,0 +1,330 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include "ipc/ipc_server.h"
+
+#include "common.h"
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
+
+#include <cerrno>
+#include <cstring>
+
+#if defined(_WIN32)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using socket_t                      = SOCKET;
+static constexpr socket_t k_no_sock = INVALID_SOCKET;
+#define poll_sockets WSAPoll
+#else
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using socket_t                      = int;
+static constexpr socket_t k_no_sock = -1;
+#define poll_sockets poll
+#endif
+
+namespace
+{
+
+//! How long the receive thread blocks in poll() before rechecking whether it has been asked to stop.
+/*!
+    Bounds how long stop() takes; nothing else waits on it, since poll() returns as soon as a packet or a
+    connection arrives.
+*/
+constexpr int k_poll_timeout_ms = 100;
+
+//! Largest amount read from one connection per poll, so one busy client cannot starve the others.
+constexpr size_t k_recv_chunk = 1 << 16;
+
+std::string socket_error_string()
+{
+#if defined(_WIN32)
+    return fmt::format("winsock error {}", WSAGetLastError());
+#else
+    return std::strerror(errno);
+#endif
+}
+
+void close_socket(socket_t s)
+{
+#if defined(_WIN32)
+    closesocket(s);
+#else
+    ::close(s);
+#endif
+}
+
+bool set_non_blocking(socket_t s)
+{
+#if defined(_WIN32)
+    u_long mode = 1;
+    return ioctlsocket(s, FIONBIO, &mode) == 0;
+#else
+    const int flags = fcntl(s, F_GETFL, 0);
+    return flags != -1 && fcntl(s, F_SETFL, flags | O_NONBLOCK) != -1;
+#endif
+}
+
+//! True when a non-blocking call failed only because there is nothing to do yet.
+bool would_block()
+{
+#if defined(_WIN32)
+    return WSAGetLastError() == WSAEWOULDBLOCK;
+#else
+    return errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR;
+#endif
+}
+
+//! Winsock needs initializing once per process; everywhere else this is nothing.
+bool init_sockets()
+{
+#if defined(_WIN32)
+    static const bool ok = []
+    {
+        WSADATA data;
+        return WSAStartup(MAKEWORD(2, 2), &data) == 0;
+    }();
+    return ok;
+#else
+    return true;
+#endif
+}
+
+//! One connected client, and the bytes of it that have arrived so far.
+struct Connection
+{
+    socket_t          socket = k_no_sock;
+    std::vector<char> buffer; //!< a recv() returns whatever has arrived, which is rarely a whole packet
+};
+
+} // namespace
+
+IpcServer::~IpcServer() { stop(); }
+
+bool IpcServer::start(uint16_t port, PacketHandler on_packet)
+{
+    stop();
+
+    auto fail = [this](std::string message)
+    {
+        spdlog::warn("Could not listen for image updates: {}", message);
+        std::lock_guard lock{m_mutex};
+        m_last_error = std::move(message);
+        return false;
+    };
+
+    if (!init_sockets())
+        return fail("could not initialize networking");
+
+    const socket_t listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listener == k_no_sock)
+        return fail(fmt::format("could not create a socket ({})", socket_error_string()));
+
+    // Closed on every way out of here until the receive thread takes ownership of it at the end.
+    auto listener_guard = ScopeGuard{[listener] { close_socket(listener); }};
+
+    // Without this, the port stays unbindable for a minute or two after a previous run's connections
+    // finish closing, so restarting HDRView would fail for no reason the user could act on.
+    const int reuse = 1;
+    setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, (const char *)&reuse, sizeof(reuse));
+
+    sockaddr_in address{};
+    address.sin_family      = AF_INET;
+    address.sin_port        = htons(port);
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK); // loopback only; see the class comment
+
+    if (bind(listener, (const sockaddr *)&address, sizeof(address)) != 0)
+        return fail(fmt::format("port {} is unavailable ({}). Another viewer may already be listening on it.", port,
+                                socket_error_string()));
+
+    if (listen(listener, 8) != 0 || !set_non_blocking(listener))
+        return fail(fmt::format("could not listen on port {} ({})", port, socket_error_string()));
+
+    // Port 0 asks the OS to choose a free one, so the port actually bound is read back rather than assumed.
+    // Only a test has reason to do that, but reporting the real port is right either way.
+    sockaddr_in bound{};
+    socklen_t   bound_len = sizeof(bound);
+    if (getsockname(listener, (sockaddr *)&bound, &bound_len) == 0)
+        port = ntohs(bound.sin_port);
+
+    listener_guard.disarm(); // from here on the socket belongs to this object, and stop() closes it
+    m_listen_socket = int64_t(listener);
+    m_port          = port;
+    m_on_packet     = std::move(on_packet);
+    m_stopping      = false;
+    m_listening     = true;
+
+    {
+        std::lock_guard lock{m_mutex};
+        m_last_error.clear();
+    }
+
+    m_thread = std::thread{[this] { run(); }};
+
+    spdlog::info("Listening for image updates on 127.0.0.1:{}.", port);
+    return true;
+}
+
+void IpcServer::stop()
+{
+    if (!m_listening && !m_thread.joinable())
+        return;
+
+    m_stopping = true;
+    if (m_thread.joinable())
+        m_thread.join();
+
+    if (m_listen_socket != -1)
+    {
+        close_socket(socket_t(m_listen_socket));
+        m_listen_socket = -1;
+    }
+
+    m_listening = false;
+    m_on_packet = nullptr;
+
+    {
+        std::lock_guard lock{m_mutex};
+        m_num_connections = 0;
+    }
+
+    if (m_port)
+        spdlog::info("Stopped listening for image updates on port {}.", m_port);
+    m_port = 0;
+}
+
+size_t IpcServer::num_connections() const
+{
+    std::lock_guard lock{m_mutex};
+    return m_num_connections;
+}
+
+std::string IpcServer::last_error() const
+{
+    std::lock_guard lock{m_mutex};
+    return m_last_error;
+}
+
+void IpcServer::run()
+{
+    const socket_t          listener = socket_t(m_listen_socket);
+    std::vector<Connection> connections;
+
+    auto drop = [&](size_t i, const char *why)
+    {
+        spdlog::debug("Image update client disconnected: {}", why);
+        close_socket(connections[i].socket);
+        connections.erase(connections.begin() + i);
+
+        std::lock_guard lock{m_mutex};
+        m_num_connections = connections.size();
+    };
+
+    std::vector<char> chunk(k_recv_chunk);
+
+    while (!m_stopping)
+    {
+        std::vector<pollfd> fds;
+        fds.reserve(connections.size() + 1);
+        fds.push_back(pollfd{listener, POLLIN, 0});
+        for (const auto &c : connections) fds.push_back(pollfd{c.socket, POLLIN, 0});
+
+        const int ready = poll_sockets(fds.data(), (unsigned)fds.size(), k_poll_timeout_ms);
+        if (ready < 0)
+        {
+            if (would_block())
+                continue;
+            spdlog::warn("Gave up listening for image updates: {}", socket_error_string());
+            break;
+        }
+        if (ready == 0)
+            continue;
+
+        // Existing connections first, then new ones, so that a connection accepted this round is not
+        // indexed against the fds array it does not appear in.
+        for (size_t i = connections.size(); i-- > 0;)
+        {
+            const short events = fds[i + 1].revents;
+            if (!events)
+                continue;
+
+            if (events & (POLLHUP | POLLERR | POLLNVAL))
+            {
+                drop(i, "connection closed");
+                continue;
+            }
+
+            const auto received = recv(connections[i].socket, chunk.data(), (int)chunk.size(), 0);
+            if (received == 0)
+            {
+                drop(i, "end of stream");
+                continue;
+            }
+            if (received < 0)
+            {
+                if (!would_block())
+                    drop(i, "receive failed");
+                continue;
+            }
+
+            auto &buffer = connections[i].buffer;
+            buffer.insert(buffer.end(), chunk.begin(), chunk.begin() + received);
+
+            try
+            {
+                extract_ipc_packets(buffer,
+                                    [this](const IpcPacket &packet)
+                                    {
+                                        if (m_on_packet)
+                                            m_on_packet(packet);
+                                    });
+            }
+            catch (const std::exception &e)
+            {
+                // The stream carries no packet boundary to resynchronize to, so a client that sends
+                // something unreadable has to go rather than have the rest of its bytes guessed at.
+                spdlog::warn("Dropping image update client: {}", e.what());
+                drop(i, "malformed packet");
+            }
+        }
+
+        if (fds[0].revents & POLLIN)
+        {
+            while (true)
+            {
+                const socket_t client = accept(listener, nullptr, nullptr);
+                if (client == k_no_sock)
+                    break; // nothing more waiting, or the accept failed; either way, try again next poll
+
+                if (!set_non_blocking(client))
+                {
+                    close_socket(client);
+                    continue;
+                }
+
+                // Tiles arrive as small writes that matter immediately; waiting to coalesce them only adds
+                // latency to what is meant to be a live view.
+                const int no_delay = 1;
+                setsockopt(client, IPPROTO_TCP, TCP_NODELAY, (const char *)&no_delay, sizeof(no_delay));
+
+                connections.push_back(Connection{client, {}});
+                spdlog::debug("Image update client connected.");
+
+                std::lock_guard lock{m_mutex};
+                m_num_connections = connections.size();
+            }
+        }
+    }
+
+    for (auto &c : connections) close_socket(c.socket);
+}

--- a/src/ipc/ipc_server.h
+++ b/src/ipc/ipc_server.h
@@ -9,6 +9,7 @@
 #include "ipc/ipc_packet.h"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <mutex>
@@ -18,6 +19,20 @@
 
 //! The port tev listens on, and the one every client that speaks this protocol reaches for by default.
 inline constexpr uint16_t k_default_ipc_port = 14158;
+
+//! How much has arrived, for showing that a renderer is working and how hard.
+/*!
+    Deliberately not progress: the protocol carries no notion of how much is left, and the two ways clients
+    stream -- painting each tile once, or resending the whole frame at rising sample counts -- cannot be
+    told apart from the packets. Counting what has arrived is the most that can honestly be reported.
+*/
+struct IpcActivity
+{
+    uint64_t packets = 0; //!< Complete packets read since the listener started
+    uint64_t bytes   = 0; //!< Bytes read off the wire, which includes framing
+    //! Seconds since the last packet, or negative when none has arrived yet.
+    double seconds_since_last = -1.0;
+};
 
 /*!
     Accepts connections from renderers and hands their packets to a callback.
@@ -66,6 +81,9 @@ public:
     //! How many clients are connected right now. For the GUI to show what is streaming.
     size_t num_connections() const;
 
+    //! Running totals of what has been received. Safe to call from any thread.
+    IpcActivity activity() const;
+
     //! The most recent reason start() failed, for showing in the GUI next to the toggle that failed.
     std::string last_error() const;
 
@@ -75,6 +93,13 @@ private:
     std::atomic<bool> m_listening{false};
     std::atomic<bool> m_stopping{false};
     uint16_t          m_port = 0;
+
+    // Written by the receive thread and read by the GUI every frame, so atomic rather than under the mutex
+    // -- the readout is a rough gauge and is not worth contending a lock for. The timestamp is kept as a
+    // steady_clock count because time_point is not trivially copyable enough to be atomic everywhere.
+    std::atomic<uint64_t> m_packets_received{0};
+    std::atomic<uint64_t> m_bytes_received{0};
+    std::atomic<int64_t>  m_last_packet_ns{0}; //!< 0 until the first packet arrives
 
     // -1 when not listening; an OS socket handle otherwise. Kept as an int so this header needs no
     // platform socket headers -- Windows' SOCKET is a pointer-sized handle, but every value the API

--- a/src/ipc/ipc_server.h
+++ b/src/ipc/ipc_server.h
@@ -1,0 +1,90 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#pragma once
+
+#include "ipc/ipc_packet.h"
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+//! The port tev listens on, and the one every client that speaks this protocol reaches for by default.
+inline constexpr uint16_t k_default_ipc_port = 14158;
+
+/*!
+    Accepts connections from renderers and hands their packets to a callback.
+
+    Listens on the loopback interface only. Extending that to other interfaces -- so a render node could
+    push to a workstation -- means taking a bind address here and deciding what, if anything, authorizes a
+    remote sender; the protocol itself has no notion of who is connecting, and a listener reachable off the
+    machine would let anything on the network create and overwrite images. Nothing about the rest of this
+    class assumes loopback, so that is a decision to make rather than a rewrite to do.
+
+    Not started by default: a viewer that opens a listening socket on every launch is a standing exposure
+    and, on Windows and macOS, a firewall prompt for users who will never stream a render.
+*/
+class IpcServer
+{
+public:
+    /*!
+        Invoked for each packet, on the server's own receive thread.
+
+        Everything an image is made of belongs to the main thread, so a handler must not touch it directly;
+        it should decode what it needs and hand the work to HDRViewApp::post_to_main_thread().
+    */
+    using PacketHandler = std::function<void(const IpcPacket &)>;
+
+    IpcServer() = default;
+    ~IpcServer();
+
+    IpcServer(const IpcServer &)            = delete;
+    IpcServer &operator=(const IpcServer &) = delete;
+
+    /*!
+        Begin listening on 127.0.0.1:\p port.
+
+        \return true once the socket is bound and the receive thread is running. Binding fails when
+                something else already holds the port -- most likely tev itself, or another HDRView -- which
+                is reported and is not an error worth stopping the app for.
+    */
+    bool start(uint16_t port, PacketHandler on_packet);
+
+    //! Stop listening and close every connection. Safe to call when not listening, and called by ~IpcServer.
+    void stop();
+
+    bool     is_listening() const { return m_listening; }
+    uint16_t port() const { return m_port; }
+
+    //! How many clients are connected right now. For the GUI to show what is streaming.
+    size_t num_connections() const;
+
+    //! The most recent reason start() failed, for showing in the GUI next to the toggle that failed.
+    std::string last_error() const;
+
+private:
+    void run(); //!< the receive thread's loop
+
+    std::atomic<bool> m_listening{false};
+    std::atomic<bool> m_stopping{false};
+    uint16_t          m_port = 0;
+
+    // -1 when not listening; an OS socket handle otherwise. Kept as an int so this header needs no
+    // platform socket headers -- Windows' SOCKET is a pointer-sized handle, but every value the API
+    // actually returns fits, and the .cpp does the conversion in one place.
+    int64_t m_listen_socket = -1;
+
+    PacketHandler m_on_packet;
+    std::thread   m_thread;
+
+    mutable std::mutex m_mutex; //!< guards m_num_connections and m_last_error
+    size_t             m_num_connections = 0;
+    std::string        m_last_error;
+};

--- a/src/texture_gl.cpp
+++ b/src/texture_gl.cpp
@@ -299,7 +299,9 @@ int Texture::max_size()
 
 void Texture::generate_mipmap()
 {
-    spdlog::info("Generating mipmap");
+    // Trace, not info: a streaming image regenerates its mip chain on any frame a tile landed on, which at
+    // info level buries everything else in the log window.
+    spdlog::trace("Generating mipmap");
     GLenum tex_mode = m_samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
     CHK(glBindTexture(tex_mode, m_texture_handle));
     CHK(glGenerateMipmap(tex_mode));

--- a/src/vector_overlay.cpp
+++ b/src/vector_overlay.cpp
@@ -1,0 +1,367 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include "vector_overlay.h"
+
+#include "imgui.h"
+#include "imgui_internal.h"
+
+#include <cmath>
+
+int VgCommand::num_floats(Type type)
+{
+    switch (type)
+    {
+    case Type::Save:
+    case Type::Restore:
+    case Type::Fill:
+    case Type::Stroke:
+    case Type::BeginPath:
+    case Type::ClosePath:
+    case Type::DebugDumpPathCache:
+    case Type::FontFace: return 0;
+
+    case Type::PathWinding:
+    case Type::TextAlign: return 1;
+
+    case Type::StrokeWidth:
+    case Type::FontSize: return 2; // value, ScaleKind
+
+    case Type::MoveTo:
+    case Type::LineTo:
+    case Type::Text: return 2; // Text's string is carried separately
+
+    case Type::Circle: return 3;
+
+    case Type::FillColor:
+    case Type::StrokeColor:
+    case Type::Ellipse:
+    case Type::QuadTo:
+    case Type::Rect: return 4;
+
+    case Type::ArcTo:
+    case Type::RoundedRect: return 5;
+
+    case Type::Arc:
+    case Type::BezierTo: return 6;
+
+    case Type::RoundedRectVarying: return 8;
+
+    case Type::Invalid:
+    default: return -1;
+    }
+}
+
+namespace
+{
+
+//! The mutable drawing state, as NanoVG defines it. Save/Restore push and pop this whole struct.
+struct VgState
+{
+    ImU32 fill_color;
+    ImU32 stroke_color;
+    float stroke_width          = 3.f; // tev's default
+    bool  stroke_width_relative = false;
+    float font_size             = 20.f; // tev's default
+    bool  font_size_relative    = false;
+    int   text_align            = VgCommand::AlignLeft | VgCommand::AlignBaseline;
+    void *font                  = nullptr;
+};
+
+//! One run of points; a path is a list of these, as NanoVG accumulates them between MoveTo calls.
+struct SubPath
+{
+    ImVector<ImVec2> points;
+    bool             closed = false;
+};
+
+ImU32 color_from(const float *f) { return ImGui::ColorConvertFloat4ToU32(ImVec4(f[0], f[1], f[2], f[3])); }
+
+/*!
+    Builds a NanoVG-style path out of ImDrawList's own path machinery.
+
+    ImDrawList has one path buffer and no notion of subpaths, so each subpath is built there -- which gets
+    ImGui's curve and arc tessellation for free -- and then moved out into `subpaths` when it ends. Stroke
+    and Fill walk those; only BeginPath discards them, matching NanoVG, where a path can be filled and then
+    stroked without rebuilding it.
+*/
+class PathBuilder
+{
+public:
+    PathBuilder(ImDrawList *draw_list) : m_draw_list(draw_list) {}
+
+    void begin()
+    {
+        m_subpaths.clear();
+        m_draw_list->_Path.Size = 0;
+    }
+
+    //! Start a new subpath at \p p.
+    void move_to(ImVec2 p)
+    {
+        flush(false);
+        m_draw_list->PathLineTo(p);
+    }
+
+    //! ImDrawList's Path* helpers append to the subpath under construction; use them via this.
+    ImDrawList *path() { return m_draw_list; }
+
+    //! Finish the subpath under construction, if it has enough points to draw.
+    void flush(bool closed)
+    {
+        if (m_draw_list->_Path.Size >= 2)
+        {
+            m_subpaths.push_back({});
+            m_subpaths.back().points = m_draw_list->_Path;
+            m_subpaths.back().closed = closed;
+        }
+        m_draw_list->_Path.Size = 0;
+    }
+
+    //! A shape that is a closed subpath all by itself (a rect, a circle): ends whatever preceded it too.
+    void add_closed_shape() { flush(true); }
+
+    void close() { flush(true); }
+
+    void stroke(ImU32 color, float width) const
+    {
+        for (const auto &sp : m_subpaths)
+            m_draw_list->AddPolyline(sp.points.Data, sp.points.Size, color, width,
+                                     sp.closed ? ImDrawFlags_Closed : ImDrawFlags_None);
+    }
+
+    void fill(ImU32 color) const
+    {
+        // Each subpath is filled on its own. NanoVG would instead fill them together under a winding rule,
+        // which is how a subpath marked as a hole punches through the one around it; ImDrawList has no
+        // winding, so a hole comes out solid. PathWinding is refused for that reason -- see its case below.
+        for (const auto &sp : m_subpaths)
+            if (sp.points.Size >= 3)
+                m_draw_list->AddConcavePolyFilled(sp.points.Data, sp.points.Size, color);
+    }
+
+    //! Whether anything has been built but not yet ended.
+    bool building() const { return m_draw_list->_Path.Size > 0; }
+
+private:
+    ImDrawList          *m_draw_list;
+    std::vector<SubPath> m_subpaths;
+};
+
+//! Where AddText should put the string's top-left, given NanoVG's alignment flags.
+/*!
+    ImGui positions text by its top-left corner and has no notion of a baseline, so Baseline is placed as a
+    fraction of the line height -- close enough that a label sits where the sender meant it to, but not
+    metrically exact.
+*/
+ImVec2 aligned_text_pos(ImVec2 anchor, ImVec2 size, int align)
+{
+    float x = anchor.x;
+    if (align & VgCommand::AlignCenter)
+        x -= size.x * 0.5f;
+    else if (align & VgCommand::AlignRight)
+        x -= size.x;
+
+    float y = anchor.y; // AlignTop
+    if (align & VgCommand::AlignMiddle)
+        y -= size.y * 0.5f;
+    else if (align & VgCommand::AlignBottom)
+        y -= size.y;
+    else if (align & VgCommand::AlignBaseline)
+        y -= size.y * 0.8f;
+
+    return ImVec2(x, y);
+}
+
+} // namespace
+
+void draw_vector_overlay(ImDrawList *draw_list, const std::vector<VgCommand> &commands, const VgTransform &xform,
+                         uint32_t default_color, const std::function<void(const char *)> &on_unsupported)
+{
+    if (!draw_list || commands.empty() || !xform.to_screen)
+        return;
+
+    auto unsupported = [&on_unsupported](const char *what)
+    {
+        if (on_unsupported)
+            on_unsupported(what);
+    };
+
+    const auto  to_screen = [&xform](float x, float y) { return ImVec2(xform.to_screen(float2{x, y})); };
+    const float scale     = xform.scale;
+
+    VgState              state;
+    std::vector<VgState> stack;
+    state.fill_color   = default_color;
+    state.stroke_color = default_color;
+    state.font         = xform.default_font;
+
+    // Subpaths are staged through ImDrawList's own path buffer, which is scratch space between primitives
+    // and so is empty on entry and left empty on exit.
+    PathBuilder path{draw_list};
+    draw_list->_Path.Size = 0;
+
+    for (const auto &cmd : commands)
+    {
+        const float *f = cmd.data.data();
+        if (int expected = VgCommand::num_floats(cmd.type); expected < 0 || int(cmd.data.size()) != expected)
+        {
+            unsupported("a command with the wrong number of arguments");
+            continue;
+        }
+
+        switch (cmd.type)
+        {
+        // -- state ------------------------------------------------------------------------------------
+        case VgCommand::Type::Save: stack.push_back(state); break;
+        case VgCommand::Type::Restore:
+            if (!stack.empty())
+            {
+                state = stack.back();
+                stack.pop_back();
+            }
+            break;
+
+        case VgCommand::Type::FillColor: state.fill_color = color_from(f); break;
+        case VgCommand::Type::StrokeColor: state.stroke_color = color_from(f); break;
+        case VgCommand::Type::StrokeWidth:
+            state.stroke_width          = f[0];
+            state.stroke_width_relative = int(f[1]) == VgCommand::Relative;
+            break;
+
+        // -- path construction ------------------------------------------------------------------------
+        case VgCommand::Type::BeginPath: path.begin(); break;
+        case VgCommand::Type::ClosePath: path.close(); break;
+        case VgCommand::Type::MoveTo: path.move_to(to_screen(f[0], f[1])); break;
+        case VgCommand::Type::LineTo: path.path()->PathLineTo(to_screen(f[0], f[1])); break;
+
+        case VgCommand::Type::BezierTo:
+            path.path()->PathBezierCubicCurveTo(to_screen(f[0], f[1]), to_screen(f[2], f[3]), to_screen(f[4], f[5]));
+            break;
+        case VgCommand::Type::QuadTo:
+            path.path()->PathBezierQuadraticCurveTo(to_screen(f[0], f[1]), to_screen(f[2], f[3]));
+            break;
+
+        case VgCommand::Type::Arc:
+            // NanoVG's winding argument picks the sweep direction; PathArcTo sweeps from a_min to a_max, so
+            // ordering the angles expresses the same thing.
+            {
+                const ImVec2 c   = to_screen(f[0], f[1]);
+                const float  r   = f[2] * scale;
+                const bool   ccw = int(f[5]) == 1;
+                path.path()->PathArcTo(c, r, ccw ? f[4] : f[3], ccw ? f[3] : f[4]);
+            }
+            break;
+
+        case VgCommand::Type::Rect:
+        {
+            const ImVec2 a = to_screen(f[0], f[1]);
+            const ImVec2 b = to_screen(f[0] + f[2], f[1] + f[3]);
+            path.flush(false);
+            draw_list->PathRect(a, b);
+            path.add_closed_shape();
+        }
+        break;
+
+        case VgCommand::Type::RoundedRect:
+        {
+            const ImVec2 a = to_screen(f[0], f[1]);
+            const ImVec2 b = to_screen(f[0] + f[2], f[1] + f[3]);
+            path.flush(false);
+            draw_list->PathRect(a, b, f[4] * scale);
+            path.add_closed_shape();
+        }
+        break;
+
+        case VgCommand::Type::Circle:
+        {
+            // Stopping one segment short of a full turn: the subpath is closed when it is drawn, so
+            // sweeping the whole circle would leave its first and last point on top of each other. This is
+            // what ImDrawList::AddCircle() does for the same reason.
+            const ImVec2 c    = to_screen(f[0], f[1]);
+            const float  r    = f[2] * scale;
+            const int    segs = ImMax(3, draw_list->_CalcCircleAutoSegmentCount(r));
+            path.flush(false);
+            draw_list->PathArcTo(c, r, 0.f, IM_PI * 2.f * (segs - 1) / segs, segs - 1);
+            path.add_closed_shape();
+        }
+        break;
+
+        case VgCommand::Type::Ellipse:
+        {
+            const ImVec2 c    = to_screen(f[0], f[1]);
+            const ImVec2 r    = ImVec2(f[2] * scale, f[3] * scale);
+            const int    segs = ImMax(3, draw_list->_CalcCircleAutoSegmentCount(ImMax(r.x, r.y)));
+            path.flush(false);
+            draw_list->PathEllipticalArcTo(c, r, 0.f, 0.f, IM_PI * 2.f * (segs - 1) / segs, segs - 1);
+            path.add_closed_shape();
+        }
+        break;
+
+        // -- painting ---------------------------------------------------------------------------------
+        case VgCommand::Type::Stroke:
+            path.flush(false);
+            path.stroke(state.stroke_color, state.stroke_width * (state.stroke_width_relative ? scale : 1.f));
+            break;
+        case VgCommand::Type::Fill:
+            path.flush(false);
+            path.fill(state.fill_color);
+            break;
+
+        // -- text -------------------------------------------------------------------------------------
+        case VgCommand::Type::FontSize:
+            state.font_size          = f[0];
+            state.font_size_relative = int(f[1]) == VgCommand::Relative;
+            break;
+        case VgCommand::Type::TextAlign: state.text_align = int(f[0]); break;
+        case VgCommand::Type::FontFace:
+            if (xform.font_for)
+                if (void *font = xform.font_for(cmd.text))
+                    state.font = font;
+            break;
+
+        case VgCommand::Type::Text:
+        {
+            const float size = ImMax(1.f, state.font_size * (state.font_size_relative ? scale : 1.f));
+            auto       *font = (ImFont *)(state.font ? state.font : xform.default_font);
+            if (!font)
+                break;
+
+            const ImVec2 extent = font->CalcTextSizeA(size, FLT_MAX, 0.f, cmd.text.c_str());
+            const ImVec2 at     = aligned_text_pos(to_screen(f[0], f[1]), extent, state.text_align);
+            draw_list->AddText(font, size, at, state.fill_color, cmd.text.c_str());
+        }
+        break;
+
+        // -- refused ----------------------------------------------------------------------------------
+        case VgCommand::Type::PathWinding:
+            // NanoVG uses this to mark a subpath as a hole in the one around it, which needs a winding
+            // rule that ImDrawList does not have. Filling anyway would produce a solid shape where a
+            // donut was asked for, so the command is reported instead.
+            unsupported("PathWinding (holes in filled paths)");
+            break;
+
+        case VgCommand::Type::ArcTo:
+            // The tangent/fillet form: an arc of the given radius joining the current point to two others.
+            // ImDrawList only has centre-and-angles arcs, so this needs the tangent construction from
+            // NanoVG. Nothing observed sends it.
+            unsupported("ArcTo");
+            break;
+
+        case VgCommand::Type::RoundedRectVarying:
+            // ImDrawList rounds corners by flags off one radius, not a radius per corner.
+            unsupported("RoundedRectVarying");
+            break;
+
+        case VgCommand::Type::DebugDumpPathCache: break; // a NanoVG debugging aid with nothing to do here
+
+        case VgCommand::Type::Invalid:
+        default: unsupported("an unrecognized command"); break;
+        }
+    }
+
+    draw_list->_Path.Size = 0;
+}

--- a/src/vector_overlay.h
+++ b/src/vector_overlay.h
@@ -1,0 +1,128 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#pragma once
+
+#include "fwd.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+struct ImDrawList;
+
+/*!
+    A little retained drawing program layered over an image, in that image's pixel coordinates.
+
+    This is the shape tev's `VectorGraphics` IPC packet carries, kept here rather than beside the protocol
+    because an overlay on an image is not inherently a network thing -- the image model stores one, and the
+    viewport draws it, neither of which should have to know a socket exists.
+
+    The model is NanoVG's, since that is what the protocol was written against: a mutable graphics state
+    (colors, widths, font) with a save/restore stack, and a path built up from subpaths that is then
+    stroked, filled, or both. Commands carry their arguments as a flat run of floats whose length is fixed
+    per type, plus a string for the two types that need one.
+
+    An independent reimplementation from the protocol's description, as in ipc_packet.h: tev draws these
+    commands through NanoVG, where the interpreter here targets Dear ImGui's draw lists.
+*/
+struct VgCommand
+{
+    //! Command numbering is the wire protocol's; see tev's VectorGraphics.h.
+    enum class Type : int8_t
+    {
+        Invalid            = 127,
+        Save               = 0,
+        Restore            = 1,
+        FillColor          = 2,
+        Fill               = 3,
+        StrokeColor        = 4,
+        Stroke             = 5,
+        BeginPath          = 6,
+        ClosePath          = 7,
+        PathWinding        = 8,
+        DebugDumpPathCache = 9,
+        MoveTo             = 10,
+        LineTo             = 11,
+        ArcTo              = 12,
+        Arc                = 13,
+        BezierTo           = 14,
+        Circle             = 15,
+        Ellipse            = 16,
+        QuadTo             = 17,
+        Rect               = 18,
+        RoundedRect        = 19,
+        RoundedRectVarying = 20,
+        Text               = 21,
+        TextAlign          = 22,
+        FontFace           = 23,
+        FontSize           = 24,
+        StrokeWidth        = 25,
+    };
+
+    //! Whether a size is in image pixels (and so scales with zoom) or in screen pixels.
+    enum ScaleKind : int
+    {
+        Relative = 0,
+        Absolute = 1,
+    };
+
+    //! Bit flags, matching NanoVG's NVG_ALIGN_*.
+    enum TextAlign : int
+    {
+        AlignLeft     = 1 << 0,
+        AlignCenter   = 1 << 1,
+        AlignRight    = 1 << 2,
+        AlignTop      = 1 << 3,
+        AlignMiddle   = 1 << 4,
+        AlignBottom   = 1 << 5,
+        AlignBaseline = 1 << 6,
+    };
+
+    Type               type = Type::Invalid;
+    std::vector<float> data;
+    std::string        text; //!< only Text and FontFace carry one
+
+    //! How many floats \p type expects in `data`, or -1 for a type that is not one of ours.
+    /*!
+        The wire format has no per-command length, so this table is what makes a command stream parseable
+        at all: each command's arguments run exactly this long and the next command starts after them.
+    */
+    static int num_floats(Type type);
+
+    static bool has_text(Type type) { return type == Type::Text || type == Type::FontFace; }
+};
+
+//! What draw_vector_overlay() needs to know about where the image is on screen.
+struct VgTransform
+{
+    //! Image pixel coordinates to ImGui screen coordinates. Usually HDRViewApp::app_pos_at_pixel().
+    std::function<float2(float2)> to_screen;
+    //! Screen pixels per image pixel, for sizes flagged Relative. Always positive, even when flipped.
+    float scale = 1.f;
+    //! Resolves a NanoVG font-face name ("sans", "sans-bold", "mono") to a font; may return nullptr.
+    std::function<void *(const std::string &)> font_for;
+    //! Font the overlay starts with, and falls back to when a face name is unknown.
+    void *default_font = nullptr;
+};
+
+/*!
+    Execute \p commands into \p draw_list.
+
+    Unsupported commands are skipped rather than approximated -- an overlay that quietly draws something
+    other than what was asked for is worse than one with a hole in it, since the whole point of it is to be
+    trusted as a diagnostic. Each distinct one is reported once via \p on_unsupported, which is expected to
+    log; it is called with a stable name so a caller can rate-limit on it.
+
+    \param [] draw_list      Where to draw; the overlay leaves its path state as it found it
+    \param [] commands       The program, executed in order
+    \param [] xform          Where the image is on screen, and how big
+    \param [] default_color  Stroke and fill color before the program sets one
+    \param [] on_unsupported Called with the name of a command that was skipped, if any
+*/
+void draw_vector_overlay(ImDrawList *draw_list, const std::vector<VgCommand> &commands, const VgTransform &xform,
+                         uint32_t default_color, const std::function<void(const char *)> &on_unsupported = {});

--- a/tests/fuzz/fuzz_ipc_packet.cpp
+++ b/tests/fuzz/fuzz_ipc_packet.cpp
@@ -73,6 +73,21 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                         (void)sink;
                         break;
                     }
+                    case IpcPacketType::VectorGraphics:
+                    {
+                        // The command stream carries no per-command length -- each type implies its own --
+                        // so a wrong entry in that table walks the parser into the next command's bytes.
+                        // Reading every command's arguments back is what makes such a slip observable.
+                        const auto     vg   = packet.as_vector_graphics();
+                        volatile float sink = 0.f;
+                        for (const auto &cmd : vg.commands)
+                        {
+                            for (float v : cmd.data) sink = v;
+                            sink = float(cmd.text.size());
+                        }
+                        (void)sink;
+                        break;
+                    }
                     default: break; // an unknown or unsupported type is not a parser bug
                     }
                 }

--- a/tests/fuzz/fuzz_ipc_packet.cpp
+++ b/tests/fuzz/fuzz_ipc_packet.cpp
@@ -1,0 +1,91 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+// libFuzzer entry point for the IPC packet parser. Unlike the image loaders, whose input is a file the user
+// chose to open, this input arrives unprompted over a socket from another process -- so every count, offset
+// and stride in it is attacker-controlled, and the parser is the only thing standing between them and the
+// image model.
+//
+// Feeding the bytes through extract_ipc_packets() rather than straight to IpcPacket covers the framing too:
+// the length prefix decides how much is read, so it is as much part of the attack surface as the payload.
+//
+// Build:  cmake --preset linux-cpm -B build/fuzz -DHDRVIEW_BUILD_FUZZERS=ON \
+//                -DUSE_SANITIZER="Address;Undefined" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+// Run:    ./build/fuzz/hdrview_fuzz_ipc_packet corpus/ -max_len=65536
+
+#include "ipc/ipc_packet.h"
+
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+
+struct QuietLogs
+{
+    QuietLogs() { spdlog::set_level(spdlog::level::off); }
+};
+QuietLogs quiet_logs;
+
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    std::vector<char> buffer(reinterpret_cast<const char *>(data), reinterpret_cast<const char *>(data) + size);
+
+    try
+    {
+        extract_ipc_packets(
+            buffer,
+            [](const IpcPacket &packet)
+            {
+                // Read each packet as whatever it claims to be. Reading it as the wrong type
+                // throws, which is the parser working, so the type is dispatched on rather
+                // than every reader being tried.
+                try
+                {
+                    switch (packet.type())
+                    {
+                    case IpcPacketType::OpenImage:
+                    case IpcPacketType::OpenImageV2: (void)packet.as_open_image(); break;
+                    case IpcPacketType::ReloadImage: (void)packet.as_reload_image(); break;
+                    case IpcPacketType::CloseImage: (void)packet.as_close_image(); break;
+                    case IpcPacketType::CreateImage: (void)packet.as_create_image(); break;
+                    case IpcPacketType::UpdateImage:
+                    case IpcPacketType::UpdateImageV2:
+                    case IpcPacketType::UpdateImageV3:
+                    {
+                        const auto update = packet.as_update_image();
+                        // Touch every sample the parser said was addressable: an offset or
+                        // stride that passed validation but does not actually land inside
+                        // the payload is exactly the bug worth finding, and it only shows
+                        // up when the addressing is used.
+                        const int64_t  n_pixels = int64_t(update.bounds.size().x) * update.bounds.size().y;
+                        volatile float sink     = 0.f;
+                        for (int c = 0; c < update.num_channels(); ++c)
+                            for (int64_t px = 0; px < n_pixels; ++px)
+                                sink = update.data[size_t(update.channel_offsets[c] + px * update.channel_strides[c])];
+                        (void)sink;
+                        break;
+                    }
+                    default: break; // an unknown or unsupported type is not a parser bug
+                    }
+                }
+                catch (const std::exception &)
+                {
+                    // Refusing a malformed packet is the correct behavior, not a finding.
+                }
+            });
+    }
+    catch (const std::exception &)
+    {
+        // Likewise for a stream whose framing is unusable.
+    }
+
+    return 0;
+}

--- a/tests/test_ipc_packet.cpp
+++ b/tests/test_ipc_packet.cpp
@@ -115,6 +115,96 @@ TEST_CASE("IPC packets round-trip through the wire format")
     }
 }
 
+TEST_CASE("VectorGraphics packets round-trip, including the per-type argument counts")
+{
+    // The stream carries no per-command length, so a command's type is the only thing that says where the
+    // next one starts. Round-tripping a mix of every argument-count shape is what checks that table.
+    std::vector<VgCommand> commands{
+        {VgCommand::Type::BeginPath, {}},
+        {VgCommand::Type::StrokeColor, {1.f, 0.5f, 0.f, 1.f}},
+        {VgCommand::Type::StrokeWidth, {2.f, float(VgCommand::Relative)}},
+        {VgCommand::Type::Rect, {4.f, 8.f, 16.f, 32.f}},
+        {VgCommand::Type::MoveTo, {1.f, 2.f}},
+        {VgCommand::Type::BezierTo, {3.f, 4.f, 5.f, 6.f, 7.f, 8.f}},
+        {VgCommand::Type::Stroke, {}},
+        {VgCommand::Type::FontSize, {20.f, float(VgCommand::Relative)}},
+        {VgCommand::Type::TextAlign, {float(VgCommand::AlignLeft | VgCommand::AlignBaseline)}},
+        {VgCommand::Type::FontFace, {}, "sans-bold"},
+        {VgCommand::Type::Text, {5.f, 9.f}, "Tile 7"},
+    };
+
+    auto info = parse(IpcPacket::vector_graphics("render", false, true, commands).bytes()).as_vector_graphics();
+
+    CHECK(info.name == "render");
+    CHECK(info.append);
+    REQUIRE(info.commands.size() == commands.size());
+    for (size_t i = 0; i < commands.size(); ++i)
+    {
+        CAPTURE(i);
+        CHECK(info.commands[i].type == commands[i].type);
+        CHECK(info.commands[i].data == commands[i].data);
+        CHECK(info.commands[i].text == commands[i].text);
+    }
+}
+
+TEST_CASE("A VectorGraphics packet with an unreadable command stream is refused")
+{
+    auto framed_vg = [](const std::vector<char> &tail)
+    {
+        std::vector<char> payload;
+        payload.push_back(0); // grab_focus
+        append_string(payload, "img");
+        payload.push_back(1); // append
+        payload.insert(payload.end(), tail.begin(), tail.end());
+        return framed(IpcPacketType::VectorGraphics, payload);
+    };
+
+    SUBCASE("an unknown command type, whose length is therefore unknown")
+    {
+        // The whole rest of the packet becomes unparseable, so this cannot be skipped past.
+        std::vector<char> tail;
+        append<int32_t>(tail, 1);
+        tail.push_back(99); // not a command we know
+        CHECK_THROWS_AS(parse(framed_vg(tail)).as_vector_graphics(), std::runtime_error);
+    }
+
+    SUBCASE("a command count that would be an allocation attack")
+    {
+        std::vector<char> tail;
+        append<int32_t>(tail, 1 << 30);
+        CHECK_THROWS_AS(parse(framed_vg(tail)).as_vector_graphics(), std::runtime_error);
+    }
+
+    SUBCASE("a command whose arguments run off the end")
+    {
+        std::vector<char> tail;
+        append<int32_t>(tail, 1);
+        tail.push_back(char(VgCommand::Type::BezierTo)); // wants six floats
+        append<float>(tail, 1.f);                        // only one follows
+        CHECK_THROWS_AS(parse(framed_vg(tail)).as_vector_graphics(), std::runtime_error);
+    }
+
+    SUBCASE("a text command with no terminator on its string")
+    {
+        std::vector<char> tail;
+        append<int32_t>(tail, 1);
+        tail.push_back(char(VgCommand::Type::Text));
+        append<float>(tail, 0.f);
+        append<float>(tail, 0.f);
+        tail.insert(tail.end(), {'h', 'i'}); // no NUL
+        CHECK_THROWS_AS(parse(framed_vg(tail)).as_vector_graphics(), std::runtime_error);
+    }
+
+    SUBCASE("an empty command list is legitimate -- it clears the overlay")
+    {
+        std::vector<char> tail;
+        append<int32_t>(tail, 0);
+        auto info = parse(framed_vg(tail)).as_vector_graphics();
+        CHECK(info.commands.empty());
+        CHECK(info.append);
+    }
+}
+
 TEST_CASE("Older UpdateImage versions are read as the newer one's equivalent")
 {
     // V1 had no channel count and exactly one channel; V2 added the count but kept the planes contiguous.

--- a/tests/test_ipc_packet.cpp
+++ b/tests/test_ipc_packet.cpp
@@ -1,0 +1,341 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "endian-utils.h"
+#include "ipc/ipc_packet.h"
+
+#include <cstring>
+
+namespace
+{
+
+//! Frame arbitrary payload bytes as a packet, filling in the length prefix the way a sender would.
+/*!
+    Lets a test state a malformed payload directly, which the builders deliberately cannot produce.
+*/
+std::vector<char> framed(IpcPacketType type, const std::vector<char> &payload)
+{
+    std::vector<char> bytes(sizeof(uint32_t));
+    bytes.push_back(char(uint8_t(type)));
+    bytes.insert(bytes.end(), payload.begin(), payload.end());
+    write_as(reinterpret_cast<unsigned char *>(bytes.data()), uint32_t(bytes.size()), Endian::Little);
+    return bytes;
+}
+
+template <typename T>
+void append(std::vector<char> &v, T value)
+{
+    const size_t at = v.size();
+    v.resize(at + sizeof(T));
+    write_as(reinterpret_cast<unsigned char *>(v.data()) + at, value, Endian::Little);
+}
+
+void append_string(std::vector<char> &v, std::string_view s)
+{
+    v.insert(v.end(), s.begin(), s.end());
+    v.push_back('\0');
+}
+
+IpcPacket parse(const std::vector<char> &bytes) { return IpcPacket{bytes.data(), bytes.size()}; }
+
+} // namespace
+
+TEST_CASE("IPC packets round-trip through the wire format")
+{
+    SUBCASE("OpenImage keeps the path and selector apart")
+    {
+        auto p = IpcPacket::open_image("/tmp/render.exr", "diffuse", true);
+        CHECK(p.type() == IpcPacketType::OpenImageV2);
+
+        auto info = parse(p.bytes()).as_open_image();
+        CHECK(info.path == "/tmp/render.exr");
+        CHECK(info.channel_selector == "diffuse");
+        CHECK(info.grab_focus);
+    }
+
+    SUBCASE("CloseImage carries just a name")
+    {
+        auto info = parse(IpcPacket::close_image("beauty").bytes()).as_close_image();
+        CHECK(info.name == "beauty");
+    }
+
+    SUBCASE("ReloadImage")
+    {
+        auto info = parse(IpcPacket::reload_image("beauty", false).bytes()).as_reload_image();
+        CHECK(info.name == "beauty");
+        CHECK_FALSE(info.grab_focus);
+    }
+
+    SUBCASE("CreateImage names every channel")
+    {
+        const std::vector<std::string> names{"R", "G", "B", "albedo.R"};
+        auto info = parse(IpcPacket::create_image("render", true, int2{64, 32}, names).bytes()).as_create_image();
+
+        CHECK(info.name == "render");
+        CHECK(info.size == int2{64, 32});
+        CHECK(info.channel_names == names);
+    }
+
+    SUBCASE("UpdateImage preserves the interleaved payload and how to address it")
+    {
+        // Three channels interleaved, exactly as a renderer would hand over an RGB bucket.
+        const Box2i                    bounds{int2{4, 8}, int2{8, 12}};
+        const std::vector<std::string> names{"R", "G", "B"};
+        const std::vector<int64_t>     offsets{0, 1, 2};
+        const std::vector<int64_t>     strides{3, 3, 3};
+
+        std::vector<float> data(size_t(bounds.size().x) * bounds.size().y * 3);
+        for (size_t i = 0; i < data.size(); ++i) data[i] = float(i) * 0.5f;
+
+        auto info = parse(IpcPacket::update_image("render", false, names, offsets, strides, bounds, data).bytes())
+                        .as_update_image();
+
+        CHECK(info.name == "render");
+        CHECK(info.bounds == bounds);
+        CHECK(info.channel_names == names);
+        CHECK(info.channel_offsets == offsets);
+        CHECK(info.channel_strides == strides);
+        REQUIRE(info.data.size() == data.size());
+        CHECK(info.data == data);
+
+        // The addressing the struct documents has to actually land on the right samples.
+        const int n_pixels = bounds.size().x * bounds.size().y;
+        for (int c = 0; c < info.num_channels(); ++c)
+            for (int px = 0; px < n_pixels; ++px)
+                CHECK(info.data[size_t(info.channel_offsets[c] + px * info.channel_strides[c])] ==
+                      data[size_t(px * 3 + c)]);
+
+        // ...and row_stride() has to agree with it, since upload_tile() is driven by that pair.
+        CHECK(info.row_stride(0) == int64_t(bounds.size().x) * 3);
+    }
+}
+
+TEST_CASE("Older UpdateImage versions are read as the newer one's equivalent")
+{
+    // V1 had no channel count and exactly one channel; V2 added the count but kept the planes contiguous.
+    // Both have to arrive as offsets/strides, since that is all the rest of the code knows how to read.
+    const int32_t      w = 2, h = 2;
+    std::vector<float> plane_a{1.f, 2.f, 3.f, 4.f};
+    std::vector<float> plane_b{5.f, 6.f, 7.f, 8.f};
+
+    SUBCASE("v1 implies a single channel")
+    {
+        std::vector<char> payload;
+        payload.push_back(0); // grab_focus
+        append_string(payload, "img");
+        append_string(payload, "Y");
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, w);
+        append<int32_t>(payload, h);
+        for (float v : plane_a) append<float>(payload, v);
+
+        auto info = parse(framed(IpcPacketType::UpdateImage, payload)).as_update_image();
+        CHECK(info.num_channels() == 1);
+        CHECK(info.channel_offsets == std::vector<int64_t>{0});
+        CHECK(info.channel_strides == std::vector<int64_t>{1});
+        CHECK(info.data == plane_a);
+    }
+
+    SUBCASE("v2 concatenates one plane per channel")
+    {
+        std::vector<char> payload;
+        payload.push_back(0);
+        append_string(payload, "img");
+        append<int32_t>(payload, 2);
+        append_string(payload, "Y");
+        append_string(payload, "A");
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, w);
+        append<int32_t>(payload, h);
+        for (float v : plane_a) append<float>(payload, v);
+        for (float v : plane_b) append<float>(payload, v);
+
+        auto info = parse(framed(IpcPacketType::UpdateImageV2, payload)).as_update_image();
+        CHECK(info.num_channels() == 2);
+        // Plane per channel, so the second one starts a whole tile in and both step by one.
+        CHECK(info.channel_offsets == std::vector<int64_t>{0, w * h});
+        CHECK(info.channel_strides == std::vector<int64_t>{1, 1});
+        CHECK(info.data.size() == plane_a.size() + plane_b.size());
+        CHECK(info.data[size_t(info.channel_offsets[1])] == plane_b[0]);
+    }
+}
+
+TEST_CASE("Malformed IPC packets are refused rather than believed")
+{
+    // Everything here arrives over a socket from another process, so each of these is an input the parser
+    // must survive, not a case that cannot happen.
+
+    SUBCASE("a length that disagrees with the bytes present")
+    {
+        auto bytes = IpcPacket::close_image("x").bytes();
+        write_as(reinterpret_cast<unsigned char *>(bytes.data()), uint32_t(bytes.size() + 10), Endian::Little);
+        CHECK_THROWS_AS(parse(bytes), std::runtime_error);
+    }
+
+    SUBCASE("too short to hold a type at all")
+    {
+        std::vector<char> bytes(3, 0);
+        CHECK_THROWS_AS(parse(bytes), std::runtime_error);
+    }
+
+    SUBCASE("read as the wrong type")
+    {
+        auto p = parse(IpcPacket::close_image("x").bytes());
+        CHECK_THROWS_AS(p.as_update_image(), std::runtime_error);
+        CHECK_THROWS_AS(p.as_create_image(), std::runtime_error);
+    }
+
+    SUBCASE("a string with no terminator")
+    {
+        std::vector<char> payload{'n', 'a', 'm', 'e'}; // runs off the end
+        CHECK_THROWS_AS(parse(framed(IpcPacketType::CloseImage, payload)).as_close_image(), std::runtime_error);
+    }
+
+    SUBCASE("a channel count that would be an allocation attack")
+    {
+        std::vector<char> payload;
+        payload.push_back(0);
+        append_string(payload, "img");
+        append<int32_t>(payload, 1 << 30);
+        CHECK_THROWS_AS(parse(framed(IpcPacketType::UpdateImageV2, payload)).as_update_image(), std::runtime_error);
+    }
+
+    SUBCASE("a negative channel count")
+    {
+        std::vector<char> payload;
+        payload.push_back(0);
+        append_string(payload, "img");
+        append<int32_t>(payload, -1);
+        CHECK_THROWS_AS(parse(framed(IpcPacketType::UpdateImageV2, payload)).as_update_image(), std::runtime_error);
+    }
+
+    SUBCASE("negative tile dimensions")
+    {
+        std::vector<char> payload;
+        payload.push_back(0);
+        append_string(payload, "img");
+        append<int32_t>(payload, 1);
+        append_string(payload, "Y");
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, -4);
+        append<int32_t>(payload, -4);
+        CHECK_THROWS_AS(parse(framed(IpcPacketType::UpdateImageV2, payload)).as_update_image(), std::runtime_error);
+    }
+
+    SUBCASE("dimensions that overflow into a plausible pixel count")
+    {
+        std::vector<char> payload;
+        payload.push_back(0);
+        append_string(payload, "img");
+        append<int32_t>(payload, 1);
+        append_string(payload, "Y");
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 65536);
+        append<int32_t>(payload, 65536); // 2^32 pixels: wraps to 0 in 32 bits
+        CHECK_THROWS_AS(parse(framed(IpcPacketType::UpdateImageV2, payload)).as_update_image(), std::runtime_error);
+    }
+
+    SUBCASE("an offset or stride that would read outside the payload")
+    {
+        auto with = [](int64_t offset, int64_t stride)
+        {
+            std::vector<char> payload;
+            payload.push_back(0);
+            append_string(payload, "img");
+            append<int32_t>(payload, 1);
+            append_string(payload, "Y");
+            append<int32_t>(payload, 0);
+            append<int32_t>(payload, 0);
+            append<int32_t>(payload, 2);
+            append<int32_t>(payload, 2);
+            append<int64_t>(payload, offset);
+            append<int64_t>(payload, stride);
+            for (int i = 0; i < 4; ++i) append<float>(payload, 1.f);
+            return framed(IpcPacketType::UpdateImageV3, payload);
+        };
+
+        // Reaches past the four samples that follow.
+        CHECK_THROWS_AS(parse(with(0, 1000)).as_update_image(), std::runtime_error);
+        CHECK_THROWS_AS(parse(with(1000, 1)).as_update_image(), std::runtime_error);
+        // Negative addressing would index before the buffer.
+        CHECK_THROWS_AS(parse(with(-1, 1)).as_update_image(), std::runtime_error);
+        CHECK_THROWS_AS(parse(with(0, -1)).as_update_image(), std::runtime_error);
+        // Multiplying these would overflow int64 rather than exceed the payload.
+        CHECK_THROWS_AS(parse(with(0, std::numeric_limits<int64_t>::max())).as_update_image(), std::runtime_error);
+    }
+
+    SUBCASE("update data that stops short")
+    {
+        std::vector<char> payload;
+        payload.push_back(0);
+        append_string(payload, "img");
+        append<int32_t>(payload, 1);
+        append_string(payload, "Y");
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 0);
+        append<int32_t>(payload, 4);
+        append<int32_t>(payload, 4);
+        append<float>(payload, 1.f); // one sample where sixteen were promised
+        CHECK_THROWS_AS(parse(framed(IpcPacketType::UpdateImageV2, payload)).as_update_image(), std::runtime_error);
+    }
+}
+
+TEST_CASE("A byte stream is split back into the packets that were written into it")
+{
+    // What a socket actually delivers: whatever has arrived, split wherever the network chose.
+    std::vector<char> stream;
+    for (const auto &p : {IpcPacket::close_image("a"), IpcPacket::close_image("bb"), IpcPacket::close_image("ccc")})
+        stream.insert(stream.end(), p.bytes().begin(), p.bytes().end());
+
+    SUBCASE("all at once")
+    {
+        std::vector<std::string> names;
+        auto                     buffer = stream;
+        extract_ipc_packets(buffer, [&](const IpcPacket &p) { names.push_back(p.as_close_image().name); });
+
+        CHECK(names == std::vector<std::string>{"a", "bb", "ccc"});
+        CHECK(buffer.empty());
+    }
+
+    SUBCASE("one byte at a time, which is the case that exercises the buffering")
+    {
+        std::vector<std::string> names;
+        std::vector<char>        buffer;
+        for (char c : stream)
+        {
+            buffer.push_back(c);
+            extract_ipc_packets(buffer, [&](const IpcPacket &p) { names.push_back(p.as_close_image().name); });
+        }
+
+        CHECK(names == std::vector<std::string>{"a", "bb", "ccc"});
+        CHECK(buffer.empty());
+    }
+
+    SUBCASE("a trailing partial packet is kept for the next read")
+    {
+        std::vector<std::string> names;
+        auto                     buffer = stream;
+        buffer.resize(buffer.size() - 1); // cut the last packet short
+
+        extract_ipc_packets(buffer, [&](const IpcPacket &p) { names.push_back(p.as_close_image().name); });
+
+        CHECK(names == std::vector<std::string>{"a", "bb"});
+        CHECK_FALSE(buffer.empty()); // the remainder of "ccc" is still waiting
+    }
+
+    SUBCASE("an impossible length is unrecoverable, since nothing marks a packet boundary")
+    {
+        std::vector<char> buffer(sizeof(uint32_t));
+        write_as(reinterpret_cast<unsigned char *>(buffer.data()), uint32_t(2), Endian::Little);
+        CHECK_THROWS_AS(extract_ipc_packets(buffer, [](const IpcPacket &) {}), std::runtime_error);
+    }
+}

--- a/tests/test_ipc_server.cpp
+++ b/tests/test_ipc_server.cpp
@@ -1,0 +1,208 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+// Exercises the listener over a real loopback socket, which is the only way to cover what the codec tests
+// cannot: that bytes split arbitrarily by the network are reassembled into the packets that were sent, and
+// that they cross from the receive thread to the caller intact.
+
+#include <doctest/doctest.h>
+
+#include "ipc/ipc_server.h"
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+#if defined(_WIN32)
+// winsock2.h drags in windows.h, whose min/max macros would otherwise eat the std::min below.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using test_socket_t = SOCKET;
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using test_socket_t = int;
+#endif
+
+namespace
+{
+
+//! Connects to a listener on loopback, as a renderer would.
+class TestClient
+{
+public:
+    explicit TestClient(uint16_t port)
+    {
+        m_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        REQUIRE(m_socket >= 0);
+
+        sockaddr_in address{};
+        address.sin_family      = AF_INET;
+        address.sin_port        = htons(port);
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        REQUIRE(connect(m_socket, (const sockaddr *)&address, sizeof(address)) == 0);
+    }
+
+    ~TestClient()
+    {
+#if defined(_WIN32)
+        closesocket(m_socket);
+#else
+        ::close(m_socket);
+#endif
+    }
+
+    void send_all(const std::vector<char> &bytes, size_t chunk = SIZE_MAX)
+    {
+        size_t sent = 0;
+        while (sent < bytes.size())
+        {
+            const size_t n       = std::min(chunk, bytes.size() - sent);
+            const auto   written = send(m_socket, bytes.data() + sent, (int)n, 0);
+            REQUIRE(written > 0);
+            sent += size_t(written);
+        }
+    }
+
+private:
+    test_socket_t m_socket;
+};
+
+//! Collects packets as they arrive on the server's thread, and lets a test wait for a count of them.
+class Collector
+{
+public:
+    void add(std::string name)
+    {
+        {
+            std::lock_guard lock{m_mutex};
+            m_names.push_back(std::move(name));
+        }
+        m_arrived.notify_all();
+    }
+
+    //! Wait for at least `count` packets, or give up. Returns what arrived either way.
+    std::vector<std::string> wait_for(size_t count, std::chrono::milliseconds timeout = std::chrono::seconds{5})
+    {
+        std::unique_lock lock{m_mutex};
+        m_arrived.wait_for(lock, timeout, [&] { return m_names.size() >= count; });
+        return m_names;
+    }
+
+private:
+    std::mutex               m_mutex;
+    std::condition_variable  m_arrived;
+    std::vector<std::string> m_names;
+};
+
+//! Concatenated bytes of several CloseImage packets, whose only payload is a name we can check.
+std::vector<char> stream_of(const std::vector<std::string> &names)
+{
+    std::vector<char> bytes;
+    for (const auto &n : names)
+    {
+        auto packet = IpcPacket::close_image(n);
+        bytes.insert(bytes.end(), packet.bytes().begin(), packet.bytes().end());
+    }
+    return bytes;
+}
+
+} // namespace
+
+TEST_CASE("The listener receives what a client sends over loopback")
+{
+    Collector collector;
+    IpcServer server;
+
+    // Port 0 lets the OS pick a free one, so the test never fights whatever else is on this machine --
+    // including a real tev on 14158.
+    REQUIRE(server.start(0, [&](const IpcPacket &p) { collector.add(p.as_close_image().name); }));
+    REQUIRE(server.is_listening());
+    REQUIRE(server.port() != 0);
+
+    const std::vector<std::string> names{"alpha", "beta", "gamma"};
+
+    SUBCASE("sent in one write")
+    {
+        TestClient client{server.port()};
+        client.send_all(stream_of(names));
+        CHECK(collector.wait_for(names.size()) == names);
+    }
+
+    SUBCASE("dribbled a byte at a time, so no read lands on a packet boundary")
+    {
+        TestClient client{server.port()};
+        client.send_all(stream_of(names), 1);
+        CHECK(collector.wait_for(names.size()) == names);
+    }
+
+    SUBCASE("from two clients at once")
+    {
+        TestClient a{server.port()};
+        TestClient b{server.port()};
+        a.send_all(stream_of({"alpha"}));
+        b.send_all(stream_of({"beta"}));
+
+        auto got = collector.wait_for(2);
+        REQUIRE(got.size() == 2);
+        // Two connections are serviced in whichever order they become readable, so only the set is defined.
+        std::sort(got.begin(), got.end());
+        CHECK(got == std::vector<std::string>{"alpha", "beta"});
+    }
+
+    server.stop();
+    CHECK_FALSE(server.is_listening());
+}
+
+TEST_CASE("A tile survives the trip over a socket")
+{
+    // The codec tests round-trip in memory; this is the same payload through a real connection, which is
+    // where a framing mistake would show up as silently wrong pixels rather than as a parse error.
+    const Box2i                    bounds{int2{2, 3}, int2{6, 7}};
+    const std::vector<std::string> channels{"R", "G", "B"};
+    std::vector<float>             data(size_t(bounds.size().x) * bounds.size().y * 3);
+    for (size_t i = 0; i < data.size(); ++i) data[i] = float(i) * 0.25f;
+
+    std::mutex                    mutex;
+    std::condition_variable       arrived;
+    std::optional<IpcUpdateImage> received;
+
+    IpcServer server;
+    REQUIRE(server.start(0,
+                         [&](const IpcPacket &p)
+                         {
+                             std::lock_guard lock{mutex};
+                             received = p.as_update_image();
+                             arrived.notify_all();
+                         }));
+
+    {
+        TestClient client{server.port()};
+        auto       packet = IpcPacket::update_image("render", false, channels, {0, 1, 2}, {3, 3, 3}, bounds, data);
+        // In two writes, so the receiver has to hold a partial packet across reads.
+        std::vector<char> bytes = packet.bytes();
+        client.send_all({bytes.begin(), bytes.begin() + bytes.size() / 2});
+        client.send_all({bytes.begin() + bytes.size() / 2, bytes.end()});
+
+        std::unique_lock lock{mutex};
+        arrived.wait_for(lock, std::chrono::seconds{5}, [&] { return received.has_value(); });
+    }
+
+    REQUIRE(received.has_value());
+    CHECK(received->name == "render");
+    CHECK(received->bounds == bounds);
+    CHECK(received->channel_names == channels);
+    CHECK(received->data == data);
+
+    server.stop();
+}

--- a/tests/test_ipc_server.cpp
+++ b/tests/test_ipc_server.cpp
@@ -164,6 +164,41 @@ TEST_CASE("The listener receives what a client sends over loopback")
     CHECK_FALSE(server.is_listening());
 }
 
+TEST_CASE("The listener counts what it has received, for the activity readout")
+{
+    Collector collector;
+    IpcServer server;
+    REQUIRE(server.start(0, [&](const IpcPacket &p) { collector.add(p.as_close_image().name); }));
+
+    // Nothing has arrived yet, so there is no "time since the last packet" to report.
+    CHECK(server.activity().packets == 0);
+    CHECK(server.activity().bytes == 0);
+    CHECK(server.activity().seconds_since_last < 0.0);
+
+    const std::vector<std::string> names{"a", "bb", "ccc"};
+    const auto                     stream = stream_of(names);
+
+    {
+        TestClient client{server.port()};
+        client.send_all(stream);
+        REQUIRE(collector.wait_for(names.size()).size() == names.size());
+    }
+
+    const auto activity = server.activity();
+    CHECK(activity.packets == names.size());
+    // Bytes are counted off the wire, so they include each packet's length prefix and type byte.
+    CHECK(activity.bytes == stream.size());
+    CHECK(activity.seconds_since_last >= 0.0);
+
+    // Counting covers one listening session: restarting begins again from nothing.
+    server.stop();
+    REQUIRE(server.start(0, [](const IpcPacket &) {}));
+    CHECK(server.activity().packets == 0);
+    CHECK(server.activity().bytes == 0);
+    CHECK(server.activity().seconds_since_last < 0.0);
+    server.stop();
+}
+
 TEST_CASE("A tile survives the trip over a socket")
 {
     // The codec tests round-trip in memory; this is the same payload through a real connection, which is

--- a/tests/test_pixel_stats.cpp
+++ b/tests/test_pixel_stats.cpp
@@ -126,6 +126,130 @@ TEST_CASE("PixelStats::Settings::match ignores settings that only affect drawing
         b.roi = Box2i{int2{0}, int2{4}};
         CHECK_FALSE(a.match(b));
     }
+    SUBCASE("and so does the measured image's pixels having changed")
+    {
+        b.content_version = 1;
+        CHECK_FALSE(a.match(b));
+    }
+    SUBCASE("and the reference image's pixels having changed")
+    {
+        b.ref_content_version = 1;
+        CHECK_FALSE(a.match(b));
+    }
+}
+
+TEST_CASE("Channel::upload_tile writes the requested rectangle and nothing else")
+{
+    // A tile carries only its own rows; everything outside it has to survive untouched, which is what makes
+    // streaming a render bucket-by-bucket meaningful in the first place.
+    const int w = 8, h = 6;
+
+    SUBCASE("tightly packed rows")
+    {
+        Channel c        = make_identifiable_channel(w, h);
+        Channel expected = make_identifiable_channel(w, h);
+
+        const Box2i        tile{int2{2, 1}, int2{6, 4}};
+        std::vector<float> data(size_t(tile.size().x) * tile.size().y);
+        for (size_t i = 0; i < data.size(); ++i) data[i] = -1.f - float(i);
+
+        c.upload_tile(tile, data.data());
+
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x)
+            {
+                CAPTURE(x);
+                CAPTURE(y);
+                // Half-open, as upload_tile() treats it; Box::contains() would include the max edge.
+                const bool inside = x >= tile.min.x && x < tile.max.x && y >= tile.min.y && y < tile.max.y;
+                if (inside)
+                    CHECK(c(x, y) == data[size_t(y - tile.min.y) * tile.size().x + (x - tile.min.x)]);
+                else
+                    CHECK(c(x, y) == expected(x, y));
+            }
+    }
+
+    SUBCASE("strided source reads one channel out of an interleaved payload")
+    {
+        Channel c = make_identifiable_channel(w, h);
+
+        // Three channels interleaved, as a renderer would hand over an RGB tile; we want the middle one.
+        const Box2i        tile{int2{0, 0}, int2{4, 3}};
+        const int          n = 3, want = 1;
+        std::vector<float> interleaved(size_t(tile.size().x) * tile.size().y * n);
+        for (size_t i = 0; i < interleaved.size(); ++i) interleaved[i] = float(i);
+
+        c.upload_tile(tile, interleaved.data() + want, n);
+
+        for (int y = 0; y < tile.size().y; ++y)
+            for (int x = 0; x < tile.size().x; ++x)
+            {
+                CAPTURE(x);
+                CAPTURE(y);
+                CHECK(c(x, y) == interleaved[(size_t(y) * tile.size().x + x) * n + want]);
+            }
+    }
+
+    SUBCASE("a tile hanging off the edge writes only the part that lands")
+    {
+        Channel c        = make_identifiable_channel(w, h);
+        Channel expected = make_identifiable_channel(w, h);
+
+        // Straddles the right and bottom edges; rows are as wide as the *requested* tile, not the clipped one.
+        const Box2i        tile{int2{w - 2, h - 2}, int2{w + 2, h + 2}};
+        std::vector<float> data(size_t(tile.size().x) * tile.size().y);
+        for (size_t i = 0; i < data.size(); ++i) data[i] = -1.f - float(i);
+
+        c.upload_tile(tile, data.data());
+
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x)
+            {
+                CAPTURE(x);
+                CAPTURE(y);
+                if (x >= w - 2 && y >= h - 2)
+                    CHECK(c(x, y) == data[size_t(y - tile.min.y) * tile.size().x + (x - tile.min.x)]);
+                else
+                    CHECK(c(x, y) == expected(x, y));
+            }
+    }
+
+    SUBCASE("a tile entirely outside the channel is a no-op")
+    {
+        Channel c        = make_identifiable_channel(w, h);
+        Channel expected = make_identifiable_channel(w, h);
+
+        std::vector<float> data(16, -1.f);
+        c.upload_tile(Box2i{int2{w, h}, int2{w + 4, h + 4}}, data.data());
+
+        for (int y = 0; y < h; ++y)
+            for (int x = 0; x < w; ++x) CHECK(c(x, y) == expected(x, y));
+    }
+}
+
+TEST_CASE("statistics computed after a tile lands reflect the new pixels")
+{
+    // Why content has to be versioned at all: measurements taken before a tile arrived describe pixels
+    // that are gone. This measures the channel directly, so it covers the pixels moving, not the cache
+    // invalidation that Settings::match() above is responsible for.
+    const int w = 16, h = 16;
+    Channel   c("streamed", int2{w, h});
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < w; ++x) c(x, y) = 0.f;
+
+    auto before = compute(c);
+    REQUIRE(before.computed);
+    CHECK(before.summary.maximum == 0.f);
+
+    // One bucket finishes, well above everything around it.
+    const Box2i        tile{int2{4, 4}, int2{8, 8}};
+    std::vector<float> data(size_t(tile.size().x) * tile.size().y, 5.f);
+    c.upload_tile(tile, data.data());
+
+    auto after = compute(c);
+    REQUIRE(after.computed);
+    CHECK(after.summary.maximum == 5.f);
+    CHECK(after.summary.average == doctest::Approx(5.f * tile.size().x * tile.size().y / float(w * h)));
 }
 
 TEST_CASE("PixelStats::calculate takes its bin count from the channel's bit depth")

--- a/tests/test_vector_overlay.cpp
+++ b/tests/test_vector_overlay.cpp
@@ -1,0 +1,282 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+// The overlay interpreter, driven against a real ImDrawList and checked on the geometry it produces.
+// ImDrawList works without an ImGui context, so this needs no window and no graphics API -- which is what
+// makes the drawing itself testable rather than only inspectable in a screenshot.
+
+#include <doctest/doctest.h>
+
+#include "vector_overlay.h"
+
+#include "imgui.h"
+#include "imgui_internal.h"
+
+#include <algorithm>
+
+namespace
+{
+
+//! A draw list with just enough shared state to tessellate and emit geometry.
+struct TestDrawList
+{
+    ImDrawListSharedData shared;
+    ImDrawList           list;
+
+    TestDrawList() : list(&shared)
+    {
+        shared.ClipRectFullscreen   = ImVec4(-8192.f, -8192.f, 8192.f, 8192.f);
+        shared.CurveTessellationTol = 1.25f;
+        // No anti-aliasing, so a vertex count reflects the path itself rather than the AA fringe around it.
+        shared.InitialFlags = ImDrawListFlags_None;
+        shared.SetCircleTessellationMaxError(0.30f);
+
+        // What ImGui does to a draw list at the top of each frame; without it the command buffer is empty
+        // and the first PushClipRect has no command to amend.
+        list._ResetForNewFrame();
+        list.PushClipRectFullScreen();
+    }
+};
+
+//! Identity image-to-screen mapping, so expected coordinates are the ones the commands name.
+VgTransform identity_transform()
+{
+    VgTransform x;
+    x.to_screen = [](float2 p) { return p; };
+    x.scale     = 1.f;
+    return x;
+}
+
+//! Axis-aligned bounds of everything written into the vertex buffer.
+struct Bounds
+{
+    float min_x = FLT_MAX, min_y = FLT_MAX, max_x = -FLT_MAX, max_y = -FLT_MAX;
+    bool  empty() const { return min_x > max_x; }
+};
+
+Bounds vertex_bounds(const ImDrawList &list)
+{
+    Bounds b;
+    for (int i = 0; i < list.VtxBuffer.Size; ++i)
+    {
+        const ImVec2 p = list.VtxBuffer[i].pos;
+        b.min_x        = std::min(b.min_x, p.x);
+        b.min_y        = std::min(b.min_y, p.y);
+        b.max_x        = std::max(b.max_x, p.x);
+        b.max_y        = std::max(b.max_y, p.y);
+    }
+    return b;
+}
+
+VgCommand cmd(VgCommand::Type type, std::vector<float> data = {}) { return VgCommand{type, std::move(data), ""}; }
+
+} // namespace
+
+TEST_CASE("A stroked rectangle lands where the commands put it")
+{
+    TestDrawList d;
+
+    // The shape the official tevclient example draws around each finished tile.
+    draw_vector_overlay(&d.list,
+                        {
+                            cmd(VgCommand::Type::BeginPath),
+                            cmd(VgCommand::Type::StrokeColor, {1.f, 1.f, 1.f, 1.f}),
+                            cmd(VgCommand::Type::StrokeWidth, {2.f, float(VgCommand::Absolute)}),
+                            cmd(VgCommand::Type::Rect, {10.f, 20.f, 100.f, 50.f}),
+                            cmd(VgCommand::Type::Stroke),
+                        },
+                        identity_transform(), IM_COL32_WHITE);
+
+    REQUIRE(d.list.VtxBuffer.Size > 0);
+    const auto b = vertex_bounds(d.list);
+
+    // The stroke straddles the path, so with anti-aliasing off the geometry is exactly half a line width
+    // outside the rectangle on every side: [10,110]x[20,70] grown by 1.
+    CHECK(b.min_x == doctest::Approx(9.f).epsilon(0.01f));
+    CHECK(b.min_y == doctest::Approx(19.f).epsilon(0.01f));
+    CHECK(b.max_x == doctest::Approx(111.f).epsilon(0.01f));
+    CHECK(b.max_y == doctest::Approx(71.f).epsilon(0.01f));
+}
+
+TEST_CASE("Relative sizes scale with the image, absolute ones do not")
+{
+    // A stroke flagged Relative is in image pixels and so has to get thicker as the view zooms in; one
+    // flagged Absolute is in screen pixels and must not. Zoom is the only difference between these two.
+    auto stroked_line = [](float scale, VgCommand::ScaleKind kind)
+    {
+        TestDrawList d;
+        VgTransform  x = identity_transform();
+        x.scale        = scale;
+        draw_vector_overlay(&d.list,
+                            {
+                                cmd(VgCommand::Type::BeginPath),
+                                cmd(VgCommand::Type::StrokeWidth, {4.f, float(kind)}),
+                                cmd(VgCommand::Type::MoveTo, {0.f, 50.f}),
+                                cmd(VgCommand::Type::LineTo, {100.f, 50.f}),
+                                cmd(VgCommand::Type::Stroke),
+                            },
+                            x, IM_COL32_WHITE);
+        const auto b = vertex_bounds(d.list);
+        return b.max_y - b.min_y; // the drawn thickness
+    };
+
+    CHECK(stroked_line(1.f, VgCommand::Relative) == doctest::Approx(4.f).epsilon(0.05f));
+    CHECK(stroked_line(4.f, VgCommand::Relative) == doctest::Approx(16.f).epsilon(0.05f));
+
+    CHECK(stroked_line(1.f, VgCommand::Absolute) == doctest::Approx(4.f).epsilon(0.05f));
+    CHECK(stroked_line(4.f, VgCommand::Absolute) == doctest::Approx(4.f).epsilon(0.05f));
+}
+
+TEST_CASE("A filled circle covers its radius")
+{
+    TestDrawList d;
+    draw_vector_overlay(&d.list,
+                        {
+                            cmd(VgCommand::Type::FillColor, {1.f, 0.f, 0.f, 1.f}),
+                            cmd(VgCommand::Type::BeginPath),
+                            cmd(VgCommand::Type::Circle, {100.f, 100.f, 40.f}),
+                            cmd(VgCommand::Type::Fill),
+                        },
+                        identity_transform(), IM_COL32_WHITE);
+
+    REQUIRE(d.list.VtxBuffer.Size >= 3);
+    const auto b = vertex_bounds(d.list);
+    // The polygon is inscribed, so it falls just inside the true circle -- by less than the tessellation
+    // error the segment count was chosen for, which is well under a pixel.
+    CHECK(b.min_x == doctest::Approx(60.f).epsilon(0.005f));
+    CHECK(b.max_x == doctest::Approx(140.f).epsilon(0.005f));
+    CHECK(b.min_y == doctest::Approx(60.f).epsilon(0.005f));
+    CHECK(b.max_y == doctest::Approx(140.f).epsilon(0.005f));
+}
+
+TEST_CASE("Each subpath is drawn, not just the last one")
+{
+    // NanoVG accumulates subpaths and paints them together; ImDrawList has one path buffer, so this is the
+    // case that would silently drop everything but the final MoveTo run if the staging were wrong.
+    TestDrawList one, two;
+
+    const auto square = [](float x)
+    {
+        return std::vector<VgCommand>{
+            cmd(VgCommand::Type::MoveTo, {x, 0.f}),
+            cmd(VgCommand::Type::LineTo, {x + 10.f, 0.f}),
+            cmd(VgCommand::Type::LineTo, {x + 10.f, 10.f}),
+            cmd(VgCommand::Type::ClosePath),
+        };
+    };
+
+    std::vector<VgCommand> single{cmd(VgCommand::Type::BeginPath)};
+    for (auto &c : square(0.f)) single.push_back(c);
+    single.push_back(cmd(VgCommand::Type::Stroke));
+
+    std::vector<VgCommand> pair{cmd(VgCommand::Type::BeginPath)};
+    for (auto &c : square(0.f)) pair.push_back(c);
+    for (auto &c : square(100.f)) pair.push_back(c);
+    pair.push_back(cmd(VgCommand::Type::Stroke));
+
+    draw_vector_overlay(&one.list, single, identity_transform(), IM_COL32_WHITE);
+    draw_vector_overlay(&two.list, pair, identity_transform(), IM_COL32_WHITE);
+
+    CHECK(two.list.VtxBuffer.Size == 2 * one.list.VtxBuffer.Size);
+    // ...and the second subpath is actually out at x=100, not collapsed onto the first.
+    CHECK(vertex_bounds(two.list).max_x == doctest::Approx(110.f).epsilon(0.1f));
+}
+
+TEST_CASE("A path can be filled and then stroked, as NanoVG allows")
+{
+    // Only BeginPath discards the path; painting it does not. A viewer that cleared on Fill would drop the
+    // outline that a client expects to follow it.
+    TestDrawList fill_only, fill_then_stroke;
+
+    const std::vector<VgCommand> shape{
+        cmd(VgCommand::Type::BeginPath),
+        cmd(VgCommand::Type::Rect, {0.f, 0.f, 50.f, 50.f}),
+        cmd(VgCommand::Type::Fill),
+    };
+    std::vector<VgCommand> both = shape;
+    both.push_back(cmd(VgCommand::Type::Stroke));
+
+    draw_vector_overlay(&fill_only.list, shape, identity_transform(), IM_COL32_WHITE);
+    draw_vector_overlay(&fill_then_stroke.list, both, identity_transform(), IM_COL32_WHITE);
+
+    CHECK(fill_then_stroke.list.VtxBuffer.Size > fill_only.list.VtxBuffer.Size);
+}
+
+TEST_CASE("Save and Restore bracket changes to the drawing state")
+{
+    // Restore has to put back the width Save captured; without it the second line would come out thick.
+    TestDrawList d;
+    draw_vector_overlay(&d.list,
+                        {
+                            cmd(VgCommand::Type::StrokeWidth, {2.f, float(VgCommand::Absolute)}),
+                            cmd(VgCommand::Type::Save),
+                            cmd(VgCommand::Type::StrokeWidth, {20.f, float(VgCommand::Absolute)}),
+                            cmd(VgCommand::Type::Restore),
+                            cmd(VgCommand::Type::BeginPath),
+                            cmd(VgCommand::Type::MoveTo, {0.f, 50.f}),
+                            cmd(VgCommand::Type::LineTo, {100.f, 50.f}),
+                            cmd(VgCommand::Type::Stroke),
+                        },
+                        identity_transform(), IM_COL32_WHITE);
+
+    const auto b = vertex_bounds(d.list);
+    CHECK((b.max_y - b.min_y) == doctest::Approx(2.f).epsilon(0.05f));
+}
+
+TEST_CASE("Commands HDRView cannot draw are reported rather than approximated")
+{
+    TestDrawList             d;
+    std::vector<std::string> reported;
+
+    draw_vector_overlay(&d.list,
+                        {
+                            cmd(VgCommand::Type::PathWinding, {1.f}),
+                            cmd(VgCommand::Type::ArcTo, {0.f, 0.f, 1.f, 1.f, 5.f}),
+                            cmd(VgCommand::Type::RoundedRectVarying, {0, 0, 10, 10, 1, 2, 3, 4}),
+                        },
+                        identity_transform(), IM_COL32_WHITE,
+                        [&reported](const char *what) { reported.push_back(what); });
+
+    CHECK(reported.size() == 3);
+    CHECK(d.list.VtxBuffer.Size == 0); // nothing was drawn in their place
+}
+
+TEST_CASE("A command carrying the wrong number of arguments is skipped, not read past")
+{
+    // The interpreter is fed by a network parser, so a command whose data does not match its type has to be
+    // survivable rather than indexed into.
+    TestDrawList             d;
+    std::vector<std::string> reported;
+
+    draw_vector_overlay(&d.list,
+                        {
+                            VgCommand{VgCommand::Type::Rect, {1.f}, ""}, // wants four floats
+                            cmd(VgCommand::Type::BeginPath),
+                            cmd(VgCommand::Type::Rect, {0.f, 0.f, 10.f, 10.f}),
+                            cmd(VgCommand::Type::Stroke),
+                        },
+                        identity_transform(), IM_COL32_WHITE,
+                        [&reported](const char *what) { reported.push_back(what); });
+
+    CHECK(reported.size() == 1);
+    CHECK(d.list.VtxBuffer.Size > 0); // the well-formed commands after it still drew
+}
+
+TEST_CASE("An overlay leaves the draw list's shared path buffer empty")
+{
+    // The path buffer is scratch space shared with everything else drawing this frame; leaving points in it
+    // would corrupt whatever primitive came next.
+    TestDrawList d;
+    draw_vector_overlay(&d.list,
+                        {
+                            cmd(VgCommand::Type::BeginPath), cmd(VgCommand::Type::MoveTo, {0.f, 0.f}),
+                            cmd(VgCommand::Type::LineTo, {10.f, 10.f}),
+                            // deliberately left unpainted and unclosed
+                        },
+                        identity_transform(), IM_COL32_WHITE);
+
+    CHECK(d.list._Path.Size == 0);
+}


### PR DESCRIPTION
Lets a renderer push pixels into HDRView while it is still producing them, a tile at a time, over the protocol tev uses — so the clients that already exist for it work unchanged. Off until you turn it on, from the Watched Folders panel, the command palette, or `--listen`.

Verified end to end against **pbrt-v4** (`pbrt --display-server 127.0.0.1:14158`): the render arrives tile by tile, and HDRView's channel statistics match the EXR pbrt wrote independently to six digits, via pbrt's own `imgtool`. The small max-value differences run the right way — the file is Half, the IPC stream is float32, so HDRView holds the more precise values.

### Five commits, deliberately separable

Each builds and passes on its own.

1. **`edae3e3`** — the streaming core (163 tests)
2. **`2beaf4f`** — activity readout
3. **`42530d6`** — removes an unused, and wrong, `human_readable_size()`
4. **`7082af6`** — command palette integration
5. **`0b297ef`** — vector graphics overlays *(drop this commit and the rest is untouched)*

### Why the core touches the image model

Images were built assuming pixels never change after loading. That shows up in exactly two places rather than diffused through the codebase:

- **Nothing could mutate an image from another thread.** `HDRViewApp` gains a main-thread work queue, drained once per frame beside the existing background-load drain.
- **The statistics cache was keyed only on how an image is looked at, never on its contents**, so a streamed image would keep reporting measurements of pixels that were gone. `Image::content_version` now goes into `PixelStats::Settings`. A newer version is adopted only once the cache has stood as a *finished* result for 200 ms — a renderer changes pixels faster than a full pass completes, and chasing every change would cancel each computation partway and show no histogram at all.

Everything else was additive. `Texture::upload_sub_region()` already existed on both backends and was unused; `Channel::upload_tile()` is built on it. Channel textures moved to manual mipmapping with the chain rebuilt once per draw, since otherwise every tile would rebuild it per channel. Update payloads keep the sender's interleaved layout and are addressed by stride rather than deinterleaved — no tile is copied twice.

### Activity, not progress

The panel shows an indeterminate bar with the live rate and running totals. Deliberately **not** a progress bar: the protocol carries no notion of how much is left, and the two ways clients stream are indistinguishable from the packets — a bucket renderer paints each tile once, while pbrt walks the whole frame every 250 ms and resends what changed. Coverage would read "finished" almost immediately for pbrt, and any percentage would be invented.

### Provenance

An independent reimplementation of the format tev documents, not a port of its code. The packet layout matches byte for byte so existing clients work; the implementation shares nothing with tev's, which draws overlays through NanoVG where this targets Dear ImGui's draw lists.

### Safety

Everything the parser reads arrives unprompted from another process, so every count, offset and stride is checked against the bytes present, with overflow-checked arithmetic and negative addressing refused. There's a libFuzzer target alongside the existing loader fuzzers. The listener binds loopback only; extending that is a deliberate decision left for later, noted in the class comment.

### Verification

175 tests, including malformed-packet cases, real-loopback-socket tests, and headless geometry assertions for the overlay interpreter driven against a real `ImDrawList`. `HDRVIEW_ENABLE_IPC=OFF` also builds clean (157 tests) and is forced off under Emscripten, which has no raw sockets.

### Known gaps

- `update_stats()`'s cache-and-throttle path has no unit coverage — it reads the `hdrview()` singleton, so `hdrview_tests` cannot drive it. The invalidation *rule* is covered via `Settings::match`, and the behavior end to end.
- **Built and run on Linux only.** The socket code is written for Windows and macOS but exercised on neither.
- The command palette entries were confirmed by hand, not by an automated GUI test.

### On the overlay commit

Built after checking who sends these: the C++ and Python `tevclient` libraries both expose the command, the Rust one does not, pbrt-v4 sends raster only, and Mitsuba does not speak this protocol at all. No *renderer* emits them today, so the audience is someone writing a debug overlay with one of those two libraries.

`PathWinding`, `ArcTo`'s tangent form and `RoundedRectVarying` have no `ImDrawList` equivalent and are reported rather than approximated — a diagnostic overlay that quietly draws something other than what was asked for is worse than one with a gap in it. It reaches the rest of the app through one member on `Image` and one call in the draw loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)