### PR TITLE
Bring back multi-selection, over (image, channel group) pairs

### DIFF
--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -220,7 +220,7 @@ void HDRViewApp::draw_edit_command_dialog(EditCommand &cmd, bool &open)
 
         cmd.draw(ctx);
 
-        if (info.has_subject)
+        if (info.draws_subject_selector)
             draw_edit_subject_selector();
 
         // Applied on confirm rather than as the controls move: an edit per frame of a drag would fill the

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -120,8 +120,8 @@ std::vector<int> HDRViewApp::target_groups(const ConstImagePtr &img, int pointed
     if (pointed_at >= 0 && !img->is_group_selected(pointed_at))
         return {pointed_at};
 
-    // The current group is always among the selected ones, so the fallback is for an image that has not
-    // been through the panel at all -- a freshly built one, or a test driving a command directly.
+    // The current target is always selected, so the fallback is for an image the panel has never had a
+    // say over -- one a command has just produced, or a test driving a command directly.
     std::vector<int> groups = img->selected_groups();
     if (groups.empty() && img->is_valid_group(img->active_group_index(Target_Primary)))
         groups.push_back(img->active_group_index(Target_Primary));

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -42,17 +42,13 @@ struct AppEditContext final : EditContext
     //! over the selection; see HDRViewApp::apply_edit_command().
     ImagePtr img;
 
-    explicit AppEditContext(HDRViewApp *a) : app(a), img(a->current_image()) {}
+    explicit AppEditContext(HDRViewApp *a) : app(a), img(a->target_image()) {}
     AppEditContext(HDRViewApp *a, ImagePtr i) : app(a), img(std::move(i)) {}
 
     ImagePtr           image() const override { return img; }
     const EditSubject &subject() const override { return app->edit_subject(); }
 
-    // Both name groups of the *current* image. Only the commands that take no subject ask -- ungrouping,
-    // regrouping, deleting a group -- and those never fan out, so `img` is the current image whenever
-    // these are read.
-    int              target_group() const override { return app->target_group(); }
-    std::vector<int> target_groups() const override { return app->target_groups(); }
+    std::vector<int> target_groups() const override { return app->target_groups(img); }
     Box2i            selection() const override { return app->roi(); }
     void             set_selection(const Box2i &box) override { app->set_selection(box); }
     float4           background_color() const override { return app->background_color(); }
@@ -104,53 +100,71 @@ struct AppEditContext final : EditContext
 
 } // namespace
 
-int HDRViewApp::target_group() const
-{
-    if (m_target_group_override >= 0)
-        return m_target_group_override;
+ImagePtr HDRViewApp::target_image() { return m_target_image_override ? m_target_image_override : current_image(); }
 
-    auto img = current_image();
-    return img ? img->active_group_index(Target_Primary) : -1;
+std::vector<int> HDRViewApp::target_groups(const ConstImagePtr &img) const
+{
+    // The override names a group of one image, and every image numbers its own groups -- so it says
+    // nothing about the others a fan-out reaches.
+    return target_groups(img, img == m_target_image_override ? m_target_group_override : -1);
 }
 
-std::vector<int> HDRViewApp::target_groups() const
+std::vector<int> HDRViewApp::target_groups(const ConstImagePtr &img, int pointed_at) const
 {
-    if (m_target_group_override >= 0)
-        return {m_target_group_override};
-
-    auto img = current_image();
     if (!img)
         return {};
+
+    // A group pointed at from the Images panel names itself alone -- unless it is one of the selected
+    // ones, in which case the right-click covers the selection, the same way a click inside a selection
+    // keeps it rather than replacing it.
+    if (pointed_at >= 0 && !img->is_group_selected(pointed_at))
+        return {pointed_at};
 
     // The current group is always among the selected ones, so the fallback is for an image that has not
     // been through the panel at all -- a freshly built one, or a test driving a command directly.
     std::vector<int> groups = img->selected_groups();
-    if (groups.empty() && img->is_valid_group(target_group()))
-        groups.push_back(target_group());
+    if (groups.empty() && img->is_valid_group(img->active_group_index(Target_Primary)))
+        groups.push_back(img->active_group_index(Target_Primary));
 
     return groups;
 }
 
-void HDRViewApp::invoke_action_on_group(const string &action_name, int group)
+void HDRViewApp::with_target_group(int image_index, int group, const std::function<void()> &body)
 {
-    // Restored however the action leaves, since pointing at a group must not move the selection -- and an
-    // action that removes the group would otherwise leave the override naming one that is gone.
-    const int previous      = m_target_group_override;
-    m_target_group_override = group;
-    action(action_name).callback();
-    m_target_group_override = previous;
+    // Restored however `body` leaves things, since pointing at a group must not move the selection -- and
+    // an action that removes the group would otherwise leave the override naming one that is gone.
+    auto      previous_image = m_target_image_override;
+    const int previous_group = m_target_group_override;
+
+    m_target_image_override = image(image_index);
+    m_target_group_override = m_target_image_override ? group : -1;
+    body();
+    m_target_image_override = previous_image;
+    m_target_group_override = previous_group;
+}
+
+void HDRViewApp::invoke_action_on_group(const string &action_name, int image_index, int group)
+{
+    with_target_group(image_index, group, [this, &action_name] { action(action_name).callback(); });
 }
 
 std::vector<ImagePtr> HDRViewApp::edit_command_images(const EditCommand &cmd)
 {
+    // A group pointed at from the Images panel names one group of one image, which need not be the
+    // current one -- every image's groups are listed. That image is what the command runs on, alone,
+    // unless the group is part of the selection, in which case the right-click covers the selection.
+    if (m_target_image_override)
+    {
+        if (!cmd.info().fans_out || !m_target_image_override->is_group_selected(m_target_group_override))
+            return {m_target_image_override};
+        return selected_images();
+    }
+
     auto current = current_image();
     if (!current)
         return {};
 
-    // An edit with no subject covers the image entire, and one that reads or writes the clipboard has a
-    // single result -- neither has anything in it that names one selected image over another. Pointing at
-    // a group from the Images panel likewise names one group of one image, whatever else is selected.
-    if (!cmd.info().has_subject || !cmd.info().fans_out || m_target_group_override >= 0)
+    if (!cmd.info().fans_out)
         return {current};
 
     return selected_images();
@@ -182,7 +196,7 @@ void HDRViewApp::invoke_edit_command(EditCommand &cmd)
 bool HDRViewApp::edit_command_enabled(const EditCommand &cmd)
 {
     AppEditContext ctx{this};
-    if (cmd.info().needs_editable && !can_edit(current_image()))
+    if (cmd.info().needs_editable && !can_edit(target_image()))
         return false;
     return cmd.enabled(ctx);
 }

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -406,7 +406,13 @@ bool HDRViewApp::modify_colors(const ImagePtr &img, const string &name, const Ed
 
     auto [groups, channels] = subject_color_groups(*img, subject);
     if (groups.empty())
+    {
+        // "Apply to" can name a set of groups holding no color at all -- an ungrouped image, two depth
+        // passes -- and a color operation then has nothing to do. Said out loud, because the alternative
+        // is a menu item that appears to work and does nothing.
+        spdlog::warn("'{}' covers no color channel group of '{}'.", name, img->file_and_partname());
         return false;
+    }
 
     Box2i bounds = img->data_window;
     if (subject.selection_only && m_roi.has_volume())
@@ -482,7 +488,10 @@ bool HDRViewApp::modify_neighborhood(const ImagePtr &img, const string &name, co
 
     auto [groups, channels] = subject_color_groups(*img, subject);
     if (groups.empty())
+    {
+        spdlog::warn("'{}' covers no color channel group of '{}'.", name, img->file_and_partname());
         return false;
+    }
 
     Box2i bounds = img->data_window;
     if (subject.selection_only && m_roi.has_volume())

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -175,8 +175,13 @@ void HDRViewApp::apply_edit_command(EditCommand &cmd)
     // One context per image, and one call of apply() per image, so each lands as its own undo entry --
     // there is no cross-image entry to reverse, and an image that refuses the edit does not take the
     // others down with it.
+    //
+    // Each starts from the same selection: cropping clears it, having just made it the whole image, and
+    // every image after the first would otherwise find nothing to crop to.
+    const Box2i roi = m_roi;
     for (const auto &img : edit_command_images(cmd))
     {
+        m_roi = roi;
         AppEditContext ctx{this, img};
         cmd.apply(ctx);
     }

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -43,6 +43,7 @@ struct AppEditContext final : EditContext
     ImagePtr           image() const override { return app->current_image(); }
     const EditSubject &subject() const override { return app->edit_subject(); }
     int                target_group() const override { return app->target_group(); }
+    std::vector<int>   target_groups() const override { return app->target_groups(); }
     Box2i              selection() const override { return app->roi(); }
     void               set_selection(const Box2i &box) override { app->set_selection(box); }
     float4             background_color() const override { return app->background_color(); }
@@ -101,6 +102,24 @@ int HDRViewApp::target_group() const
 
     auto img = current_image();
     return img ? img->active_group_index(Target_Primary) : -1;
+}
+
+std::vector<int> HDRViewApp::target_groups() const
+{
+    if (m_target_group_override >= 0)
+        return {m_target_group_override};
+
+    auto img = current_image();
+    if (!img)
+        return {};
+
+    // The current group is always among the selected ones, so the fallback is for an image that has not
+    // been through the panel at all -- a freshly built one, or a test driving a command directly.
+    std::vector<int> groups = img->selected_groups();
+    if (groups.empty() && img->is_valid_group(target_group()))
+        groups.push_back(target_group());
+
+    return groups;
 }
 
 void HDRViewApp::invoke_action_on_group(const string &action_name, int group)
@@ -264,28 +283,50 @@ bool HDRViewApp::modify_channels(const ImagePtr &img, const string &name, const 
         { return std::make_unique<ChannelRectUndo>(image, channels, bounds, name); });
 }
 
-namespace
-{
-
-//! The color groups \p subject covers, and every channel of them.
-/*!
-    Only RGB and RGBA: everything else in an image -- depth, motion vectors, an ID -- is not color, and a
-    color operation has no meaning for it, so it is left alone rather than run through one.
-*/
-std::pair<std::vector<int>, std::vector<int>> resolve_color_groups(const ConstImagePtr &img, const EditSubject &subject)
+//! The groups \p subject's scope names, before any filtering by what they contain.
+static std::vector<int> subject_groups(const Image &img, const EditSubject &subject)
 {
     std::vector<int> groups;
     if (subject.scope == EditSubject::Scope_AllChannels)
     {
-        for (int g = 0; g < int(img->groups.size()); ++g) groups.push_back(g);
+        for (int g = 0; g < int(img.groups.size()); ++g) groups.push_back(g);
     }
-    else if (int g = img->active_group_index(Target_Primary); img->is_valid_group(g))
+    else if (subject.scope == EditSubject::Scope_SelectedGroups)
+        groups = img.selected_groups();
+    else if (int g = img.active_group_index(Target_Primary); img.is_valid_group(g))
         groups.push_back(g);
+
+    return groups;
+}
+
+std::vector<int> subject_channels(const Image &img, const EditSubject &subject)
+{
+    // Every channel, rather than the union of every group's, so that a channel belonging to no group is
+    // still covered by "all channels".
+    if (subject.scope == EditSubject::Scope_AllChannels)
+    {
+        std::vector<int> channels(img.channels.size());
+        std::iota(channels.begin(), channels.end(), 0);
+        return channels;
+    }
+
+    std::vector<int> channels;
+    for (int g : subject_groups(img, subject))
+    {
+        const auto &group = img.groups[size_t(g)];
+        for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
+    }
+    return channels;
+}
+
+std::pair<std::vector<int>, std::vector<int>> subject_color_groups(const Image &img, const EditSubject &subject)
+{
+    std::vector<int> groups = subject_groups(img, subject);
 
     groups.erase(std::remove_if(groups.begin(), groups.end(),
                                 [&img](int g)
                                 {
-                                    const auto t = img->groups[size_t(g)].type;
+                                    const auto t = img.groups[size_t(g)].type;
                                     return t != ChannelGroup::RGB_Channels && t != ChannelGroup::RGBA_Channels;
                                 }),
                  groups.end());
@@ -294,14 +335,12 @@ std::pair<std::vector<int>, std::vector<int>> resolve_color_groups(const ConstIm
     std::vector<int> channels;
     for (int g : groups)
     {
-        const auto &group = img->groups[size_t(g)];
+        const auto &group = img.groups[size_t(g)];
         for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
     }
 
     return {groups, channels};
 }
-
-} // namespace
 
 bool HDRViewApp::modify_colors(const ImagePtr &img, const string &name, const EditSubject &subject,
                                const function<float4(const float4 &, int2)> &op, const function<void(Image &)> &retag)
@@ -309,7 +348,7 @@ bool HDRViewApp::modify_colors(const ImagePtr &img, const string &name, const Ed
     if (!can_edit(img))
         return false;
 
-    auto [groups, channels] = resolve_color_groups(img, subject);
+    auto [groups, channels] = subject_color_groups(*img, subject);
     if (groups.empty())
         return false;
 
@@ -385,7 +424,7 @@ bool HDRViewApp::modify_neighborhood(const ImagePtr &img, const string &name, co
     if (!can_edit(img))
         return false;
 
-    auto [groups, channels] = resolve_color_groups(img, subject);
+    auto [groups, channels] = subject_color_groups(*img, subject);
     if (groups.empty())
         return false;
 
@@ -532,28 +571,18 @@ void HDRViewApp::close_all_images()
 
 bool HDRViewApp::scope_matters(const ConstImagePtr &img)
 {
-    // With one group, "the group the viewport is showing" and "every channel" are the same set, so there
-    // is nothing for the user to decide.
+    // With one group, every scope names the same channels -- the group on screen is the selection is the
+    // whole image -- so there is nothing for the user to decide.
     return img && img->groups.size() > 1;
 }
 
 std::pair<std::vector<int>, Box2i> HDRViewApp::resolve_subject(const ConstImagePtr &img,
                                                                const EditSubject   &subject) const
 {
-    std::vector<int> channels;
     if (!img)
-        return {channels, Box2i{}};
+        return {std::vector<int>{}, Box2i{}};
 
-    if (subject.scope == EditSubject::Scope_AllChannels)
-    {
-        channels.resize(img->channels.size());
-        std::iota(channels.begin(), channels.end(), 0);
-    }
-    else if (int g = img->active_group_index(Target_Primary); img->is_valid_group(g))
-    {
-        const auto &group = img->groups[size_t(g)];
-        for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
-    }
+    std::vector<int> channels = subject_channels(*img, subject);
 
     Box2i bounds = img->data_window;
     // An empty selection means "no selection", not "select nothing" -- leaving the box on should not make
@@ -663,7 +692,7 @@ void HDRViewApp::draw_edit_subject_selector()
         if (ImGui::RadioButton(edit_scope_name(i), m_edit_subject.scope == i))
             m_edit_subject.scope = EditSubject::Scope(i);
     if (!matters && img)
-        ImGui::Tooltip("This image has a single channel group, so both choices cover the same channels.");
+        ImGui::Tooltip("This image has a single channel group, so all three choices cover the same channels.");
 
     ImGui::Checkbox("Selection only", &m_edit_subject.selection_only);
     if (!m_roi.has_volume())

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -38,54 +38,63 @@ struct AppEditContext final : EditContext
 {
     HDRViewApp *app;
 
-    explicit AppEditContext(HDRViewApp *a) : app(a) {}
+    //! The image this run of the command is against, which is the current one unless it is fanning out
+    //! over the selection; see HDRViewApp::apply_edit_command().
+    ImagePtr img;
 
-    ImagePtr           image() const override { return app->current_image(); }
+    explicit AppEditContext(HDRViewApp *a) : app(a), img(a->current_image()) {}
+    AppEditContext(HDRViewApp *a, ImagePtr i) : app(a), img(std::move(i)) {}
+
+    ImagePtr           image() const override { return img; }
     const EditSubject &subject() const override { return app->edit_subject(); }
-    int                target_group() const override { return app->target_group(); }
-    std::vector<int>   target_groups() const override { return app->target_groups(); }
-    Box2i              selection() const override { return app->roi(); }
-    void               set_selection(const Box2i &box) override { app->set_selection(box); }
-    float4             background_color() const override { return app->background_color(); }
-    ConstImagePtr      clipboard() const override { return app->clipboard(); }
-    void               set_clipboard(ImagePtr img) override { app->set_clipboard(std::move(img)); }
+
+    // Both name groups of the *current* image. Only the commands that take no subject ask -- ungrouping,
+    // regrouping, deleting a group -- and those never fan out, so `img` is the current image whenever
+    // these are read.
+    int              target_group() const override { return app->target_group(); }
+    std::vector<int> target_groups() const override { return app->target_groups(); }
+    Box2i            selection() const override { return app->roi(); }
+    void             set_selection(const Box2i &box) override { app->set_selection(box); }
+    float4           background_color() const override { return app->background_color(); }
+    ConstImagePtr    clipboard() const override { return app->clipboard(); }
+    void             set_clipboard(ImagePtr img) override { app->set_clipboard(std::move(img)); }
 
     bool modify_pixels(const string &name, const function<float(float, int2, int)> &op) override
     {
-        return app->modify_pixels(app->current_image(), name, app->edit_subject(), op);
+        return app->modify_pixels(img, name, app->edit_subject(), op);
     }
     bool modify_colors(const string &name, const function<float4(const float4 &, int2)> &op,
                        const function<void(Image &)> &retag) override
     {
-        return app->modify_colors(app->current_image(), name, app->edit_subject(), op, retag);
+        return app->modify_colors(img, name, app->edit_subject(), op, retag);
     }
     bool modify_neighborhood(const string &name, const function<float4(const function<float4(int2)> &, int2)> &op,
                              int border_x, int border_y) override
     {
-        return app->modify_neighborhood(app->current_image(), name, app->edit_subject(), op, border_x, border_y);
+        return app->modify_neighborhood(img, name, app->edit_subject(), op, border_x, border_y);
     }
     bool modify_channels(const string &name, const function<Array2Df(const Array2Df &, const Box2i &)> &filter) override
     {
-        return app->modify_channels(app->current_image(), name, app->edit_subject(), filter);
+        return app->modify_channels(img, name, app->edit_subject(), filter);
     }
     void modify_channels_async(
         const string &name, const function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &f) override
     {
-        app->modify_channels_async(app->current_image(), name, app->edit_subject(), f);
+        app->modify_channels_async(img, name, app->edit_subject(), f);
     }
     void modify_image_async(const string &name, int2 size,
                             const function<Array2Df(const Array2Df &, AtomicProgress)> &op) override
     {
-        app->modify_image_async(app->current_image(), name, size, op);
+        app->modify_image_async(img, name, size, op);
     }
     bool modify_structure(const string &name, const function<void(Image &)> &op) override
     {
-        return app->modify_structure(app->current_image(), name, op);
+        return app->modify_structure(img, name, op);
     }
     bool modify_reversibly(const string &name, const function<void(Image &)> &forward,
                            const function<void(Image &)> &backward) override
     {
-        return app->modify_image_reversibly(app->current_image(), name, forward, backward);
+        return app->modify_image_reversibly(img, name, forward, backward);
     }
 
     void add_image(ImagePtr img, const std::string &partname) override { app->add_image_beside_current(img, partname); }
@@ -132,6 +141,33 @@ void HDRViewApp::invoke_action_on_group(const string &action_name, int group)
     m_target_group_override = previous;
 }
 
+std::vector<ImagePtr> HDRViewApp::edit_command_images(const EditCommand &cmd)
+{
+    auto current = current_image();
+    if (!current)
+        return {};
+
+    // An edit with no subject covers the image entire, and one that reads or writes the clipboard has a
+    // single result -- neither has anything in it that names one selected image over another. Pointing at
+    // a group from the Images panel likewise names one group of one image, whatever else is selected.
+    if (!cmd.info().has_subject || !cmd.info().fans_out || m_target_group_override >= 0)
+        return {current};
+
+    return selected_images();
+}
+
+void HDRViewApp::apply_edit_command(EditCommand &cmd)
+{
+    // One context per image, and one call of apply() per image, so each lands as its own undo entry --
+    // there is no cross-image entry to reverse, and an image that refuses the edit does not take the
+    // others down with it.
+    for (const auto &img : edit_command_images(cmd))
+    {
+        AppEditContext ctx{this, img};
+        cmd.apply(ctx);
+    }
+}
+
 void HDRViewApp::invoke_edit_command(EditCommand &cmd)
 {
     if (cmd.has_dialog())
@@ -140,8 +176,7 @@ void HDRViewApp::invoke_edit_command(EditCommand &cmd)
         return;
     }
 
-    AppEditContext ctx{this};
-    cmd.apply(ctx);
+    apply_edit_command(cmd);
 }
 
 bool HDRViewApp::edit_command_enabled(const EditCommand &cmd)
@@ -179,7 +214,9 @@ void HDRViewApp::draw_edit_command_dialog(EditCommand &cmd, bool &open)
         const auto result = ImGui::DialogButtons(info.confirm.c_str());
         if (result == ImGui::DialogResult::Confirm)
         {
-            cmd.apply(ctx);
+            // The dialog itself is drawn against the current image -- its defaults, its size, its
+            // preview -- but confirming applies across the selection.
+            apply_edit_command(cmd);
             cmd.on_close(ctx);
             ImGui::CloseCurrentPopup();
         }
@@ -510,35 +547,38 @@ bool HDRViewApp::modify_structure(const ImagePtr &img, const string &name, const
     return true;
 }
 
-bool HDRViewApp::undo()
+bool HDRViewApp::step_selected_histories(bool forward)
 {
-    auto img = current_image();
-    if (!can_edit(img) || !img->history.has_undo())
-        return false;
+    // One image's own history, stepped one entry. False when it had nothing to step.
+    auto step = [this, forward](const ImagePtr &img)
+    {
+        if (!can_edit(img) || (forward ? !img->history.has_redo() : !img->history.has_undo()))
+            return false;
 
-    for (auto &c : img->channels) c.cancel_stats();
+        for (auto &c : img->channels) c.cancel_stats();
 
-    if (!img->history.undo(*img))
-        return false;
+        if (!(forward ? img->history.redo(*img) : img->history.undo(*img)))
+            return false;
 
-    after_modify(img);
-    return true;
+        after_modify(img);
+        return true;
+    };
+
+    // Every selected image steps, but the answer is the current image's; see undo().
+    auto current = current_image();
+    bool stepped = false;
+    for (const auto &img : selected_images())
+    {
+        const bool ok = step(img);
+        if (img == current)
+            stepped = ok;
+    }
+    return stepped;
 }
 
-bool HDRViewApp::redo()
-{
-    auto img = current_image();
-    if (!can_edit(img) || !img->history.has_redo())
-        return false;
+bool HDRViewApp::undo() { return step_selected_histories(false); }
 
-    for (auto &c : img->channels) c.cancel_stats();
-
-    if (!img->history.redo(*img))
-        return false;
-
-    after_modify(img);
-    return true;
-}
+bool HDRViewApp::redo() { return step_selected_histories(true); }
 
 void HDRViewApp::close_image(int index)
 {
@@ -703,8 +743,15 @@ void HDRViewApp::modify_channels_async(
     const ImagePtr &img, const string &name, const EditSubject &subject,
     const function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &filter)
 {
-    if (!can_edit(img) || m_running_filter)
+    if (!can_edit(img))
         return;
+
+    if (m_running_filter)
+    {
+        m_filter_queue.push_back([this, img, name, subject, filter]
+                                 { modify_channels_async(img, name, subject, filter); });
+        return;
+    }
 
     auto [channels, bounds] = resolve_subject(img, subject);
     if (channels.empty() || !bounds.has_volume())
@@ -775,8 +822,14 @@ void HDRViewApp::modify_channels_async(
 void HDRViewApp::modify_image_async(const ImagePtr &img, const string &name, int2 size,
                                     const function<Array2Df(const Array2Df &, AtomicProgress)> &op)
 {
-    if (!can_edit(img) || m_running_filter || size.x <= 0 || size.y <= 0)
+    if (!can_edit(img) || size.x <= 0 || size.y <= 0)
         return;
+
+    if (m_running_filter)
+    {
+        m_filter_queue.push_back([this, img, name, size, op] { modify_image_async(img, name, size, op); });
+        return;
+    }
 
     auto running    = std::make_unique<RunningFilter>();
     running->image  = img;
@@ -832,6 +885,8 @@ void HDRViewApp::drain_running_filter()
     {
         spdlog::debug("Filter '{}' was canceled.", running->name);
         m_running_filter_resizes = false;
+        // Cancel means the whole run, not just the image it happened to have reached.
+        m_filter_queue.clear();
         return;
     }
 
@@ -856,6 +911,7 @@ void HDRViewApp::drain_running_filter()
                              image.data_window    = Box2i{image.data_window.min, image.data_window.min + size};
                              image.display_window = image.data_window;
                          });
+        start_next_filter();
         return;
     }
 
@@ -874,6 +930,18 @@ void HDRViewApp::drain_running_filter()
         },
         [&channels, &bounds, &running](const Image &image) -> UndoPtr
         { return std::make_unique<ChannelRectUndo>(image, channels, bounds, running->name); });
+
+    start_next_filter();
+}
+
+void HDRViewApp::start_next_filter()
+{
+    if (m_filter_queue.empty())
+        return;
+
+    auto next = m_filter_queue.front();
+    m_filter_queue.erase(m_filter_queue.begin());
+    next();
 }
 
 void HDRViewApp::draw_filter_progress_dialog(bool &open)
@@ -898,6 +966,12 @@ void HDRViewApp::draw_filter_progress_dialog(bool &open)
         ImGui::Dummy(ImVec2(24.f * HelloImGui::EmSize(), 0.f));
 
         ImGui::TextUnformatted(m_running_filter->name.c_str());
+        if (!m_filter_queue.empty())
+        {
+            // The bar measures one image; an edit over a multi-selection runs them one after another.
+            ImGui::SameLine();
+            ImGui::TextDisabled("(%d more image%s)", int(m_filter_queue.size()), m_filter_queue.size() == 1 ? "" : "s");
+        }
         ImGui::ProgressBar(m_running_filter->progress.progress(), ImVec2(-FLT_MIN, 0.f));
 
         // Only asks the filter to stop; the work unwinds on its own thread and drain_running_filter()

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -854,6 +854,9 @@ void HDRViewApp::close_image_immediately(int index)
 
 void HDRViewApp::close_all_images_immediately()
 {
+    // Nothing left for a queued filter to be applied to.
+    m_filter_queue.clear();
+
     m_images.clear();
     m_current   = -1;
     m_reference = -1;
@@ -889,6 +892,16 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
         entry["alpha_is_transparency"] = img->alpha_is_transparency;
         entry["selected_group"]        = img->selected_group;
         entry["reference_group"]       = img->reference_group;
+
+        // The multi-selection, by channel name rather than by group index: a group index means whatever
+        // the rebuild after loading makes it mean, while the names are what the grouping is derived from
+        // and what the panel addresses.
+        json selected_channels = json::array();
+        for (const auto &c : img->channels)
+            if (c.selected)
+                selected_channels.push_back(c.name);
+        entry["selected_channels"] = selected_channels;
+
         images.push_back(entry);
     }
     j["images"] = images;
@@ -1181,6 +1194,7 @@ void HDRViewApp::begin_session_load(const json &j, const fs::path &dir)
         e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
         e.selected_group        = entry.value<int>("selected_group", 0);
         e.reference_group       = entry.value<int>("reference_group", 0);
+        e.selected_channels     = entry.value<vector<string>>("selected_channels", {});
 
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
@@ -1225,6 +1239,7 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
         e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
         e.selected_group        = entry.value<int>("selected_group", 0);
         e.reference_group       = entry.value<int>("reference_group", 0);
+        e.selected_channels     = entry.value<vector<string>>("selected_channels", {});
 
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
@@ -1273,6 +1288,13 @@ void HDRViewApp::finish_pending_session()
             // meaningful "no reference group" state that update_visibility() assigns.
             e.loaded->selected_group  = clamp(e.selected_group, 0, std::max(0, (int)e.loaded->groups.size() - 1));
             e.loaded->reference_group = e.reference_group;
+
+            // A name the image no longer has simply selects nothing. A session written before this was
+            // saved leaves every channel unselected, and update_visibility() below then collapses the
+            // selection onto the group each image is showing, which is where a fresh load starts anyway.
+            for (auto &c : e.loaded->channels)
+                c.selected = std::find(e.selected_channels.begin(), e.selected_channels.end(), c.name) !=
+                             e.selected_channels.end();
         }
 
     // Rebuild m_images in the saved order: images arrive in whatever order their independent background

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -486,7 +486,8 @@ void HDRViewApp::draw_menus()
 
         MenuItem(action("Ungroup channels"));
         MenuItem(action("Regroup channels"));
-        MenuItem(action("Delete channel group"), delete_channels_label(current_image(), target_group()));
+        MenuItem(action("Delete channel group"),
+                 delete_channels_label(current_image(), target_groups(current_image())));
 
         // The edits that read the samples around the one they are writing.
         ImGui::SeparatorText("Neighborhood filters");

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -516,7 +516,7 @@ void HDRViewApp::draw_menus()
                     m_edit_subject.scope = EditSubject::Scope(i);
 
             if (!matters && img)
-                ImGui::Tooltip("This image has a single channel group, so both choices cover the same "
+                ImGui::Tooltip("This image has a single channel group, so all three choices cover the same "
                                "channels.");
 
             ImGui::Separator();

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -809,8 +809,8 @@ void HDRViewApp::set_current_group(int index, int group)
     if (!img->is_valid_group(img->selected_group))
         return;
 
-    // A target already in the selection keeps it and merely becomes its current member; one outside it
-    // starts the selection over.
+    // If the target wasn't already selected, deselect the others -- a click outside the selection starts
+    // a new one, while one inside it only moves current.
     if (!img->is_group_selected(img->selected_group))
     {
         for (auto &i : m_images) i->deselect_all();
@@ -820,6 +820,11 @@ void HDRViewApp::set_current_group(int index, int group)
 
 void HDRViewApp::toggle_group_selected(int index, int group)
 {
+    // logic:
+    // if the target is not selected, then select it
+    // if the target is already selected, then deselect it (but only if some other target is selected)
+    //   if it was also the current target, then need to find a different current one from the selected
+
     auto img = image(index);
     if (!img || !img->is_valid_group(group))
         return;
@@ -830,15 +835,12 @@ void HDRViewApp::toggle_group_selected(int index, int group)
         return;
     }
 
-    // Never down to nothing: an empty selection would leave every edit with nothing to act on and no way
-    // back except clicking something.
     auto selected = selected_targets();
     if (selected.size() < 2)
         return;
 
     img->select_group(group, false);
 
-    // Current has to stay selected, so hand it to whichever target still is.
     if (index == m_current && group == img->selected_group)
         for (const auto &[i, g] : selected)
             if (i != index || g != group)

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -514,6 +514,10 @@ void HDRViewApp::draw_history_window()
 
     // Clicking a row walks there one entry at a time, which is the only way to get from one state to
     // another: each entry knows how to reverse the one edit it describes and nothing knows how to skip.
+    //
+    // The cursor read here is the current image's while undo() and redo() step every selected image --
+    // intended, since this window shows the current image's history, and they report what that image did,
+    // so the walk still ends when it runs out.
     if (target >= 0)
     {
         while (history.current_state() > target && undo()) {}
@@ -757,6 +761,22 @@ std::vector<std::pair<int, int>> HDRViewApp::selected_targets() const
             if (img->groups[size_t(g)].visible)
                 out.emplace_back(int(i), g);
     }
+    return out;
+}
+
+std::vector<ImagePtr> HDRViewApp::selected_images()
+{
+    std::vector<ImagePtr> out;
+    for (size_t i : m_visible_images)
+        if (m_images[i]->is_selected())
+            out.push_back(m_images[i]);
+
+    // Visible only, and the current image is always both visible and selected -- so an empty result means
+    // the panel has never had a say, which is how a test driving the app directly finds it.
+    if (out.empty())
+        if (auto img = current_image())
+            out.push_back(img);
+
     return out;
 }
 

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -747,6 +747,142 @@ void HDRViewApp::draw_statistics_window()
     }
 }
 
+std::vector<std::pair<int, int>> HDRViewApp::selected_targets() const
+{
+    std::vector<std::pair<int, int>> out;
+    for (size_t i : m_visible_images)
+    {
+        const auto &img = m_images[i];
+        for (int g : img->selected_groups())
+            if (img->groups[size_t(g)].visible)
+                out.emplace_back(int(i), g);
+    }
+    return out;
+}
+
+void HDRViewApp::set_current_image_index(int index, bool force)
+{
+    if (!(force || is_valid(index)))
+        return;
+
+    if (!is_valid(index))
+    {
+        m_current = index;
+        return;
+    }
+
+    set_current_group(index, m_images[size_t(index)]->selected_group);
+}
+
+void HDRViewApp::set_current_group(int index, int group)
+{
+    m_current = index;
+
+    auto img = image(index);
+    if (!img)
+        return;
+
+    if (img->is_valid_group(group))
+        img->selected_group = group;
+
+    // Nothing to reconcile against while a channel filter leaves the image with no group to show.
+    if (!img->is_valid_group(img->selected_group))
+        return;
+
+    // A target already in the selection keeps it and merely becomes its current member; one outside it
+    // starts the selection over.
+    if (!img->is_group_selected(img->selected_group))
+    {
+        for (auto &i : m_images) i->deselect_all();
+        img->select_group(img->selected_group);
+    }
+}
+
+void HDRViewApp::toggle_group_selected(int index, int group)
+{
+    auto img = image(index);
+    if (!img || !img->is_valid_group(group))
+        return;
+
+    if (!img->is_group_selected(group))
+    {
+        img->select_group(group);
+        return;
+    }
+
+    // Never down to nothing: an empty selection would leave every edit with nothing to act on and no way
+    // back except clicking something.
+    auto selected = selected_targets();
+    if (selected.size() < 2)
+        return;
+
+    img->select_group(group, false);
+
+    // Current has to stay selected, so hand it to whichever target still is.
+    if (index == m_current && group == img->selected_group)
+        for (const auto &[i, g] : selected)
+            if (i != index || g != group)
+            {
+                set_current_group(i, g);
+                break;
+            }
+}
+
+void HDRViewApp::select_image_range_to(int index)
+{
+    auto pos = [this](int i)
+    {
+        auto it = std::find(m_visible_images.begin(), m_visible_images.end(), size_t(i));
+        return it == m_visible_images.end() ? -1 : int(it - m_visible_images.begin());
+    };
+
+    const int to = pos(index);
+    if (to < 0)
+        return;
+
+    const int current = pos(m_current);
+    const int from    = current < 0 ? to : current;
+    for (int v = std::min(from, to); v <= std::max(from, to); ++v)
+    {
+        auto &img = m_images[m_visible_images[size_t(v)]];
+        img->select_group(img->selected_group);
+    }
+
+    // The far end is selected by the loop above, so set_current_image_index() moves current into the
+    // range rather than collapsing the selection onto it.
+    set_current_image_index(index);
+}
+
+void HDRViewApp::select_group_range_to(int index, int group)
+{
+    // Every visible target, in the order the panel lists them: images in list order, and within each, its
+    // groups in the order build_layers_and_groups() created them, which is layer order.
+    std::vector<std::pair<int, int>> targets;
+    for (size_t i : m_visible_images)
+        for (int g = 0; g < (int)m_images[i]->groups.size(); ++g)
+            if (m_images[i]->groups[size_t(g)].visible)
+                targets.emplace_back(int(i), g);
+
+    auto pos = [&targets](int i, int g)
+    {
+        auto it = std::find(targets.begin(), targets.end(), std::pair{i, g});
+        return it == targets.end() ? -1 : int(it - targets.begin());
+    };
+
+    const int to = pos(index, group);
+    if (to < 0)
+        return;
+
+    auto      cur     = current_image();
+    const int current = cur ? pos(m_current, cur->selected_group) : -1;
+    const int from    = current < 0 ? to : current;
+
+    for (int t = std::min(from, to); t <= std::max(from, to); ++t)
+        m_images[size_t(targets[size_t(t)].first)]->select_group(targets[size_t(t)].second);
+
+    set_current_group(index, group);
+}
+
 void HDRViewApp::update_visibility()
 {
     // compute image:channel visibility and update selection indices
@@ -814,6 +950,11 @@ void HDRViewApp::update_visibility()
     // one shortened name per visible image, in the same order.
     auto short_names = shorten_names(visible_image_names);
     for (size_t n = 0; n < m_visible_images.size(); ++n) m_images[m_visible_images[n]]->short_name = short_names[n];
+
+    // Filtering moves current and the group it shows by assignment above rather than through
+    // set_current_group(), so the rule that the current target is selected is restored once, here.
+    if (auto img = current_image())
+        set_current_group(m_current, img->selected_group);
 
     set_image_textures();
 }
@@ -1033,10 +1174,11 @@ void HDRViewApp::draw_file_window()
                 auto &img          = m_images[i];
                 bool  is_current   = m_current == i;
                 bool  is_reference = m_reference == i;
+                bool  is_selected  = img->is_selected();
 
                 ImGuiTreeNodeFlags node_flags = base_node_flags;
 
-                if (is_current || is_reference)
+                if (is_current || is_reference || is_selected)
                     node_flags |= ImGuiTreeNodeFlags_Selected;
                 if (m_file_list_mode == 0)
                     node_flags |= ImGuiTreeNodeFlags_Leaf;
@@ -1063,7 +1205,8 @@ void HDRViewApp::draw_file_window()
                                            {
                                                if (m_file_list_mode == 0)
                                                    ImGui::Unindent(ImGui::GetTreeNodeToLabelSpacing());
-                                               ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift);
+                                               ImGui::PushRowColors(is_current, is_reference, ImGui::GetIO().KeyShift,
+                                                                    is_selected);
                                            });
                 auto icon = img->groups.size() > 1 ? ICON_MY_IMAGES : ICON_MY_IMAGE;
                 ImGui::SameLine(0.f, 0.f);
@@ -1089,7 +1232,7 @@ void HDRViewApp::draw_file_window()
                     ImGui::BeginDisabled(is_current);
                     if (ImGui::MenuItem("Select as current image"))
                     {
-                        m_current = i;
+                        set_current_image_index(i);
                         set_image_textures();
                     }
                     ImGui::EndDisabled();
@@ -1110,12 +1253,20 @@ void HDRViewApp::draw_file_window()
 
                 if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
                 {
-                    if (ImGui::GetIO().KeyShift)
+                    // Shift is the reference modifier, as it has always been, so the selection chords are
+                    // ctrl/cmd and ctrl/cmd+shift. An image row stands for the group the image is
+                    // showing, which is the target the selection is actually made of.
+                    auto &io = ImGui::GetIO();
+                    if (io.KeyCtrl && io.KeyShift)
+                        select_image_range_to(i);
+                    else if (io.KeyCtrl)
+                        toggle_group_selected(i, img->selected_group);
+                    else if (io.KeyShift)
                         m_reference = is_reference ? -1 : i;
                     else
-                        m_current = i;
+                        set_current_image_index(i);
                     set_image_textures();
-                    spdlog::trace("Setting image {} to the {} image", i, is_reference ? "reference" : "current");
+                    spdlog::trace("Clicked image {}; current is {}, reference is {}", i, m_current, m_reference);
                 }
 
                 if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None))

--- a/src/app.h
+++ b/src/app.h
@@ -122,6 +122,9 @@ public:
     void invoke_action_on_group(const std::string &action_name, int group);
     //! The group an edit acts on: the one being pointed at, or the one on screen.
     int target_group() const;
+    //! The plural counterpart: the pointed-at group, or every group selected in the current image.
+    //! Falls back to target_group() for an image with nothing selected.
+    std::vector<int> target_groups() const;
     //! Put \p img into the list just after the current image, named \p partname, and select it.
     /*!
         Where duplicate_image() and the commands that derive an image from another one both land. Beside
@@ -424,16 +427,44 @@ public:
     int           image_index(ConstImagePtr img) const;
     ConstImagePtr image(int index) const { return is_valid(index) ? m_images[index] : nullptr; }
     ImagePtr      image(int index) { return is_valid(index) ? m_images[index] : nullptr; }
-    void          set_current_image_index(int index, bool force = false)
-    {
-        m_current = force || is_valid(index) ? index : m_current;
-    }
-    void set_reference_image_index(int index, bool force = false)
+    void          set_current_image_index(int index, bool force = false);
+    void          set_reference_image_index(int index, bool force = false)
     {
         m_reference = force || is_valid(index) ? index : m_reference;
     }
     int next_visible_image_index(int index, Direction_ direction) const;
     int nth_visible_image_index(int n) const;
+    //-----------------------------------------------------------------------------
+
+    //-----------------------------------------------------------------------------
+    // the multi-selection
+    //-----------------------------------------------------------------------------
+    /*!
+        Selection runs over (image, channel group) targets, not over images: an image counts as selected
+        when any of its groups is. Two rules hold at all times -- something is selected whenever there is
+        an image to select, and the current target is one of the selected ones -- and every entry point
+        below maintains them. The reference is a separate axis and is not touched by any of this.
+
+        The flags themselves live on Channel; see Image::is_group_selected() and the helpers beside it.
+    */
+    //! Every selected target, as (image index, group index) pairs, in the order the panel lists them.
+    std::vector<std::pair<int, int>> selected_targets() const;
+    //! Make group \p group of image \p index the current target, and reconcile the selection with it.
+    /*!
+        A target that was already selected simply becomes the selection's current member; one that was not
+        replaces the whole selection, which is how a plain click starts a new one.
+    */
+    void set_current_group(int index, int group);
+    //! Add group \p group of image \p index to the selection, or take it out.
+    /*!
+        Refuses to empty the selection, and hands current to another selected target when it is current
+        that leaves.
+    */
+    void toggle_group_selected(int index, int group);
+    //! Select every image between the current one and \p index, each by the group it is showing.
+    void select_image_range_to(int index);
+    //! Select every target between the current one and (\p index, \p group), inclusive.
+    void select_group_range_to(int index, int group);
     //-----------------------------------------------------------------------------
 
     //-----------------------------------------------------------------------------

--- a/src/app.h
+++ b/src/app.h
@@ -149,6 +149,13 @@ public:
     void save_session();
     void load_session();
     void load_session(const string &filename);
+    //! The "HDRView session" manifest for the images and view settings as they stand.
+    /*!
+        Shared by save_session() and export_session_bundle(), which differ only in what "path" each image
+        gets -- `path_of` supplies it: a filesystem-relative path for a plain .hsess, an in-bundle
+        location for a zip export.
+    */
+    json build_session_manifest(const std::function<string(ConstImagePtr)> &path_of) const;
     void export_session_bundle();
     // Emscripten's "Load session..." entry point: uploads a .zip and loads it strictly as a session bundle,
     // erroring rather than falling back to plain image loading if it doesn't contain a manifest.
@@ -378,6 +385,14 @@ public:
         keyboard chord cannot reach it by different routes.
     */
     void invoke_edit_command(EditCommand &cmd);
+    //! Run \p cmd once per image it covers, each with its own undo entry.
+    /*!
+        Which is every selected image for an edit that takes a subject, and the current one alone for
+        everything else; see edit_command_images().
+    */
+    void apply_edit_command(EditCommand &cmd);
+    //! The images one invocation of \p cmd covers.
+    std::vector<ImagePtr> edit_command_images(const EditCommand &cmd);
     //! Whether \p cmd could run now: the image accepts edits, and the command itself is satisfied.
     bool edit_command_enabled(const EditCommand &cmd);
     //! The shell, the "Apply to" selector and the Cancel/Confirm footer that every command's dialog wears.
@@ -398,9 +413,18 @@ public:
     /// Whether any open image has edits that are not in its file.
     bool any_image_modified() const;
 
-    /// Reverse the current image's most recent edit. False if there was nothing to undo.
+    //! Reverse the most recent edit of every selected image. False if the current image had none.
+    /*!
+        Offered and labeled from the current image alone -- the button says what undoing the image being
+        looked at would do -- but applied across the selection, each image stepping its own history. One
+        that cannot, because a renderer owns it or because it has nothing left to undo, sits it out rather
+        than stopping the rest.
+
+        The result is the current image's, not "any image undid", because that is what
+        draw_history_window()'s walk to a clicked entry terminates on.
+    */
     bool undo();
-    /// Reapply the edit undo() last reversed. False if there was nothing to redo.
+    //! Reapply the edit undo() last reversed, across the selection. False if the current image had none.
     bool redo();
 
     //! Everything a completed edit invalidates, applied to \p img.
@@ -465,6 +489,8 @@ public:
     void select_image_range_to(int index);
     //! Select every target between the current one and (\p index, \p group), inclusive.
     void select_group_range_to(int index, int group);
+    //! Every selected image, in list order; the current one alone when nothing is selected.
+    std::vector<ImagePtr> selected_images();
     //-----------------------------------------------------------------------------
 
     //-----------------------------------------------------------------------------
@@ -667,12 +693,6 @@ public:
 private:
     void load_fonts();
 
-    // Builds the "HDRView session" manifest for the currently loaded images/view settings, shared by
-    // save_session() and export_session_bundle() -- they differ only in what "path" each image gets, which
-    // `path_of` supplies (a filesystem-relative path for a plain .hsess, an in-bundle location for a zip
-    // export).
-    json build_session_manifest(const std::function<string(ConstImagePtr)> &path_of) const;
-
     // Begins asynchronously loading the images listed in a parsed session file `j` (paths resolved relative to
     // `dir`), populating m_pending_session so the per-frame image-loader drain can apply the rest of the session
     // (current/reference selection, blend mode, view settings) once every image has finished loading.
@@ -823,8 +843,22 @@ private:
     int2 m_running_filter_size{0};
 
     std::unique_ptr<RunningFilter> m_running_filter;
+
+    //! The filters still waiting for the one in flight, one per image a fan-out has yet to reach.
+    /*!
+        Only one filter can run at a time -- there is one progress dialog and one Cancel -- but an edit
+        over a multi-selection arrives as one call per image within a single frame. The rest wait here
+        rather than being dropped, and each is started as the one before it lands.
+    */
+    std::vector<std::function<void()>> m_filter_queue;
+
     //! Applies a finished filter's results, or clears an abandoned one. Called once a frame.
     void drain_running_filter();
+    //! Starts the next queued filter, if a fan-out left any waiting.
+    void start_next_filter();
+
+    //! The shared body of undo() and redo().
+    bool step_selected_histories(bool forward);
 
     //! What the menu's edits apply to; see Edit > Apply to.
     EditSubject m_edit_subject;
@@ -1096,11 +1130,12 @@ private:
     {
         struct Entry
         {
-            fs::path path;
-            string   channel_selector;
-            bool     alpha_is_transparency = true;
-            int      selected_group = 0, reference_group = 0;
-            ImagePtr loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
+            fs::path       path;
+            string         channel_selector;
+            bool           alpha_is_transparency = true;
+            int            selected_group = 0, reference_group = 0;
+            vector<string> selected_channels; ///< The multi-selection, by channel name; see Channel::selected
+            ImagePtr       loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
         };
         vector<Entry> entries; ///< One per saved "images" entry, in file order; the same path may repeat
         int           current_index = -1, reference_index = -1; ///< Index into entries, or -1 if unset

--- a/src/app.h
+++ b/src/app.h
@@ -468,12 +468,19 @@ public:
     // the multi-selection
     //-----------------------------------------------------------------------------
     /*!
-        Selection runs over (image, channel group) targets, not over images: an image counts as selected
-        when any of its groups is. Two rules hold at all times -- something is selected whenever there is
-        an image to select, and the current target is one of the selected ones -- and every entry point
-        below maintains them. The reference is a separate axis and is not touched by any of this.
+        A target -- an (image, channel group) pair -- can have four states:
+          * deselected
+          * selected
+          * current
+          * reference
 
-        The flags themselves live on Channel; see Image::is_group_selected() and the helpers beside it.
+        Multiple targets can be selected, but only one can be current, and only one can be reference. If a
+        target is current, it is automatically selected. An image counts as selected when any of its
+        groups is.
+
+        Every entry point below maintains that, and something is selected whenever there is an image to
+        select. The flags live on Channel, read through Image::is_group_selected() and the helpers beside
+        it.
     */
     //! Every selected target, as (image index, group index) pairs, in the order the panel lists them.
     std::vector<std::pair<int, int>> selected_targets() const;
@@ -484,10 +491,6 @@ public:
     */
     void set_current_group(int index, int group);
     //! Add group \p group of image \p index to the selection, or take it out.
-    /*!
-        Refuses to empty the selection, and hands current to another selected target when it is current
-        that leaves.
-    */
     void toggle_group_selected(int index, int group);
     //! Select every image between the current one and \p index, each by the group it is showing.
     void select_image_range_to(int index);

--- a/src/app.h
+++ b/src/app.h
@@ -119,12 +119,20 @@ public:
         viewport goes on showing whatever it was showing, and only the operation is told which group was
         meant.
     */
-    void invoke_action_on_group(const std::string &action_name, int group);
-    //! The group an edit acts on: the one being pointed at, or the one on screen.
-    int target_group() const;
-    //! The plural counterpart: the pointed-at group, or every group selected in the current image.
-    //! Falls back to target_group() for an image with nothing selected.
-    std::vector<int> target_groups() const;
+    void invoke_action_on_group(const std::string &action_name, int image_index, int group);
+    //! Point at \p group of image \p image_index for the duration of \p body.
+    /*!
+        What makes the Images panel's context menu name a group: while this is in force, the commands and
+        the menu that offers them address that group of that image rather than the current one.
+    */
+    void with_target_group(int image_index, int group, const std::function<void()> &body);
+    //! The image an edit acts on: the one being pointed at, or the current one.
+    ImagePtr target_image();
+    //! The groups of \p img an edit acts on: the selected ones, or a group pointed at from outside them.
+    //! Falls back to the group on screen for an image with nothing selected.
+    std::vector<int> target_groups(const ConstImagePtr &img) const;
+    //! The same, for a group named by the caller rather than by what is currently pointed at.
+    std::vector<int> target_groups(const ConstImagePtr &img, int pointed_at) const;
     //! Put \p img into the list just after the current image, named \p partname, and select it.
     /*!
         Where duplicate_image() and the commands that derive an image from another one both land. Beside
@@ -880,8 +888,14 @@ private:
     std::vector<std::function<void()>> m_main_thread_queue;
 
     //! The group a command acts on while one is being pointed at rather than selected; -1 otherwise.
-    int  m_target_group_override = -1;
-    void drain_main_thread_queue();
+    //! The group the Images panel's context menu is pointing at, and the image whose group it is.
+    /*!
+        A group index means nothing on its own -- every image numbers its own groups, and the panel lists
+        every image's -- so the two are only ever set and read together; see with_target_group().
+    */
+    ImagePtr m_target_image_override;
+    int      m_target_group_override = -1;
+    void     drain_main_thread_queue();
 
 #if HDRVIEW_ENABLE_IPC
     IpcServer m_ipc_server;

--- a/src/app.h
+++ b/src/app.h
@@ -421,15 +421,11 @@ public:
     /// Whether any open image has edits that are not in its file.
     bool any_image_modified() const;
 
-    //! Reverse the most recent edit of every selected image. False if the current image had none.
+    //! Reverse the most recent edit of every selected image. False if the *current* image had none.
     /*!
-        Offered and labeled from the current image alone -- the button says what undoing the image being
-        looked at would do -- but applied across the selection, each image stepping its own history. One
-        that cannot, because a renderer owns it or because it has nothing left to undo, sits it out rather
-        than stopping the rest.
-
-        The result is the current image's, not "any image undid", because that is what
-        draw_history_window()'s walk to a clicked entry terminates on.
+        Offered and labeled from the current image, applied across the selection, each image stepping its
+        own history; one with nothing to undo sits it out. The result is the current image's rather than
+        "any image undid", which is what draw_history_window()'s walk to a clicked entry terminates on.
     */
     bool undo();
     //! Reapply the edit undo() last reversed, across the selection. False if the current image had none.
@@ -852,11 +848,10 @@ private:
 
     std::unique_ptr<RunningFilter> m_running_filter;
 
-    //! The filters still waiting for the one in flight, one per image a fan-out has yet to reach.
+    //! Filters waiting for the one in flight, one per image a fan-out has yet to reach.
     /*!
-        Only one filter can run at a time -- there is one progress dialog and one Cancel -- but an edit
-        over a multi-selection arrives as one call per image within a single frame. The rest wait here
-        rather than being dropped, and each is started as the one before it lands.
+        Only one can run at a time -- one progress dialog, one Cancel -- but an edit over a multi-selection
+        arrives as one call per image in a single frame. Each is started as the one before it lands.
     */
     std::vector<std::function<void()>> m_filter_queue;
 

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -49,6 +49,14 @@ struct EditContext
     */
     virtual int target_group() const = 0;
 
+    //! The channel groups an operation acts on: every selected one, or just the one being pointed at.
+    /*!
+        The plural counterpart to target_group(), with the same distinction behind it -- reached from the
+        Images panel's context menu this is the one group that was named, and reached from the menu it is
+        the whole multi-selection.
+    */
+    virtual std::vector<int> target_groups() const = 0;
+
     virtual Box2i selection() const               = 0;
     virtual void  set_selection(const Box2i &box) = 0;
     //! The color the viewport draws behind the image, for the edits that composite against it.

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -129,26 +129,21 @@ public:
             contents; see HDRViewApp::draw_edit_command_dialog().
         */
         float width_em = 24.f;
-        //! Whether the edit is narrowed by the subject at all, which is what puts the "Apply to" controls
-        //! on its dialog. False for the ones that cover the whole image whatever the subject says -- a
-        //! crop, a resize, a quarter turn.
-        bool has_subject = true;
-
-        //! Whether invoking this with several images selected runs it on all of them, or only the current
-        //! one.
+        //! Whether the "Apply to" settings -- the channel scope and "selection only" -- mean anything for
+        //! this edit, and so whether its dialog shows them.
         /*!
-            Each selected image gets its own invocation and its own undo entry; one that refuses the edit
-            sits it out rather than stopping the rest. True for the edits that write samples, and for the
-            three the selection itself names -- ungrouping, regrouping, deleting a group.
+            False for the edits that replace or reshape the image: there is no rotating only the green
+            channel, or only the marquee. Independent of fans_out below -- ungrouping shows no controls
+            but does run over the selection.
+        */
+        bool draws_subject_selector = true;
 
-            False for Copy and Cut, where it is forced: there is one clipboard, so running them once per
-            image would leave only the last image's copy in it.
-
-            Also false for the edits that reshape or replace an image -- a crop, a resize, a quarter turn,
-            a mip pyramid -- and that one is a choice rather than a constraint. Cropping every selected
-            image to the same rectangle would be perfectly meaningful; a shape change is just a blunter
-            thing to spread over a selection from one keystroke than a tonal edit is, so these stay with
-            the image being looked at.
+        //! With several images selected, whether this runs on all of them or only the current one.
+        /*!
+            Each selected image gets its own invocation and its own undo entry. Copy and Cut cannot: there
+            is one clipboard, so running them per image would leave only the last one's copy in it. The
+            edits that reshape an image stay with the current one by choice rather than necessity -- a
+            shape change is a blunter thing to spread over a selection than a tonal edit is.
         */
         bool fans_out = true;
 

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -140,10 +140,9 @@ public:
 
         //! With several images selected, whether this runs on all of them or only the current one.
         /*!
-            Each selected image gets its own invocation and its own undo entry. Copy and Cut cannot: there
-            is one clipboard, so running them per image would leave only the last one's copy in it. The
-            edits that reshape an image stay with the current one by choice rather than necessity -- a
-            shape change is a blunter thing to spread over a selection than a tonal edit is.
+            Each selected image gets its own invocation and its own undo entry, and each starts from the
+            same selection. False only for Copy and Cut: there is one clipboard, so running them per image
+            would leave only the last one's copy in it.
         */
         bool fans_out = true;
 

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -39,21 +39,15 @@ struct EditContext
     //! Which of that image's samples the edit covers.
     virtual const EditSubject &subject() const = 0;
 
-    //! The channel group an operation acts on: normally the one being shown.
+    //! The channel groups an operation acts on: normally the selected ones.
     /*!
-        Named separately from the selection because a group can be pointed at without being selected --
-        right-clicking one in the Images panel says which group is meant without disturbing what the
-        viewport is showing, so a lone depth channel can be deleted while a color stays on screen.
+        Not simply the selection, because a group can be pointed at without being selected: right-clicking
+        one *outside* the selection in the Images panel says which group is meant without disturbing what
+        is selected or what the viewport is showing, so a lone depth channel can be deleted while a color
+        stays on screen. Right-clicking one that is *in* the selection covers the selection, the same way
+        a plain click inside one keeps it rather than replacing it.
 
-        -1 when the image has no group to speak of.
-    */
-    virtual int target_group() const = 0;
-
-    //! The channel groups an operation acts on: every selected one, or just the one being pointed at.
-    /*!
-        The plural counterpart to target_group(), with the same distinction behind it -- reached from the
-        Images panel's context menu this is the one group that was named, and reached from the menu it is
-        the whole multi-selection.
+        Empty when the image has no group to speak of.
     */
     virtual std::vector<int> target_groups() const = 0;
 
@@ -135,20 +129,19 @@ public:
             contents; see HDRViewApp::draw_edit_command_dialog().
         */
         float width_em = 24.f;
-        //! Whether the edit is narrowed by the subject at all.
-        /*!
-            False for the ones that cover the whole image whatever the subject says -- a crop, a resize, a
-            quarter turn -- which is both why their dialogs do not carry the "Apply to" controls and why
-            they stay with the image being looked at: an edit that says which of an image's samples it
-            covers has nothing in it that names one image over another, and so runs once per selected
-            image, but one that covers the image entire does not.
-        */
+        //! Whether the edit is narrowed by the subject at all, which is what puts the "Apply to" controls
+        //! on its dialog. False for the ones that cover the whole image whatever the subject says -- a
+        //! crop, a resize, a quarter turn.
         bool has_subject = true;
 
-        //! Whether this may run over the whole selection, for a command that does take a subject.
+        //! Whether this runs once per selected image, rather than on the current one alone.
         /*!
-            False for the ones whose result lives outside the image: the clipboard has one slot, so
-            copying from several images at once has no meaning. Ignored when has_subject is false.
+            True for the edits whose reach is stated relative to an image -- the samples a subject names,
+            the groups a selection names -- since nothing in that says which image is meant.
+
+            False for the ones that cover an image entire, which stay with the image being looked at, and
+            for the ones whose result lives outside it: the clipboard has one slot, so copying from
+            several images at once would just be copying from the last of them.
         */
         bool fans_out = true;
 

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -135,9 +135,22 @@ public:
             contents; see HDRViewApp::draw_edit_command_dialog().
         */
         float width_em = 24.f;
-        //! Whether the dialog carries the "Apply to" controls. False for the edits that cover the whole
-        //! image whatever the subject says -- a crop, a resize.
+        //! Whether the edit is narrowed by the subject at all.
+        /*!
+            False for the ones that cover the whole image whatever the subject says -- a crop, a resize, a
+            quarter turn -- which is both why their dialogs do not carry the "Apply to" controls and why
+            they stay with the image being looked at: an edit that says which of an image's samples it
+            covers has nothing in it that names one image over another, and so runs once per selected
+            image, but one that covers the image entire does not.
+        */
         bool has_subject = true;
+
+        //! Whether this may run over the whole selection, for a command that does take a subject.
+        /*!
+            False for the ones whose result lives outside the image: the clipboard has one slot, so
+            copying from several images at once has no meaning. Ignored when has_subject is false.
+        */
+        bool fans_out = true;
 
         //! Whether the image has to accept edits for this to be offered. False for the one command that
         //! only reads: copying is not editing, and is worth having on an image a renderer owns.

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -134,14 +134,21 @@ public:
         //! crop, a resize, a quarter turn.
         bool has_subject = true;
 
-        //! Whether this runs once per selected image, rather than on the current one alone.
+        //! Whether invoking this with several images selected runs it on all of them, or only the current
+        //! one.
         /*!
-            True for the edits whose reach is stated relative to an image -- the samples a subject names,
-            the groups a selection names -- since nothing in that says which image is meant.
+            Each selected image gets its own invocation and its own undo entry; one that refuses the edit
+            sits it out rather than stopping the rest. True for the edits that write samples, and for the
+            three the selection itself names -- ungrouping, regrouping, deleting a group.
 
-            False for the ones that cover an image entire, which stay with the image being looked at, and
-            for the ones whose result lives outside it: the clipboard has one slot, so copying from
-            several images at once would just be copying from the last of them.
+            False for Copy and Cut, where it is forced: there is one clipboard, so running them once per
+            image would leave only the last image's copy in it.
+
+            Also false for the edits that reshape or replace an image -- a crop, a resize, a quarter turn,
+            a mip pyramid -- and that one is a choice rather than a constraint. Cropping every selected
+            image to the same rectangle would be perfectly meaningful; a shape change is just a blunter
+            thing to spread over a selection from one keystroke than a tonal edit is, so these stay with
+            the image being looked at.
         */
         bool fans_out = true;
 

--- a/src/edit/commands.h
+++ b/src/edit/commands.h
@@ -31,10 +31,10 @@ void add_channel_commands(std::vector<EditCommandPtr> &out);
 
 //! What "Delete channel group" should be labelled for \p group of \p img.
 /*!
-    One channel or several: deleting a lone depth channel is not deleting a group, and saying so is worth
-    the one call. The action's name stays put either way, since that is what addresses it.
+    One channel, one group or several: deleting a lone depth channel is not deleting a group, and saying so
+    is worth the one call. The action's name stays put either way, since that is what addresses it.
 */
-std::string delete_channels_label(const ImagePtr &img, int group);
+std::string delete_channels_label(const ImagePtr &img, const std::vector<int> &groups);
 void        add_mipmap_commands(std::vector<EditCommandPtr> &out);
 void        add_filter_commands(std::vector<EditCommandPtr> &out);
 void        add_envmap_commands(std::vector<EditCommandPtr> &out);

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -147,7 +147,7 @@ public:
                 ImGuiInputFlags_None,
                 "Ungroup",
                 24.f,
-                /* has_subject */ false};
+                /* draws_subject_selector */ false};
     }
 
     //! Only worth offering while one of the groups it would take apart is more than one channel.
@@ -223,7 +223,7 @@ public:
                 ImGuiInputFlags_None,
                 "Regroup",
                 24.f,
-                /* has_subject */ false};
+                /* draws_subject_selector */ false};
     }
 
     bool enabled(const EditContext &ctx) const override { return !regroup_channels(ctx).empty(); }
@@ -276,7 +276,7 @@ public:
                 ImGuiInputFlags_None,
                 "Delete",
                 24.f,
-                /* has_subject */ false};
+                /* draws_subject_selector */ false};
     }
 
     //! Never every group: an image with no channels is not an image.

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -8,6 +8,10 @@
     \author Wojciech Jarosz
 
     The edits that change which channels an image has, and how they are grouped.
+
+    None of them carries a subject: the channels they cover are named by the multi-selection, or by a
+    single group right-clicked from outside it, rather than by a scope over one image's channels. They do
+    still fan out, since a selection can hold groups of more than one image.
 */
 
 #include "edit/commands.h"
@@ -53,7 +57,7 @@ std::vector<int> group_channels(const ImagePtr &img, int group)
     return out;
 }
 
-//! Every channel of every group an edit is about to act on, which is not always the one on screen.
+//! Every channel of every group an edit is about to act on, which need not include the one on screen.
 std::vector<int> target_channels(const EditContext &ctx)
 {
     std::vector<int> out;
@@ -64,10 +68,8 @@ std::vector<int> target_channels(const EditContext &ctx)
 
 //! The channel to leave the viewport on after a rebuild, or -1 to leave it where it is.
 /*!
-    A rebuild renumbers the groups, so the index that was selected can afterwards mean something else
-    entirely -- following a channel is the only way to stay on what was being shown. Only when the group
-    on screen is one of the ones being changed; one merely pointed at from the panel must leave the
-    viewport where it was.
+    Only a group being changed is worth following: one merely pointed at from the panel must leave the
+    viewport where it was. See select_channels_group() for why following it is what it takes.
 */
 int followed_channel(const ImagePtr &img, const std::vector<int> &changed)
 {
@@ -145,8 +147,6 @@ public:
                 ImGuiInputFlags_None,
                 "Ungroup",
                 24.f,
-                // No subject: the channels are named by the selection, not by a scope. It still fans
-                // out, since a selection can hold groups of more than one image.
                 /* has_subject */ false};
     }
 
@@ -223,8 +223,6 @@ public:
                 ImGuiInputFlags_None,
                 "Regroup",
                 24.f,
-                // No subject: the channels are named by the selection, not by a scope. It still fans
-                // out, since a selection can hold groups of more than one image.
                 /* has_subject */ false};
     }
 
@@ -278,8 +276,6 @@ public:
                 ImGuiInputFlags_None,
                 "Delete",
                 24.f,
-                // No subject: the channels are named by the selection, not by a scope. It still fans
-                // out, since a selection can hold groups of more than one image.
                 /* has_subject */ false};
     }
 

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -53,8 +53,30 @@ std::vector<int> group_channels(const ImagePtr &img, int group)
     return out;
 }
 
-//! The channels of the group an edit is about to act on, which is not always the one on screen.
-std::vector<int> target_channels(const EditContext &ctx) { return group_channels(ctx.image(), ctx.target_group()); }
+//! Every channel of every group an edit is about to act on, which is not always the one on screen.
+std::vector<int> target_channels(const EditContext &ctx)
+{
+    std::vector<int> out;
+    for (int g : ctx.target_groups())
+        for (int c : group_channels(ctx.image(), g)) out.push_back(c);
+    return out;
+}
+
+//! The channel to leave the viewport on after a rebuild, or -1 to leave it where it is.
+/*!
+    A rebuild renumbers the groups, so the index that was selected can afterwards mean something else
+    entirely -- following a channel is the only way to stay on what was being shown. Only when the group
+    on screen is one of the ones being changed; one merely pointed at from the panel must leave the
+    viewport where it was.
+*/
+int followed_channel(const ImagePtr &img, const std::vector<int> &changed)
+{
+    const std::vector<int> showing = group_channels(img, img->selected_group);
+    for (int c : changed)
+        if (std::find(showing.begin(), showing.end(), c) != showing.end())
+            return c;
+    return -1;
+}
 
 //! The layer \p group belongs to, which is the prefix its channel names share.
 std::string layer_of(const ImagePtr &img, int group)
@@ -123,38 +145,60 @@ public:
                 ImGuiInputFlags_None,
                 "Ungroup",
                 24.f,
+                // No subject: the channels are named by the selection, not by a scope. It still fans
+                // out, since a selection can hold groups of more than one image.
                 /* has_subject */ false};
     }
 
-    //! Only worth offering for a group that is more than one channel already.
-    bool enabled(const EditContext &ctx) const override { return target_channels(ctx).size() > 1; }
+    //! Only worth offering while one of the groups it would take apart is more than one channel.
+    bool enabled(const EditContext &ctx) const override { return !ungroupable_channels(ctx).empty(); }
 
     void apply(EditContext &ctx) override
     {
-        const std::vector<int> channels = target_channels(ctx);
-        if (channels.size() < 2)
+        auto img = ctx.image();
+        if (!img)
             return;
 
-        // Only follow the channels across the rebuild when it was the group on screen that was ungrouped;
-        // one pointed at from the panel must leave the viewport where it was.
-        const bool follow = ctx.target_group() == ctx.image()->selected_group;
+        const std::vector<int> channels = ungroupable_channels(ctx);
+        if (channels.empty())
+            return;
+
+        const int follow = followed_channel(img, channels);
 
         ctx.modify_reversibly(
             "Ungroup channels",
-            [channels, follow](Image &img)
+            [channels, follow](Image &img2)
             {
-                for (int c : channels) img.channels[size_t(c)].ungrouped = true;
-                img.rebuild_layers();
-                if (follow)
-                    select_channels_group(img, channels.front());
+                for (int c : channels) img2.channels[size_t(c)].ungrouped = true;
+                img2.rebuild_layers();
+                if (follow >= 0)
+                    select_channels_group(img2, follow);
             },
-            [channels, follow](Image &img)
+            [channels, follow](Image &img2)
             {
-                for (int c : channels) img.channels[size_t(c)].ungrouped = false;
-                img.rebuild_layers();
-                if (follow)
-                    select_channels_group(img, channels.front());
+                for (int c : channels) img2.channels[size_t(c)].ungrouped = false;
+                img2.rebuild_layers();
+                if (follow >= 0)
+                    select_channels_group(img2, follow);
             });
+    }
+
+private:
+    //! The channels of the target groups that hold more than one, which are all this can take apart.
+    /*!
+        A group already standing alone is skipped rather than marked: marking it would change nothing but
+        would still record an entry, and undoing that entry would clear a flag the channel never had.
+    */
+    static std::vector<int> ungroupable_channels(const EditContext &ctx)
+    {
+        std::vector<int> out;
+        for (int g : ctx.target_groups())
+        {
+            const std::vector<int> channels = group_channels(ctx.image(), g);
+            if (channels.size() > 1)
+                out.insert(out.end(), channels.begin(), channels.end());
+        }
+        return out;
     }
 };
 
@@ -179,6 +223,8 @@ public:
                 ImGuiInputFlags_None,
                 "Regroup",
                 24.f,
+                // No subject: the channels are named by the selection, not by a scope. It still fans
+                // out, since a selection can hold groups of more than one image.
                 /* has_subject */ false};
     }
 
@@ -194,16 +240,7 @@ public:
         if (marked.empty())
             return;
 
-        // Follow the group on screen across the rebuild when it is one of the ones being put back
-        // together; one merely pointed at from the panel must leave the viewport where it was.
-        const std::vector<int> showing = group_channels(img, img->selected_group);
-        int                    follow  = -1;
-        for (int c : marked)
-            if (std::find(showing.begin(), showing.end(), c) != showing.end())
-            {
-                follow = c;
-                break;
-            }
+        const int follow = followed_channel(img, marked);
 
         ctx.modify_reversibly(
             "Regroup channels",
@@ -241,10 +278,12 @@ public:
                 ImGuiInputFlags_None,
                 "Delete",
                 24.f,
+                // No subject: the channels are named by the selection, not by a scope. It still fans
+                // out, since a selection can hold groups of more than one image.
                 /* has_subject */ false};
     }
 
-    //! Never the last group: an image with no channels is not an image.
+    //! Never every group: an image with no channels is not an image.
     bool enabled(const EditContext &ctx) const override
     {
         auto img = ctx.image();
@@ -284,11 +323,15 @@ public:
 
 } // namespace
 
-std::string delete_channels_label(const ImagePtr &img, int group)
+std::string delete_channels_label(const ImagePtr &img, const std::vector<int> &groups)
 {
     // The action's own name never changes -- it is the key the registry, the palette and the tests address
     // it by -- so only what the menu shows is chosen here.
-    return group_channels(img, group).size() == 1 ? "Delete channel" : "Delete channel group";
+    if (groups.size() > 1)
+        return "Delete channel groups";
+
+    return groups.size() == 1 && group_channels(img, groups.front()).size() == 1 ? "Delete channel"
+                                                                                 : "Delete channel group";
 }
 
 void add_channel_commands(std::vector<EditCommandPtr> &out)

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -22,14 +22,6 @@
 namespace
 {
 
-//! The layer the group on screen belongs to, which is the prefix its channel names share.
-/*!
-    What scopes regrouping. A group can be selected but a set of them cannot, so an operation that puts
-    channels back together has to work out for itself which ones are meant -- and once a group has been
-    ungrouped, the only thing its channels still have in common is the layer they came from.
-*/
-std::string target_layer(const EditContext &ctx);
-
 //! Every channel of \p img in the layer \p layer that ungrouping marked.
 /*!
     Marked, rather than merely standing alone: a layer can hold channels whose names never grouped -- a
@@ -64,6 +56,39 @@ std::vector<int> group_channels(const ImagePtr &img, int group)
 //! The channels of the group an edit is about to act on, which is not always the one on screen.
 std::vector<int> target_channels(const EditContext &ctx) { return group_channels(ctx.image(), ctx.target_group()); }
 
+//! The layer \p group belongs to, which is the prefix its channel names share.
+std::string layer_of(const ImagePtr &img, int group)
+{
+    const std::vector<int> channels = group_channels(img, group);
+    return channels.empty() ? std::string{} : Channel::head(img->channels[size_t(channels.front())].name);
+}
+
+//! The channels regrouping would put back together.
+/*!
+    Every marked channel of every group the command was invoked on -- except that a single group cannot
+    say which channels it should rejoin, since ungrouping left each of them standing alone. One group
+    therefore restores its whole layer, which is all its channels still have in common, and that is also
+    what the Images panel's context menu asks for when it names one group. Two or more say exactly which.
+*/
+std::vector<int> regroup_channels(const EditContext &ctx)
+{
+    auto img = ctx.image();
+    if (!img)
+        return {};
+
+    const std::vector<int> groups = ctx.target_groups();
+    if (groups.size() == 1)
+        return ungrouped_in_layer(img, layer_of(img, groups.front()));
+
+    std::vector<int> out;
+    for (int g : groups)
+        for (int c : group_channels(img, g))
+            if (img->channels[size_t(c)].ungrouped)
+                out.push_back(c);
+
+    return out;
+}
+
 //! Leave the viewport on whichever group now holds \p channel.
 /*!
     A rebuild renumbers the groups, so the index that was selected can afterwards mean something else
@@ -79,12 +104,6 @@ void select_channels_group(Image &img, int channel)
                 img.selected_group = int(g);
                 return;
             }
-}
-
-std::string target_layer(const EditContext &ctx)
-{
-    const std::vector<int> channels = target_channels(ctx);
-    return channels.empty() ? std::string{} : Channel::head(ctx.image()->channels[size_t(channels.front())].name);
 }
 
 /*!
@@ -140,15 +159,14 @@ public:
 };
 
 /*!
-    Put the channels of a layer back into the groups their names ask for.
+    Put ungrouped channels back into the groups their names ask for.
 
-    The counterpart to ungrouping, and scoped to a layer because that is all there is to go on.
-    Ungrouping leaves a group's channels standing on their own, and only one group can be selected at a
-    time -- so selecting any one of them and asking for its layer back is the way to say which of them is
-    meant.
+    The counterpart to ungrouping, and scoped by the selection: selecting the channels that should end up
+    together and asking for them back is how an RGBA group becomes an RGB group beside a lone alpha. The
+    groups are still derived from the names, so this only decides which channels are available to match --
+    with A held out, the R,G,B,A pattern comes up short and R,G,B matches instead.
 
-    A layer holding two ungrouped groups is restored in one go, since nothing distinguishes them once they
-    are apart.
+    A single selected group falls back to its whole layer; see regroup_channels().
 */
 class RegroupChannels final : public EditCommand
 {
@@ -164,11 +182,7 @@ public:
                 /* has_subject */ false};
     }
 
-    bool enabled(const EditContext &ctx) const override
-    {
-        auto img = ctx.image();
-        return img && !ungrouped_in_layer(img, target_layer(ctx)).empty();
-    }
+    bool enabled(const EditContext &ctx) const override { return !regroup_channels(ctx).empty(); }
 
     void apply(EditContext &ctx) override
     {
@@ -176,11 +190,20 @@ public:
         if (!img)
             return;
 
-        const std::vector<int> marked = ungrouped_in_layer(img, target_layer(ctx));
+        const std::vector<int> marked = regroup_channels(ctx);
         if (marked.empty())
             return;
 
-        const bool follow = ctx.target_group() == img->selected_group;
+        // Follow the group on screen across the rebuild when it is one of the ones being put back
+        // together; one merely pointed at from the panel must leave the viewport where it was.
+        const std::vector<int> showing = group_channels(img, img->selected_group);
+        int                    follow  = -1;
+        for (int c : marked)
+            if (std::find(showing.begin(), showing.end(), c) != showing.end())
+            {
+                follow = c;
+                break;
+            }
 
         ctx.modify_reversibly(
             "Regroup channels",
@@ -188,15 +211,15 @@ public:
             {
                 for (int c : marked) img2.channels[size_t(c)].ungrouped = false;
                 img2.rebuild_layers();
-                if (follow)
-                    select_channels_group(img2, marked.front());
+                if (follow >= 0)
+                    select_channels_group(img2, follow);
             },
             [marked, follow](Image &img2)
             {
                 for (int c : marked) img2.channels[size_t(c)].ungrouped = true;
                 img2.rebuild_layers();
-                if (follow)
-                    select_channels_group(img2, marked.front());
+                if (follow >= 0)
+                    select_channels_group(img2, follow);
             });
     }
 };

--- a/src/edit/commands/clipboard.cpp
+++ b/src/edit/commands/clipboard.cpp
@@ -46,8 +46,8 @@ public:
         // Reading an image is not editing it, so this is offered for one whose pixels a renderer owns --
         // taking a copy is in fact how a frame of one is kept.
         i.needs_editable = false;
-        // One clipboard, so copying from every selected image at once would just be copying from the last
-        // of them.
+        // One clipboard, so copying from every selected image would just be copying from the last of
+        // them. The only reason any command stays with the current image.
         i.fans_out = false;
         return i;
     }

--- a/src/edit/commands/clipboard.cpp
+++ b/src/edit/commands/clipboard.cpp
@@ -46,6 +46,9 @@ public:
         // Reading an image is not editing it, so this is offered for one whose pixels a renderer owns --
         // taking a copy is in fact how a frame of one is kept.
         i.needs_editable = false;
+        // One clipboard, so copying from every selected image at once would just be copying from the last
+        // of them.
+        i.fans_out = false;
         return i;
     }
 
@@ -61,7 +64,13 @@ public:
 class Cut final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Cut", "Cut selection"}, ICON_MY_CUT, ImGuiMod_Ctrl | ImGuiKey_X}; }
+    Info info() const override
+    {
+        Info i{{"Cut", "Cut selection"}, ICON_MY_CUT, ImGuiMod_Ctrl | ImGuiKey_X};
+        // Cutting is a copy as much as it is an edit, and the copy is what cannot fan out; see Copy.
+        i.fans_out = false;
+        return i;
+    }
 
     void apply(EditContext &ctx) override
     {

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -48,8 +48,8 @@ public:
                27.f};
         // Reparameterizes the whole image, so there is no subject to narrow and nothing in it that names
         // one selected image over another.
-        i.has_subject = false;
-        i.fans_out    = false;
+        i.draws_subject_selector = false;
+        i.fans_out               = false;
         return i;
     }
 
@@ -170,8 +170,8 @@ public:
                ImGuiInputFlags_None,
                "Convolve",
                27.f};
-        i.has_subject = false;
-        i.fans_out    = false;
+        i.draws_subject_selector = false;
+        i.fans_out               = false;
         return i;
     }
 

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -46,10 +46,8 @@ public:
                ImGuiInputFlags_None,
                "Remap",
                27.f};
-        // Reparameterizes the whole image, so there is no subject to narrow and nothing in it that names
-        // one selected image over another.
+        // Reparameterizes the whole image, so there is no subject to narrow.
         i.draws_subject_selector = false;
-        i.fans_out               = false;
         return i;
     }
 
@@ -171,7 +169,6 @@ public:
                "Convolve",
                27.f};
         i.draws_subject_selector = false;
-        i.fans_out               = false;
         return i;
     }
 

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -40,13 +40,17 @@ class Remap final : public EditCommand
 public:
     Info info() const override
     {
-        return {{"Remap envmap...", "Change environment map format", "Spherical remapping"},
-                ICON_MY_ENVMAP,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Remap",
-                27.f,
-                false};
+        Info i{{"Remap envmap...", "Change environment map format", "Spherical remapping"},
+               ICON_MY_ENVMAP,
+               ImGuiKey_None,
+               ImGuiInputFlags_None,
+               "Remap",
+               27.f};
+        // Reparameterizes the whole image, so there is no subject to narrow and nothing in it that names
+        // one selected image over another.
+        i.has_subject = false;
+        i.fans_out    = false;
+        return i;
     }
 
     //! Opens at the current image's size, then follows the target's own aspect from there.
@@ -160,13 +164,15 @@ class Irradiance final : public EditCommand
 public:
     Info info() const override
     {
-        return {{"Irradiance envmap...", "Diffuse convolution", "Cosine convolution"},
-                ICON_MY_IRRADIANCE,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Convolve",
-                27.f,
-                false};
+        Info i{{"Irradiance envmap...", "Diffuse convolution", "Cosine convolution"},
+               ICON_MY_IRRADIANCE,
+               ImGuiKey_None,
+               ImGuiInputFlags_None,
+               "Convolve",
+               27.f};
+        i.has_subject = false;
+        i.fans_out    = false;
+        return i;
     }
 
     //! The current image's size, rather than a fixed small one: the result is usually looked at beside it.

--- a/src/edit/commands/mipmap.cpp
+++ b/src/edit/commands/mipmap.cpp
@@ -48,10 +48,8 @@ public:
                ImGuiInputFlags_None,
                "Generate",
                26.f};
-        // Rewrites the whole image into a pyramid, so there is no subject to narrow and nothing in it
-        // that names one selected image over another.
+        // Rewrites the whole image into a pyramid, so there is no subject to narrow.
         i.draws_subject_selector = false;
-        i.fans_out               = false;
         return i;
     }
 

--- a/src/edit/commands/mipmap.cpp
+++ b/src/edit/commands/mipmap.cpp
@@ -23,10 +23,7 @@ namespace
 {
 
 //! How many levels an image of \p size has, counting the image itself, down to a single sample.
-int level_count(int2 size)
-{
-    return 1 + int(std::floor(std::log2(float(std::max(1, std::max(size.x, size.y))))));
-}
+int level_count(int2 size) { return 1 + int(std::floor(std::log2(float(std::max(1, std::max(size.x, size.y)))))); }
 
 /*!
     Halve an image repeatedly, putting each level in the list as an image of its own.
@@ -45,13 +42,17 @@ class GenerateMipmaps final : public EditCommand
 public:
     Info info() const override
     {
-        return {{"Generate mipmaps...", "Build a mip pyramid", "Halve repeatedly"},
-                ICON_MY_CHANNEL_GROUP,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Generate",
-                26.f,
-                /* has_subject */ false};
+        Info i{{"Generate mipmaps...", "Build a mip pyramid", "Halve repeatedly"},
+               ICON_MY_CHANNEL_GROUP,
+               ImGuiKey_None,
+               ImGuiInputFlags_None,
+               "Generate",
+               26.f};
+        // Rewrites the whole image into a pyramid, so there is no subject to narrow and nothing in it
+        // that names one selected image over another.
+        i.has_subject = false;
+        i.fans_out    = false;
+        return i;
     }
 
     bool enabled(const EditContext &ctx) const override

--- a/src/edit/commands/mipmap.cpp
+++ b/src/edit/commands/mipmap.cpp
@@ -50,8 +50,8 @@ public:
                26.f};
         // Rewrites the whole image into a pyramid, so there is no subject to narrow and nothing in it
         // that names one selected image over another.
-        i.has_subject = false;
-        i.fans_out    = false;
+        i.draws_subject_selector = false;
+        i.fans_out               = false;
         return i;
     }
 

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -36,8 +36,8 @@ public:
         // A flip or a quarter turn moves every sample of every channel by definition, so there is no
         // subject for it to carry and nothing for a scope to narrow -- and nothing in it that names one
         // selected image over another either.
-        m_info.has_subject = false;
-        m_info.fans_out    = false;
+        m_info.draws_subject_selector = false;
+        m_info.fans_out               = false;
     }
 
     Info info() const override { return m_info; }
@@ -57,8 +57,8 @@ public:
         Info i{{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C};
         // Reshapes the image rather than writing into it, as the other two size commands do, so the
         // subject has nothing to say about it, and it stays with the image being looked at.
-        i.has_subject = false;
-        i.fans_out    = false;
+        i.draws_subject_selector = false;
+        i.fans_out               = false;
         return i;
     }
 
@@ -181,8 +181,8 @@ public:
                30.f};
         // Replaces the image rather than writing into it, so the subject has nothing to say about it, and
         // it stays with the image being looked at.
-        i.has_subject = false;
-        i.fans_out    = false;
+        i.draws_subject_selector = false;
+        i.fans_out               = false;
         return i;
     }
 
@@ -246,8 +246,8 @@ public:
                ImGuiInputFlags_None,
                "Resize",
                30.f};
-        i.has_subject = false;
-        i.fans_out    = false;
+        i.draws_subject_selector = false;
+        i.fans_out               = false;
         return i;
     }
 

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -34,8 +34,10 @@ public:
         m_info(std::move(info)), m_forward(std::move(forward)), m_backward(std::move(backward))
     {
         // A flip or a quarter turn moves every sample of every channel by definition, so there is no
-        // subject for it to carry and nothing for a scope to narrow.
+        // subject for it to carry and nothing for a scope to narrow -- and nothing in it that names one
+        // selected image over another either.
         m_info.has_subject = false;
+        m_info.fans_out    = false;
     }
 
     Info info() const override { return m_info; }
@@ -54,8 +56,9 @@ public:
     {
         Info i{{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C};
         // Reshapes the image rather than writing into it, as the other two size commands do, so the
-        // subject has nothing to say about it.
+        // subject has nothing to say about it, and it stays with the image being looked at.
         i.has_subject = false;
+        i.fans_out    = false;
         return i;
     }
 
@@ -170,13 +173,17 @@ class ImageSize final : public EditCommand
 public:
     Info info() const override
     {
-        return {{"Image size...", "Resize the image"},
-                ICON_MY_IMAGE_SIZE,
-                ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_I,
-                ImGuiInputFlags_None,
-                "Resize",
-                30.f,
-                false};
+        Info i{{"Image size...", "Resize the image"},
+               ICON_MY_IMAGE_SIZE,
+               ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_I,
+               ImGuiInputFlags_None,
+               "Resize",
+               30.f};
+        // Replaces the image rather than writing into it, so the subject has nothing to say about it, and
+        // it stays with the image being looked at.
+        i.has_subject = false;
+        i.fans_out    = false;
+        return i;
     }
 
     //! Opens on the image's own size, and does not carry it to the next one.
@@ -233,13 +240,15 @@ class CanvasSize final : public EditCommand
 public:
     Info info() const override
     {
-        return {{"Canvas size..."},
-                ICON_MY_CANVAS_SIZE,
-                ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C,
-                ImGuiInputFlags_None,
-                "Resize",
-                30.f,
-                false};
+        Info i{{"Canvas size..."},
+               ICON_MY_CANVAS_SIZE,
+               ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C,
+               ImGuiInputFlags_None,
+               "Resize",
+               30.f};
+        i.has_subject = false;
+        i.fans_out    = false;
+        return i;
     }
 
     //! Opens describing the canvas as it is: its own size, or -- given relatively -- no change at all.

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -33,6 +33,9 @@ public:
     Geometric(Info info, std::function<void(Image &)> forward, std::function<void(Image &)> backward) :
         m_info(std::move(info)), m_forward(std::move(forward)), m_backward(std::move(backward))
     {
+        // A flip or a quarter turn moves every sample of every channel by definition, so there is no
+        // subject for it to carry and nothing for a scope to narrow.
+        m_info.has_subject = false;
     }
 
     Info info() const override { return m_info; }
@@ -47,7 +50,14 @@ private:
 class Crop final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C}; }
+    Info info() const override
+    {
+        Info i{{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C};
+        // Reshapes the image rather than writing into it, as the other two size commands do, so the
+        // subject has nothing to say about it.
+        i.has_subject = false;
+        return i;
+    }
 
     //! Only when there is something to crop to, and it is not already the whole image.
     bool enabled(const EditContext &ctx) const override

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -33,11 +33,9 @@ public:
     Geometric(Info info, std::function<void(Image &)> forward, std::function<void(Image &)> backward) :
         m_info(std::move(info)), m_forward(std::move(forward)), m_backward(std::move(backward))
     {
-        // A flip or a quarter turn moves every sample of every channel by definition, so there is no
-        // subject for it to carry and nothing for a scope to narrow -- and nothing in it that names one
-        // selected image over another either.
+        // A flip or a quarter turn moves every sample of every channel by definition, so there is
+        // nothing for a scope to narrow.
         m_info.draws_subject_selector = false;
-        m_info.fans_out               = false;
     }
 
     Info info() const override { return m_info; }
@@ -56,9 +54,8 @@ public:
     {
         Info i{{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C};
         // Reshapes the image rather than writing into it, as the other two size commands do, so the
-        // subject has nothing to say about it, and it stays with the image being looked at.
+        // subject has nothing to say about it.
         i.draws_subject_selector = false;
-        i.fans_out               = false;
         return i;
     }
 
@@ -77,7 +74,18 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        const Box2i box = ctx.selection();
+        auto img = ctx.image();
+        if (!img)
+            return;
+
+        // The same two conditions enabled() asks about, asked again per image: running over a selection
+        // reaches images the rectangle misses entirely, or already is, and neither is a crop -- an entry
+        // for one would sit in the history changing nothing.
+        Box2i box = ctx.selection();
+        box.intersect(img->data_window);
+        if (!box.has_volume() || box == img->data_window)
+            return;
+
         ctx.modify_structure("Crop to selection", [box](Image &i) { i.crop(box); });
 
         // What was selected is now the whole image, so the selection has nothing left to say.
@@ -179,10 +187,8 @@ public:
                ImGuiInputFlags_None,
                "Resize",
                30.f};
-        // Replaces the image rather than writing into it, so the subject has nothing to say about it, and
-        // it stays with the image being looked at.
+        // Replaces the image rather than writing into it, so the subject has nothing to say about it.
         i.draws_subject_selector = false;
-        i.fans_out               = false;
         return i;
     }
 
@@ -247,7 +253,6 @@ public:
                "Resize",
                30.f};
         i.draws_subject_selector = false;
-        i.fans_out               = false;
         return i;
     }
 

--- a/src/edit/subject.h
+++ b/src/edit/subject.h
@@ -6,6 +6,11 @@
 
 #pragma once
 
+#include "fwd.h"
+
+#include <utility>
+#include <vector>
+
 /*!
     Which of an image's samples an edit applies to.
 
@@ -13,15 +18,16 @@
     An image is now a set of named channels grouped into layers, and "invert" over a thirty-layer EXR is
     not one operation -- so every edit carries this, and says so where the user can see it.
 
-    Deliberately only two scopes. "Every visible group" would sound like a third, but group visibility is
-    recomputed from the Images panel's channel-filter text on every keystroke, which would let typing in a
-    search box quietly redefine what a destructive edit covers.
+    Three scopes and deliberately no fourth: "every visible group" would sound like one, but group
+    visibility is recomputed from the Images panel's channel-filter text on every keystroke, which would
+    let typing in a search box quietly redefine what a destructive edit covers.
 */
 struct EditSubject
 {
     enum Scope : int
     {
         Scope_CurrentGroup = 0, //!< Only the channels the viewport is currently showing
+        Scope_SelectedGroups,   //!< Every group selected in the Images panel, which always includes the current one
         Scope_AllChannels,      //!< Every channel in the image, whatever layer it belongs to
 
         Scope_COUNT
@@ -46,7 +52,25 @@ inline const char *edit_scope_name(int scope)
     switch (scope)
     {
     case EditSubject::Scope_CurrentGroup: return "Current channel group";
+    case EditSubject::Scope_SelectedGroups: return "Selected channel groups";
     case EditSubject::Scope_AllChannels: return "All channels";
     default: return "";
     }
 }
+
+/*!
+    What a scope covers, resolved against an image.
+
+    Free functions rather than members of HDRViewApp, because this depends on the subject and the image
+    alone -- which is what lets an edit's coverage be checked without constructing a window; see
+    tests/test_edit_commands.cpp.
+*/
+//! The channels of \p img that \p subject's scope names, in channel order.
+std::vector<int> subject_channels(const Image &img, const EditSubject &subject);
+
+//! The color groups of \p img that \p subject's scope names, and every channel of them.
+/*!
+    Only RGB and RGBA: everything else in an image -- depth, motion vectors, an ID -- is not color, and a
+    color operation has no meaning for it, so it is left alone rather than run through one.
+*/
+std::pair<std::vector<int>, std::vector<int>> subject_color_groups(const Image &img, const EditSubject &subject);

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -855,12 +855,15 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
         if (!group.visible)
             continue;
 
-        bool is_selected_channel  = is_current && selected_group == layer.groups[g];
+        // The group on screen, and the group's membership of the multi-selection: two different things,
+        // and a row can be either without being the other.
+        bool is_current_channel   = is_current && selected_group == layer.groups[g];
         bool is_reference_channel = is_reference && reference_group == layer.groups[g];
+        bool is_selected_channel  = is_group_selected(layer.groups[g]);
 
-        ImGuiTreeNodeFlags flags =
-            tree_node_flags |
-            (is_selected_channel || is_reference_channel ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None);
+        ImGuiTreeNodeFlags flags = tree_node_flags | (is_current_channel || is_reference_channel || is_selected_channel
+                                                          ? ImGuiTreeNodeFlags_Selected
+                                                          : ImGuiTreeNodeFlags_None);
         ImGui::TreeRow((void *)(intptr_t)id_++, flags, name.c_str(),
                        [&]
                        {
@@ -869,8 +872,10 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
                                                  : "";
                            ImGui::TextAligned2(0.0f, -FLT_MIN, shortcut.c_str());
                        },
-                       [&]
-                       { ImGui::PushRowColors(is_selected_channel, is_reference_channel, ImGui::GetIO().KeyShift); });
+                       [&] {
+                           ImGui::PushRowColors(is_current_channel, is_reference_channel, ImGui::GetIO().KeyShift,
+                                                is_selected_channel);
+                       });
 
         // Right-clicking a group points at it without selecting it: the viewport goes on showing whatever
         // it was showing, and only the operation is told which group was meant -- so a lone depth channel
@@ -906,7 +911,10 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
 
         if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen())
         {
-            if (ImGui::GetIO().KeyShift)
+            // Shift on its own is the reference modifier, as it has always been; everything else is the
+            // selection, with ctrl/cmd to toggle one group and ctrl/cmd+shift to take a range.
+            auto &io = ImGui::GetIO();
+            if (io.KeyShift && !io.KeyCtrl)
             {
                 spdlog::trace("Shift-clicked on {}", name);
                 // check if we are already the reference channel group
@@ -920,18 +928,26 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
                 {
                     spdlog::trace("Setting reference image to {}", img_idx);
                     hdrview()->set_reference_image_index(img_idx);
-                    reference_group = layer.groups[g];
+                    reference_group = this_group;
                 }
                 set_as_texture(Target_Secondary);
             }
             else
             {
-                hdrview()->set_current_image_index(img_idx);
-                selected_group = layer.groups[g];
-                set_as_texture(Target_Primary);
+                if (io.KeyShift)
+                    hdrview()->select_group_range_to(img_idx, this_group);
+                else if (io.KeyCtrl)
+                    hdrview()->toggle_group_selected(img_idx, this_group);
+                else
+                    hdrview()->set_current_group(img_idx, this_group);
+
+                // Not necessarily this image: taking the current target out of the selection hands current
+                // to whatever is still in it, which can be another image entirely.
+                if (auto cur = hdrview()->current_image())
+                    cur->set_as_texture(Target_Primary);
             }
         }
-        else if (is_selected_channel && scroll_to >= -0.5f)
+        else if (is_current_channel && scroll_to >= -0.5f)
         {
             if (!ImGui::IsItemVisible())
                 ImGui::SetScrollHereY(scroll_to);

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -657,8 +657,12 @@ void Image::draw_histogram()
                     heights[c] = shown[c] ? std::max(0.f, column_height(stats[c], xa, xb)) : 0.f;
                     order[c]   = c;
                 }
-                std::sort(order.begin(), order.begin() + n_channels,
-                          [&](int a, int b) { return heights[a] < heights[b]; });
+                // Insertion sort rather than std::sort: this runs once per pixel column over at most four
+                // elements, where std::sort's machinery costs more than the sort, and its bounds stay
+                // plain enough that the optimizer does not lose them.
+                for (int i = 1; i < n_channels; ++i)
+                    for (int j = i; j > 0 && heights[order[j]] < heights[order[j - 1]]; --j)
+                        std::swap(order[j], order[j - 1]);
 
                 // Sweep bands from the baseline upward; the channels active in a band are exactly those
                 // whose height reaches into it, so their colors sum additively.

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -879,33 +879,46 @@ void Image::draw_layer_groups(const Layer &layer, int img_idx, int &id_, bool is
 
         // Right-clicking a group points at it without selecting it: the viewport goes on showing whatever
         // it was showing, and only the operation is told which group was meant -- so a lone depth channel
-        // can be deleted while a color stays on screen.
+        // can be deleted while a color stays on screen. Right-clicking one that is already selected covers
+        // the whole selection instead; see HDRViewApp::target_groups().
         const int this_group = layer.groups[g];
 
         if (ImGui::BeginPopupContextItem())
         {
             ImGui::TextDisabled("%s", name.c_str());
             ImGui::Separator();
-            for (const char *command : {"Ungroup channels", "Regroup channels", "Delete channel group"})
-            {
-                const auto &a = hdrview()->action(command);
 
-                // Deleting one channel is not deleting a group, and the label says which it is about to
-                // be; the action's name stays put, since that is what addresses it.
-                const string label = string(command) == "Delete channel group"
-                                         ? delete_channels_label(hdrview()->current_image(), this_group)
-                                         : a.names[0];
+            // Drawn as if the group were already pointed at, so what each item says and whether it is
+            // offered match what choosing it would do -- on this image, which need not be the current one.
+            hdrview()->with_target_group(
+                img_idx, this_group,
+                [&]
+                {
+                    for (const char *command : {"Ungroup channels", "Regroup channels", "Delete channel group"})
+                    {
+                        const auto &a = hdrview()->action(command);
 
-                // Spelled out as strings: imgui_ext declares a MenuItemEx taking std::string, and a
-                // null here binds to that rather than to Dear ImGui's char* one, which constructs a
-                // string from nullptr.
-                if (ImGui::MenuItemEx(label, a.icon, ImGui::GetKeyChordNameTranslated(a.chord), nullptr, a.enabled()))
-                    // Next frame rather than now: deleting a group rebuilds the very layers and groups
-                    // this loop is walking, and the rest of the tree would be drawn from vectors that had
-                    // moved out from under it.
-                    hdrview()->post_to_main_thread([command, this_group]
-                                                   { hdrview()->invoke_action_on_group(command, this_group); });
-            }
+                        // Deleting one channel is not deleting a group, nor several groups, and the label
+                        // says which it is about to be; the action's name stays put, since that is what
+                        // addresses it.
+                        auto         target = hdrview()->target_image();
+                        const string label  = string(command) == "Delete channel group"
+                                                  ? delete_channels_label(target, hdrview()->target_groups(target))
+                                                  : a.names[0];
+
+                        // Spelled out as strings: imgui_ext declares a MenuItemEx taking std::string, and a
+                        // null here binds to that rather than to Dear ImGui's char* one, which constructs a
+                        // string from nullptr.
+                        if (ImGui::MenuItemEx(label, a.icon, ImGui::GetKeyChordNameTranslated(a.chord), nullptr,
+                                              a.enabled()))
+                            // Next frame rather than now: deleting a group rebuilds the very layers and
+                            // groups this loop is walking, and the rest of the tree would be drawn from
+                            // vectors that had moved out from under it.
+                            hdrview()->post_to_main_thread(
+                                [command, img_idx, this_group]
+                                { hdrview()->invoke_action_on_group(command, img_idx, this_group); });
+                    }
+                });
             ImGui::EndPopup();
         }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1691,6 +1691,15 @@ string Image::to_string() const
     return out;
 }
 
+std::vector<int> Image::selected_groups() const
+{
+    std::vector<int> out;
+    for (int g = 0; g < (int)groups.size(); ++g)
+        if (is_group_selected(g))
+            out.push_back(g);
+    return out;
+}
+
 int Image::next_visible_group_index(int index, Direction_ direction) const
 {
     return next_matching_index(groups, index, [](size_t, const ChannelGroup &g) { return g.visible; }, direction);

--- a/src/image.h
+++ b/src/image.h
@@ -260,6 +260,17 @@ struct Channel : public Array2Df
     */
     bool ungrouped = false;
 
+    //! Whether this channel is part of the multi-selection that the Images panel shows and edits act on.
+    /*!
+        Per channel rather than per group, for the same reason as `ungrouped`: build_layers_and_groups()
+        clears and rebuilds the whole group vector, so a flag kept on a group would not survive a rebuild
+        -- including one caused by an edit that never touched the channels.
+
+        Read and written through Image::is_group_selected() and the helpers beside it, which treat a group
+        as selected when all of its channels are.
+    */
+    bool selected = false;
+
 private:
     PixelStats::Ptr                    cached_stats;
     ThreadPool::TaskTracker            async_tracker;
@@ -572,6 +583,56 @@ public:
     int2 size() const { return data_window.size(); }
 
     bool is_valid_group(int index) const { return index >= 0 && index < (int)groups.size(); }
+
+    /*!
+        \name Multi-selection
+
+        Which of this image's channel groups the user has selected. Stored on the channels (see
+        Channel::selected) and only ever derived for a group, so that a rebuild of the group vector cannot
+        lose it. HDRViewApp owns the rules that relate the selection to the current and reference images.
+    */
+    ///@{
+    //! Whether every channel of group \p index is selected.
+    bool is_group_selected(int index) const
+    {
+        if (!is_valid_group(index))
+            return false;
+
+        const auto &g = groups[size_t(index)];
+        for (int c = 0; c < g.num_channels; ++c)
+            if (!channels[size_t(g.channels[c])].selected)
+                return false;
+        return true;
+    }
+
+    //! Whether any of this image's channels is selected.
+    bool is_selected() const
+    {
+        for (const auto &c : channels)
+            if (c.selected)
+                return true;
+        return false;
+    }
+
+    //! Mark or unmark every channel of group \p index.
+    void select_group(int index, bool select = true)
+    {
+        if (!is_valid_group(index))
+            return;
+
+        const auto &g = groups[size_t(index)];
+        for (int c = 0; c < g.num_channels; ++c) channels[size_t(g.channels[c])].selected = select;
+    }
+
+    //! Unmark every channel.
+    void deselect_all()
+    {
+        for (auto &c : channels) c.selected = false;
+    }
+
+    //! The selected groups, in group order.
+    std::vector<int> selected_groups() const;
+    ///@}
 
     //! The group index to use for `target`: `selected_group` for Target_Primary, `reference_group` for
     //! Target_Secondary -- except reference_group can be left at -1 by update_visibility() (a channel

--- a/src/image.h
+++ b/src/image.h
@@ -260,14 +260,12 @@ struct Channel : public Array2Df
     */
     bool ungrouped = false;
 
-    //! Whether this channel is part of the multi-selection that the Images panel shows and edits act on.
+    //! Whether this channel is part of the multi-selection the Images panel shows and edits act on.
     /*!
         Per channel rather than per group, for the same reason as `ungrouped`: build_layers_and_groups()
-        clears and rebuilds the whole group vector, so a flag kept on a group would not survive a rebuild
-        -- including one caused by an edit that never touched the channels.
-
-        Read and written through Image::is_group_selected() and the helpers beside it, which treat a group
-        as selected when all of its channels are.
+        rebuilds the whole group vector, so a flag kept on a group would not survive a rebuild -- including
+        one caused by an edit that never touched the channels. Read through Image::is_group_selected(),
+        which counts a group selected when all its channels are.
     */
     bool selected = false;
 

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -408,7 +408,7 @@ void ScrollWhenDraggingOnVoid(const ImVec2 &delta, ImGuiMouseButton mouse_button
         ImGui::SetScrollY(window, window->Scroll.y + delta.y);
 }
 
-void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
+void PushRowColors(bool is_current, bool is_reference, bool reference_mod, bool is_selected)
 {
     float4 active  = GetStyleColorVec4(ImGuiCol_HeaderActive);
     float4 header  = GetStyleColorVec4(ImGuiCol_Header);
@@ -418,7 +418,7 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
     // visible row per frame, so they're cached and rederived only when the theme actually changes --
     // comparing three colors is much cheaper than six HSV<->RGB conversions.
     static float4 cached_hovered{-1.f}, cached_header{-1.f}, cached_active{-1.f};
-    static float4 hovered_c, header_c, active_c, hovered_avg, header_avg, active_avg;
+    static float4 hovered_c, header_c, active_c, hovered_avg, header_avg, active_avg, header_dim;
     if (hovered != cached_hovered || header != cached_header || active != cached_active)
     {
         cached_hovered = hovered;
@@ -435,11 +435,17 @@ void PushRowColors(bool is_current, bool is_reference, bool reference_mod)
         hovered_avg = 0.5f * (hovered_c + hovered);
         header_avg  = 0.5f * (header_c + header);
         active_avg  = 0.5f * (active_c + active);
+
+        // A selected row that isn't the current one is the same color at three quarters strength, which
+        // is done with the alpha rather than by scaling the color: against the light theme's background,
+        // a darker blue would read as more emphasis than the current row rather than less.
+        header_dim = float4{header.xyz(), 0.75f * header.w};
     }
 
     ImGui::PushStyleColor(ImGuiCol_HeaderHovered, reference_mod ? (is_current ? hovered_avg : hovered_c)
                                                                 : (is_reference ? hovered_avg : hovered));
-    ImGui::PushStyleColor(ImGuiCol_Header, is_reference ? (is_current ? header_avg : header_c) : header);
+    ImGui::PushStyleColor(ImGuiCol_Header, is_reference ? (is_current ? header_avg : header_c)
+                                                        : (is_current || !is_selected ? header : header_dim));
     ImGui::PushStyleColor(ImGuiCol_HeaderActive, reference_mod ? (is_current ? active_avg : active_c) : active);
 }
 

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -286,7 +286,13 @@ inline void AlignCursor(const std::string &text, float align) { AlignCursor(Calc
 // right-align the truncated file name
 std::string TruncatedText(const std::string &filename, const std::string &icon);
 
-void PushRowColors(bool is_current, bool is_reference, bool reference_mod = false);
+//! Push the Header/HeaderHovered/HeaderActive colors an image-list row is drawn with.
+/*!
+    A row can be the current one, one of several selected, the reference, or both current and reference --
+    which draws the average of the two, since those are independent of each other. `reference_mod` previews
+    what a shift-click would do, so hovering with shift held tints in the reference color.
+*/
+void PushRowColors(bool is_current, bool is_reference, bool reference_mod = false, bool is_selected = false);
 
 //! Draws one row of a table-as-tree/outliner view -- the shared skeleton behind the image list's three
 //! row kinds (top-level image rows, flat/tree channel-group rows, tree-mode layer-path rows): TableNextRow(),

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -119,6 +119,35 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         reset_images(ctx);
     };
 
+    t           = IM_REGISTER_TEST(engine, "edit", "a color edit that covers nothing says so");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        if (!load_fixture(ctx))
+            return;
+
+        // Ungrouping leaves every channel standing alone, and a lone channel is not a color group -- so
+        // the scope now names groups that a color operation has nothing to do with. Reachable from the
+        // menu in two clicks, which is why doing nothing quietly is not good enough.
+        menu_click(ctx, "Edit/Ungroup channels");
+        auto img = hdrview()->current_image();
+        IM_CHECK_EQ((int)img->groups.size(), 4);
+
+        const auto original = snapshot(img);
+        const int  entries  = (int)img->history.size();
+
+        LogWatcher  log;
+        EditSubject all_channels;
+        all_channels.scope = EditSubject::Scope_AllChannels;
+        IM_CHECK_EQ(hdrview()->modify_colors(img, "Test", all_channels, [](const float4 &c, int2) { return -c; }),
+                    false);
+
+        IM_CHECK(snapshot(img) == original);
+        IM_CHECK_EQ((int)img->history.size(), entries);
+        IM_CHECK(log.warnings() > 0);
+
+        reset_images(ctx);
+    };
+
     t           = IM_REGISTER_TEST(engine, "edit", "a filter over a selection reaches every image in turn");
     t->TestFunc = [](ImGuiTestContext *ctx)
     {

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -69,6 +69,71 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 {
     ImGuiTest *t = nullptr;
 
+    t           = IM_REGISTER_TEST(engine, "edit", "an edit covers every selected image");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        reset_images(ctx);
+        hdrview()->roi()          = Box2i{};
+        hdrview()->edit_subject() = EditSubject{};
+        IM_CHECK_SILENT(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2}) == 2);
+
+        // Selected here rather than clicked: the chords that build a selection are navigation's business,
+        // and what this is about is what an edit does once there is one.
+        hdrview()->set_current_image_index(0);
+        hdrview()->toggle_group_selected(1, hdrview()->image(1)->selected_group);
+        IM_CHECK(hdrview()->image(0)->is_selected());
+        IM_CHECK(hdrview()->image(1)->is_selected());
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+
+        // An edit that takes a subject reaches both, each as an entry in its own history.
+        menu_click(ctx, "Edit/Invert");
+        for (int i = 0; i < 2; ++i)
+        {
+            IM_CHECK_EQ((int)hdrview()->image(i)->history.size(), 1);
+            IM_CHECK_STR_EQ(hdrview()->image(i)->history.undo_name().c_str(), "Invert");
+        }
+
+        // Undo and redo step every selected image, not only the one being looked at.
+        menu_click(ctx, "Edit/Undo");
+        for (int i = 0; i < 2; ++i) IM_CHECK_EQ(hdrview()->image(i)->history.has_undo(), false);
+        menu_click(ctx, "Edit/Redo");
+        for (int i = 0; i < 2; ++i) IM_CHECK_EQ(hdrview()->image(i)->history.has_undo(), true);
+
+        // An edit that covers the image entire has no subject to narrow, so there is nothing in it that
+        // names one selected image over another: it stays with the one being looked at.
+        menu_click(ctx, "Edit/Flip image horizontally");
+        IM_CHECK_EQ((int)hdrview()->image(0)->history.size(), 2);
+        IM_CHECK_EQ((int)hdrview()->image(1)->history.size(), 1);
+
+        // And copying reads one image however many are selected -- there is one clipboard.
+        menu_click(ctx, "Edit/Copy");
+        IM_CHECK(hdrview()->clipboard() != nullptr);
+        IM_CHECK_EQ(hdrview()->clipboard()->size().x, hdrview()->image(0)->size().x);
+        IM_CHECK_EQ(hdrview()->clipboard()->size().y, hdrview()->image(0)->size().y);
+    };
+
+    t           = IM_REGISTER_TEST(engine, "edit", "a filter over a selection reaches every image in turn");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        reset_images(ctx);
+        hdrview()->roi()          = Box2i{};
+        hdrview()->edit_subject() = EditSubject{};
+        IM_CHECK_SILENT(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2}) == 2);
+
+        hdrview()->set_current_image_index(0);
+        hdrview()->toggle_group_selected(1, hdrview()->image(1)->selected_group);
+
+        // Only one filter runs at a time -- there is one progress bar and one Cancel -- so the second
+        // image's blur waits for the first and is started as it lands, rather than being dropped.
+        menu_click(ctx, "Edit/Blur...");
+        ctx->SetRef("Blur...");
+        ctx->KeyPress(ImGuiKey_Enter);
+        wait_until(ctx,
+                   [] { return hdrview()->image(0)->history.has_undo() && hdrview()->image(1)->history.has_undo(); });
+
+        for (int i = 0; i < 2; ++i) IM_CHECK_EQ((int)hdrview()->image(i)->history.size(), 1);
+    };
+
     t           = IM_REGISTER_TEST(engine, "edit", "flip from the menu changes the pixels");
     t->TestFunc = [](ImGuiTestContext *ctx)
     {

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -110,6 +110,10 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         IM_CHECK(hdrview()->clipboard() != nullptr);
         IM_CHECK_EQ(hdrview()->clipboard()->size().x, hdrview()->image(0)->size().x);
         IM_CHECK_EQ(hdrview()->clipboard()->size().y, hdrview()->image(0)->size().y);
+
+        // Edited images left loaded would make the next test's close_all_images() prompt rather than
+        // close.
+        reset_images(ctx);
     };
 
     t           = IM_REGISTER_TEST(engine, "edit", "a filter over a selection reaches every image in turn");
@@ -132,6 +136,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
                    [] { return hdrview()->image(0)->history.has_undo() && hdrview()->image(1)->history.has_undo(); });
 
         for (int i = 0; i < 2; ++i) IM_CHECK_EQ((int)hdrview()->image(i)->history.size(), 1);
+
+        reset_images(ctx);
     };
 
     t           = IM_REGISTER_TEST(engine, "edit", "flip from the menu changes the pixels");

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -99,14 +99,17 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         menu_click(ctx, "Edit/Redo");
         for (int i = 0; i < 2; ++i) IM_CHECK_EQ(hdrview()->image(i)->history.has_undo(), true);
 
-        // An edit that covers the image entire has no subject to narrow, so there is nothing in it that
-        // names one selected image over another: it stays with the one being looked at.
-        menu_click(ctx, "Edit/Flip image horizontally");
-        IM_CHECK_EQ((int)hdrview()->image(0)->history.size(), 2);
-        IM_CHECK_EQ((int)hdrview()->image(1)->history.size(), 1);
+        // An edit that reshapes an image reaches both too: nothing about a quarter turn names one
+        // selected image over another.
+        menu_click(ctx, "Edit/Rotate 90 degrees clockwise");
+        for (int i = 0; i < 2; ++i) IM_CHECK_EQ((int)hdrview()->image(i)->history.size(), 2);
 
-        // And copying reads one image however many are selected -- there is one clipboard.
-        menu_click(ctx, "Edit/Copy");
+        // Cutting is the exception, and copying with it: there is one clipboard, so both read and clear
+        // the image being looked at and leave the rest of the selection alone.
+        menu_click(ctx, "Edit/Select all");
+        menu_click(ctx, "Edit/Cut");
+        IM_CHECK_EQ((int)hdrview()->image(0)->history.size(), 3);
+        IM_CHECK_EQ((int)hdrview()->image(1)->history.size(), 2);
         IM_CHECK(hdrview()->clipboard() != nullptr);
         IM_CHECK_EQ(hdrview()->clipboard()->size().x, hdrview()->image(0)->size().x);
         IM_CHECK_EQ(hdrview()->clipboard()->size().y, hdrview()->image(0)->size().y);
@@ -481,6 +484,29 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         menu_click(ctx, "Edit/Undo");
         IM_CHECK(img->size() == size);
         IM_CHECK(snapshot(img) == original);
+
+        // With several images selected it crops all of them, to the same rectangle. Cropping consumes the
+        // selection it just made the whole image, so every image after the first would find nothing to
+        // crop to unless each invocation starts from the same one.
+        reset_images(ctx);
+        hdrview()->roi()          = Box2i{};
+        hdrview()->edit_subject() = EditSubject{};
+        IM_CHECK_SILENT(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2}) == 2);
+        hdrview()->set_current_image_index(0);
+        hdrview()->toggle_group_selected(1, hdrview()->image(1)->selected_group);
+
+        hdrview()->set_selection(Box2i{int2{1, 1}, int2{5, 4}});
+        ctx->Yield();
+        menu_click(ctx, "Edit/Crop to selection");
+
+        for (int i = 0; i < 2; ++i)
+        {
+            IM_CHECK((hdrview()->image(i)->size() == int2{4, 3}));
+            IM_CHECK_EQ((int)hdrview()->image(i)->history.size(), 1);
+        }
+        IM_CHECK_EQ(hdrview()->roi().has_volume(), false);
+
+        reset_images(ctx);
     };
 
     t           = IM_REGISTER_TEST(engine, "edit", "cropping is only offered when it would do something");

--- a/tests/gui/test_gui_navigation.cpp
+++ b/tests/gui/test_gui_navigation.cpp
@@ -43,6 +43,34 @@ static void load_both_fixtures(ImGuiTestContext *ctx)
     IM_CHECK_EQ(hdrview()->num_visible_images(), 2);
 }
 
+//! The Images window's image rows, in list order.
+/*!
+    The rows are rendered inside a BeginTable("ImageList", ...) (app-windows.cpp), which ImGui hosts in its
+    own child window named "Images/ImageList_<hex ID>" -- the hex suffix is a per-build ID hash, not
+    something to hardcode. Each image row is an unlabeled TreeNodeEx at depth 2 within that window (depth 3
+    is the row's own nested content, e.g. its channel-group rows), so gather broadly and filter.
+*/
+static std::vector<ImGuiID> gather_image_rows(ImGuiTestContext *ctx)
+{
+    // GatherItems()'s parent ref resolves relative to whatever SetRef() is still active (the same quirk
+    // WindowInfo() has), so a bare "Images" here could resolve to "Images/Images". Use the absolute form.
+    ImGuiTestItemList all_items;
+    ctx->GatherItems(&all_items, "//Images", -1);
+
+    std::vector<ImGuiID> row_ids;
+    for (const ImGuiTestItemInfo &item : all_items)
+        if (item.Depth == 2 && item.Window && strstr(item.Window->Name, "ImageList") != nullptr)
+            row_ids.push_back(item.ID);
+    return row_ids;
+}
+
+//! Whether image \p i has any channel group in the multi-selection.
+static bool image_is_selected(int i)
+{
+    ConstImagePtr img = hdrview()->image(i);
+    return img && img->is_selected();
+}
+
 void RegisterTests_Navigation(ImGuiTestEngine *engine)
 {
     ImGuiTest *t = IM_REGISTER_TEST(engine, "navigation", "keyboard_next_previous");
@@ -76,22 +104,7 @@ void RegisterTests_Navigation(ImGuiTestEngine *engine)
     {
         load_both_fixtures(ctx);
 
-        // load_both_fixtures() leaves SetRef("Images") active; GatherItems()'s parent ref resolves
-        // relative to that (the same quirk WindowInfo() has - see test_gui_dialogs.cpp), so a bare
-        // "Images" here would actually resolve to "Images/Images". Use the explicit absolute form instead.
-        //
-        // The row list is rendered inside a BeginTable("ImageList", ...) (app-windows.cpp), which ImGui
-        // hosts in its own child window named "Images/ImageList_<hex ID>" - the hex suffix is a per-build
-        // ID hash, not something to hardcode. Each row is an unlabeled TreeNodeEx at depth 2 within that
-        // window (depth 3 is the row's own nested content, e.g. its channel-group selector) - filter the
-        // full gathered list down to exactly those rather than guessing a fixed path.
-        ImGuiTestItemList all_items;
-        ctx->GatherItems(&all_items, "//Images", -1);
-
-        std::vector<ImGuiID> row_ids;
-        for (const ImGuiTestItemInfo &item : all_items)
-            if (item.Depth == 2 && item.Window && strstr(item.Window->Name, "ImageList") != nullptr)
-                row_ids.push_back(item.ID);
+        std::vector<ImGuiID> row_ids = gather_image_rows(ctx);
         IM_CHECK_EQ((int)row_ids.size(), 2);
 
         ctx->ItemClick(row_ids[1]);
@@ -152,5 +165,87 @@ void RegisterTests_Navigation(ImGuiTestEngine *engine)
         ctx->KeyUp(ImGuiMod_Shift);
         IM_CHECK_EQ(hdrview()->reference_image_index(), -1);
         IM_CHECK_EQ(img->reference_group, -1);
+    };
+
+    // The whole click state machine in one walk: a plain click either collapses the selection or merely
+    // moves current through it, ctrl/cmd toggles, and neither is allowed to leave nothing selected or to
+    // leave current outside the selection.
+    t           = IM_REGISTER_TEST(engine, "navigation", "ctrl_click_multi_selection");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        load_both_fixtures(ctx);
+
+        std::vector<ImGuiID> row_ids = gather_image_rows(ctx);
+        IM_CHECK_EQ((int)row_ids.size(), 2);
+
+        // A plain click on a row outside the selection collapses the selection onto it.
+        ctx->ItemClick(row_ids[1]);
+        ctx->ItemClick(row_ids[0]);
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+        IM_CHECK(image_is_selected(0));
+        IM_CHECK(!image_is_selected(1));
+
+        // Ctrl/cmd adds to the selection without moving current.
+        ctx->KeyDown(ImGuiMod_Ctrl);
+        ctx->ItemClick(row_ids[1]);
+        ctx->KeyUp(ImGuiMod_Ctrl);
+        IM_CHECK(image_is_selected(0));
+        IM_CHECK(image_is_selected(1));
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+
+        // A plain click inside the selection keeps it, and only moves current.
+        ctx->ItemClick(row_ids[1]);
+        IM_CHECK_EQ(hdrview()->current_image_index(), 1);
+        IM_CHECK(image_is_selected(0));
+        IM_CHECK(image_is_selected(1));
+
+        // Taking the current row out of the selection hands current to what is left of it.
+        ctx->KeyDown(ImGuiMod_Ctrl);
+        ctx->ItemClick(row_ids[1]);
+        ctx->KeyUp(ImGuiMod_Ctrl);
+        IM_CHECK(!image_is_selected(1));
+        IM_CHECK(image_is_selected(0));
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+
+        // And the last selected row refuses to leave: an empty selection would leave every edit with
+        // nothing to act on and no way back except clicking something.
+        ctx->KeyDown(ImGuiMod_Ctrl);
+        ctx->ItemClick(row_ids[0]);
+        ctx->KeyUp(ImGuiMod_Ctrl);
+        IM_CHECK(image_is_selected(0));
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+    };
+
+    t           = IM_REGISTER_TEST(engine, "navigation", "ctrl_shift_click_selects_a_range");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        ctx->SetRef("Images");
+        ctx->ItemInputValue("##file filter", "");
+        hdrview()->close_all_images();
+
+        // Three rows rather than two, so a range has a middle for a chord that only selected its ends to
+        // fall through.
+        hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2, HDRVIEW_GUI_TEST_IMAGE});
+        wait_for_loads(ctx);
+        IM_CHECK_EQ(hdrview()->num_visible_images(), 3);
+
+        std::vector<ImGuiID> row_ids = gather_image_rows(ctx);
+        IM_CHECK_EQ((int)row_ids.size(), 3);
+
+        ctx->ItemClick(row_ids[0]);
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+        IM_CHECK(!image_is_selected(1));
+
+        ctx->KeyDown(ImGuiMod_Ctrl);
+        ctx->KeyDown(ImGuiMod_Shift);
+        ctx->ItemClick(row_ids[2]);
+        ctx->KeyUp(ImGuiMod_Shift);
+        ctx->KeyUp(ImGuiMod_Ctrl);
+
+        for (int i = 0; i < 3; ++i) IM_CHECK(image_is_selected(i));
+        IM_CHECK_EQ(hdrview()->current_image_index(), 2);
+
+        // Shift alone still means the reference, which is why the range chord needs ctrl as well.
+        IM_CHECK_EQ(hdrview()->reference_image_index(), -1);
     };
 }

--- a/tests/gui/test_gui_navigation.cpp
+++ b/tests/gui/test_gui_navigation.cpp
@@ -36,7 +36,9 @@ static void load_both_fixtures(ImGuiTestContext *ctx)
     ctx->SetRef("Images");
     ctx->ItemInputValue("##file filter", "");
 
-    hdrview()->close_all_images();
+    // Closed outright rather than through close_all_images(), which prompts when an earlier test left an
+    // edited image behind and would then leave both fixtures loaded on top of it.
+    reset_images(ctx);
     hdrview()->load_images({HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2});
     wait_for_loads(ctx);
     IM_CHECK_EQ(hdrview()->num_images(), 2);
@@ -69,6 +71,42 @@ static bool image_is_selected(int i)
 {
     ConstImagePtr img = hdrview()->image(i);
     return img && img->is_selected();
+}
+
+//! Switches the Images window to its flat channel-group list, which is where group rows exist at all.
+/*!
+    The mode persists in the app settings, so drive the combo rather than relying on whatever this run
+    started with. Its entries are icon-prefixed, so address them by position in the popup: 1 = flat list.
+*/
+static void use_flat_list_mode(ImGuiTestContext *ctx)
+{
+    ctx->SetRef("");
+    ctx->ItemClick("//Images/##channel list mode");
+    ImGuiTestItemList modes;
+    ctx->GatherItems(&modes, "//$FOCUSED", -1);
+    IM_CHECK_SILENT(modes.GetSize() > 1);
+    ctx->ItemClick(modes[1]->ID);
+    ctx->Yield(2);
+}
+
+//! The channel-group rows named "(R,G,B,A)", one per fixture.
+/*!
+    A group row is a depth-3 item in the ImageList child window; so are the table's own header cells, and
+    every one of these is drawn with a leading icon glyph, so neither depth nor an empty-label test
+    separates them. Match the group name instead: both fixtures are RGBA PNGs, so each contributes exactly
+    one such row.
+*/
+static std::vector<ImGuiID> gather_rgba_group_rows(ImGuiTestContext *ctx)
+{
+    ImGuiTestItemList all_items;
+    ctx->GatherItems(&all_items, "//Images", -1);
+
+    std::vector<ImGuiID> ids;
+    for (const ImGuiTestItemInfo &item : all_items)
+        if (item.Depth == 3 && item.Window && strstr(item.Window->Name, "ImageList") != nullptr &&
+            strstr(item.DebugLabel, "(R,G,B,A)") != nullptr)
+            ids.push_back(item.ID);
+    return ids;
 }
 
 void RegisterTests_Navigation(ImGuiTestEngine *engine)
@@ -247,5 +285,78 @@ void RegisterTests_Navigation(ImGuiTestEngine *engine)
 
         // Shift alone still means the reference, which is why the range chord needs ctrl as well.
         IM_CHECK_EQ(hdrview()->reference_image_index(), -1);
+    };
+
+    t           = IM_REGISTER_TEST(engine, "navigation", "right_click_on_a_selected_group_covers_the_selection");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        load_both_fixtures(ctx);
+        use_flat_list_mode(ctx);
+
+        std::vector<ImGuiID> group_ids = gather_rgba_group_rows(ctx);
+        IM_CHECK_EQ((int)group_ids.size(), 2);
+
+        ctx->ItemClick(group_ids[0]);
+        ctx->KeyDown(ImGuiMod_Ctrl);
+        ctx->ItemClick(group_ids[1]);
+        ctx->KeyUp(ImGuiMod_Ctrl);
+        for (int i = 0; i < 2; ++i) IM_CHECK(image_is_selected(i));
+
+        // Right-clicking a row that is in the selection covers the selection rather than that row alone,
+        // the same way a plain click inside one keeps it.
+        ctx->ItemClick(group_ids[1], ImGuiMouseButton_Right);
+        ctx->ItemClick("//$FOCUSED/Ungroup channels");
+        // The action is posted to the main thread rather than run from the popup, since it rebuilds the
+        // very layer list the panel is walking.
+        ctx->Yield(4);
+
+        for (int i = 0; i < 2; ++i)
+        {
+            IM_CHECK_EQ((int)hdrview()->image(i)->groups.size(), 4);
+            IM_CHECK_EQ((int)hdrview()->image(i)->history.size(), 1);
+        }
+
+        // Edited images left loaded would make the next test's close_all_images() prompt rather than
+        // close.
+        reset_images(ctx);
+    };
+
+    // Every image numbers its own groups, and the panel lists every image's rows, so a group index alone
+    // cannot say which image a right-click meant.
+    t           = IM_REGISTER_TEST(engine, "navigation", "right_click_names_the_image_whose_row_it_is");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        load_both_fixtures(ctx);
+        use_flat_list_mode(ctx);
+
+        // Give the two images different group structures: after this, image 0 has four single-channel
+        // groups where image 1 still has one of four channels, so the index 0 means different things.
+        std::vector<ImGuiID> group_ids = gather_rgba_group_rows(ctx);
+        IM_CHECK_EQ((int)group_ids.size(), 2);
+        ctx->ItemClick(group_ids[0]);
+        ctx->ItemClick(group_ids[0], ImGuiMouseButton_Right);
+        ctx->ItemClick("//$FOCUSED/Ungroup channels");
+        ctx->Yield(4);
+        IM_CHECK_EQ((int)hdrview()->image(0)->groups.size(), 4);
+        IM_CHECK_EQ((int)hdrview()->image(1)->groups.size(), 1);
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+
+        // Now right-click the other image's row while image 0 is still the current one. Image 0's group 0
+        // is a lone channel by now, so a command that took the index and applied it to the current image
+        // would quietly do nothing and leave image 1 whole.
+        group_ids = gather_rgba_group_rows(ctx);
+        IM_CHECK_EQ((int)group_ids.size(), 1); // only image 1 still has an (R,G,B,A) row
+        ctx->ItemClick(group_ids[0], ImGuiMouseButton_Right);
+        ctx->ItemClick("//$FOCUSED/Ungroup channels");
+        ctx->Yield(4);
+
+        IM_CHECK_EQ((int)hdrview()->image(1)->groups.size(), 4);
+        IM_CHECK_EQ((int)hdrview()->image(1)->history.size(), 1);
+
+        // And the image being looked at was left alone, having neither moved nor gained an entry.
+        IM_CHECK_EQ((int)hdrview()->image(0)->history.size(), 1);
+        IM_CHECK_EQ(hdrview()->current_image_index(), 0);
+
+        reset_images(ctx);
     };
 }

--- a/tests/gui/test_gui_session.cpp
+++ b/tests/gui/test_gui_session.cpp
@@ -38,6 +38,9 @@ using namespace hdrview_test;
 #ifndef HDRVIEW_GUI_TEST_IMAGE
 #error "HDRVIEW_GUI_TEST_IMAGE must be defined by CMake to a small fixture image path"
 #endif
+#ifndef HDRVIEW_GUI_TEST_IMAGE_2
+#error "HDRVIEW_GUI_TEST_IMAGE_2 must be defined by CMake to a second, distinctly-named fixture image path"
+#endif
 
 namespace
 {
@@ -182,6 +185,37 @@ void RegisterTests_Session(ImGuiTestEngine *engine)
         IM_CHECK(hdrview()->current_image() != hdrview()->reference_image());
         IM_CHECK_EQ(hdrview()->current_image()->selected_group, 0);
         IM_CHECK_EQ(hdrview()->reference_image()->reference_group, 1);
+    };
+
+    // Written by build_session_manifest() rather than by hand, so a name it writes and a name the loader
+    // reads that had drifted apart would show up as a selection that did not come back.
+    t           = IM_REGISTER_TEST(engine, "session", "multi_selection_survives_a_round_trip");
+    t->TestFunc = [](ImGuiTestContext *ctx)
+    {
+        reset_images(ctx);
+        IM_CHECK_SILENT(load_and_wait(ctx, {HDRVIEW_GUI_TEST_IMAGE, HDRVIEW_GUI_TEST_IMAGE_2}) == 2);
+
+        hdrview()->set_current_image_index(0);
+        hdrview()->toggle_group_selected(1, hdrview()->image(1)->selected_group);
+        IM_CHECK(hdrview()->image(0)->is_selected());
+        IM_CHECK(hdrview()->image(1)->is_selected());
+
+        // Absolute paths, so the file can sit in the temp directory and still find its images.
+        json     j = hdrview()->build_session_manifest([](ConstImagePtr img) { return img->path.generic_u8string(); });
+        fs::path session_path = write_temp_session(j, "hdrview_test_selection.hsess");
+
+        reset_images(ctx);
+        hdrview()->load_session(session_path.string());
+        wait_for_loads(ctx);
+        wait_until(ctx, [] { return hdrview()->num_images() == 2; });
+
+        IM_CHECK_EQ(hdrview()->num_images(), 2);
+
+        // Both come back selected. Without the selection in the file, update_visibility() would collapse
+        // it onto the group the current image is showing, leaving the other one out.
+        for (int i = 0; i < 2; ++i) IM_CHECK(hdrview()->image(i)->is_selected());
+
+        fs::remove(session_path);
     };
 
     t           = IM_REGISTER_TEST(engine, "session", "missing_file_entry_logs_warning_and_loads_rest");

--- a/tests/gui/test_gui_support.h
+++ b/tests/gui/test_gui_support.h
@@ -22,6 +22,7 @@
 #include "imgui_test_engine/imgui_te_context.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <functional>
@@ -36,6 +37,43 @@ namespace hdrview_test
 {
 
 namespace fs = std::filesystem;
+
+//! Counts the warnings and errors logged while it is alive.
+/*!
+    For the paths whose whole point is to say something rather than to change something. Counted rather
+    than matched: what matters is that the app spoke up at all, and pinning the wording would make a test
+    that fails when the wording improves.
+*/
+class LogWatcher
+{
+public:
+    LogWatcher() : m_sink(std::make_shared<Sink>()) { spdlog::default_logger()->sinks().push_back(m_sink); }
+    ~LogWatcher()
+    {
+        auto &sinks = spdlog::default_logger()->sinks();
+        sinks.erase(std::remove(sinks.begin(), sinks.end(), m_sink), sinks.end());
+    }
+
+    LogWatcher(const LogWatcher &)            = delete;
+    LogWatcher &operator=(const LogWatcher &) = delete;
+
+    int warnings() const { return m_sink->count.load(); }
+
+private:
+    struct Sink final : spdlog::sinks::base_sink<std::mutex>
+    {
+        std::atomic<int> count{0};
+
+        void sink_it_(const spdlog::details::log_msg &msg) override
+        {
+            if (msg.level >= spdlog::level::warn)
+                ++count;
+        }
+        void flush_() override {}
+    };
+
+    std::shared_ptr<Sink> m_sink;
+};
 
 //! Yields until `done` holds, or `timeout` passes. Returns whether it held.
 /*!

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -552,10 +552,16 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
                         covered.push_back(img->groups[size_t(g)].channels[i]);
             }
 
-            const std::vector<float> before = samples(img);
-            const int                steps  = img->history.size();
+            const std::vector<float> before      = samples(img);
+            const int                steps       = img->history.size();
+            const ConstImagePtr      clip_before = ctx.clipboard();
 
             cmd->apply(ctx);
+
+            // There is one clipboard, so a command that fills it cannot be one that runs once per
+            // selected image -- it would only be copying from the last of them.
+            if (ctx.clipboard() != clip_before)
+                CHECK_FALSE(cmd->info().fans_out);
 
             // An edit that changed the image without going through a chokepoint that takes the subject
             // covers the image entire, and has to say so: has_subject is also what decides whether the
@@ -1112,99 +1118,64 @@ TEST_CASE("Regrouping from a selection puts back exactly the channels it names")
     CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
 }
 
-TEST_CASE("Ungrouping and deleting cover every selected group")
+TEST_CASE("A group command covers every group it is given, and nothing else")
 {
-    // Both used to reach only the group on screen, so selecting several and asking for them to come apart
-    // took apart one of them.
-    SUBCASE("ungrouping")
+    // All three are addressed by target_groups(), and each used to resolve a single group -- so selecting
+    // several and asking for them to come apart took apart one of them. Swept together rather than one
+    // test each: what they do differs, but "every target group changes and nothing outside them does" is
+    // a property all three owe.
+    for (const char *name : {"Ungroup channels", "Regroup channels", "Delete channel group"})
     {
-        auto img = make_layered_image();
-        REQUIRE(img->groups.size() == 3); // R,G,B,A -- Z -- normal.R,G,B
+        CAPTURE(name);
 
+        auto img = make_layered_image(); // R,G,B,A -- Z -- normal.R,G,B
+        REQUIRE(img->groups.size() == 3);
+
+        TestEditContext ctx{img};
+
+        // Two of the three groups selected, so a command reaching only the one on screen and one reaching
+        // every group are both caught. The depth channel is the one that has to come through untouched.
         img->selected_group = group_of_channel(img, "R");
         img->select_group(group_of_channel(img, "R"));
         img->select_group(group_of_channel(img, "normal.R"));
 
-        TestEditContext ctx{img};
-        auto            explode = find_command("Ungroup channels");
-        REQUIRE(explode);
-        REQUIRE(explode->enabled(ctx));
-        explode->apply(ctx);
+        // Regrouping has nothing to put back until something has been taken apart. The selection rides on
+        // the channels, so it survives the rebuild that renumbers the groups.
+        if (std::string(name) == "Regroup channels")
+        {
+            find_command("Ungroup channels")->apply(ctx);
+            REQUIRE(img->history.size() == 1);
+            REQUIRE(ctx.target_groups().size() == 7);
+        }
 
-        // Both color groups came apart, and the depth channel -- which was not selected -- did not.
-        CHECK(img->groups.size() == 8);
-        for (const char *n : {"R", "G", "B", "A", "normal.R", "normal.G", "normal.B"})
-            CHECK(img->channels[size_t(channel_index(img, n))].ungrouped);
+        auto cmd = find_command(name);
+        REQUIRE(cmd);
+        REQUIRE(cmd->enabled(ctx));
+
+        const int before = img->history.size();
+        cmd->apply(ctx);
+        CHECK(img->history.size() == before + 1); // one entry over the lot, not one per group
+
+        // Whatever it did, it left the group nobody selected alone.
+        REQUIRE(channel_index(img, "Z") >= 0);
         CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
 
-        // One entry over the lot, not one per group, so one undo puts all of it back.
-        CHECK(img->history.size() == 1);
+        // And it reached both of the ones that were.
+        if (std::string(name) == "Ungroup channels")
+            for (const char *n : {"R", "G", "B", "A", "normal.R", "normal.G", "normal.B"})
+                CHECK(img->channels[size_t(channel_index(img, n))].ungrouped);
+        else if (std::string(name) == "Regroup channels")
+            for (const char *n : {"R", "G", "B", "A", "normal.R", "normal.G", "normal.B"})
+                CHECK_FALSE(img->channels[size_t(channel_index(img, n))].ungrouped);
+        else
+        {
+            REQUIRE(img->channels.size() == 1);
+            CHECK(img->channels[0].name == "Z");
+        }
+
+        // Undoing puts back exactly what was taken, and still nothing more.
         REQUIRE(img->history.undo(*img));
-        CHECK(img->groups.size() == 3);
-        for (const auto &c : img->channels) CHECK_FALSE(c.ungrouped);
-    }
-
-    SUBCASE("deleting")
-    {
-        auto img            = make_layered_image();
-        img->selected_group = group_of_channel(img, "R");
-        img->select_group(group_of_channel(img, "R"));
-        img->select_group(group_of_channel(img, "normal.R"));
-
-        TestEditContext ctx{img};
-
-        // And the menu says so: one channel, one group, or several.
-        CHECK(delete_channels_label(img, ctx.target_groups()) == "Delete channel groups");
-
-        auto del = find_command("Delete channel group");
-        REQUIRE(del);
-        REQUIRE(del->enabled(ctx));
-        del->apply(ctx);
-
-        // Only the channel whose group was not selected is left.
-        REQUIRE(img->channels.size() == 1);
-        CHECK(img->channels[0].name == "Z");
-
-        REQUIRE(img->history.undo(*img));
-        CHECK(img->channels.size() == 8);
-    }
-
-    SUBCASE("a group pointed at from outside the selection still names itself alone")
-    {
-        auto img            = make_layered_image();
-        img->selected_group = group_of_channel(img, "R");
-        img->select_group(group_of_channel(img, "R"));
-        img->select_group(group_of_channel(img, "normal.R"));
-
-        TestEditContext ctx{img};
-        ctx.set_target_group(group_of_channel(img, "Z"));
-
-        CHECK(ctx.target_groups() == std::vector<int>{group_of_channel(img, "Z")});
-        CHECK(delete_channels_label(img, ctx.target_groups()) == "Delete channel");
-
-        find_command("Delete channel group")->apply(ctx);
-
-        // The depth channel is gone; the two selected color groups it was pointed away from are not.
-        CHECK(img->channels.size() == 7);
-        CHECK(channel_index(img, "Z") == -1);
-    }
-
-    SUBCASE("a group pointed at from inside the selection covers the selection")
-    {
-        auto img            = make_layered_image();
-        img->selected_group = group_of_channel(img, "R");
-        img->select_group(group_of_channel(img, "R"));
-        img->select_group(group_of_channel(img, "normal.R"));
-
-        TestEditContext ctx{img};
-        // Right-clicking one of the selected rows, which is the case the reported bug was about.
-        ctx.set_target_group(group_of_channel(img, "normal.R"));
-
-        CHECK(ctx.target_groups().size() == 2);
-
-        find_command("Ungroup channels")->apply(ctx);
-        for (const char *n : {"R", "G", "B", "A", "normal.R", "normal.G", "normal.B"})
-            CHECK(img->channels[size_t(channel_index(img, n))].ungrouped);
+        CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
     }
 }
 
@@ -1245,7 +1216,10 @@ TEST_CASE("A group can be acted on without becoming the one on screen")
     REQUIRE(color >= 0);
     REQUIRE(depth >= 0);
 
+    // Shown *and* selected, so what follows says the pointed-at group wins over the selection rather
+    // than merely over what the viewport happens to show.
     img->selected_group = color;
+    img->select_group(color);
 
     TestEditContext ctx{img};
 
@@ -1255,18 +1229,27 @@ TEST_CASE("A group can be acted on without becoming the one on screen")
 
     // Point at the depth channel without selecting it.
     ctx.set_target_group(depth);
+    CHECK(ctx.target_groups() == std::vector<int>{depth});
+    CHECK(delete_channels_label(img, ctx.target_groups()) == "Delete channel");
 
     auto del = find_command("Delete channel group");
     REQUIRE(del);
     REQUIRE(del->enabled(ctx));
     del->apply(ctx);
 
-    // The depth channel is gone and the color is untouched -- and still what the viewport shows.
+    // The depth channel is gone and the color is untouched -- and still what the viewport shows, and
+    // still selected.
     CHECK(img->channels.size() == 3);
     for (const auto &c : img->channels) CHECK(c.name != "Z");
 
     REQUIRE(img->is_valid_group(img->selected_group));
     CHECK(img->groups[size_t(img->selected_group)].num_channels == 3);
+    CHECK(img->is_group_selected(img->selected_group));
+
+    // Pointing at a group that *is* selected is the other half of the rule: the right-click then covers
+    // the selection, the same way a click inside one keeps it rather than replacing it.
+    ctx.set_target_group(img->selected_group);
+    CHECK(ctx.target_groups() == img->selected_groups());
 }
 
 TEST_CASE("Ungrouping a group that is not on screen leaves the viewport where it was")

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -50,27 +50,21 @@ public:
     ImagePtr           image() const override { return m_image; }
     const EditSubject &subject() const override { return m_subject; }
 
-    //! The group being pointed at when one has been set, and otherwise the one the image is showing.
-    int target_group() const override
-    {
-        if (m_target_group >= 0)
-            return m_target_group;
-        return m_image ? m_image->active_group_index(Target_Primary) : -1;
-    }
-
-    //! The pointed-at group when one has been set, and otherwise the image's selection; mirrors
-    //! HDRViewApp::target_groups(), including its fallback to the group on screen when nothing is
-    //! selected.
+    //! Mirrors HDRViewApp::target_groups(): a group pointed at from outside the selection names itself
+    //! alone, one inside it covers the selection, and an image the panel has never had a say over falls
+    //! back to the group it is showing.
     std::vector<int> target_groups() const override
     {
-        if (m_target_group >= 0)
-            return {m_target_group};
         if (!m_image)
             return {};
 
+        if (m_target_group >= 0 && !m_image->is_group_selected(m_target_group))
+            return {m_target_group};
+
         std::vector<int> groups = m_image->selected_groups();
-        if (groups.empty() && m_image->is_valid_group(target_group()))
-            groups.push_back(target_group());
+        const int        shown  = m_image->active_group_index(Target_Primary);
+        if (groups.empty() && m_image->is_valid_group(shown))
+            groups.push_back(shown);
         return groups;
     }
 
@@ -1118,19 +1112,115 @@ TEST_CASE("Regrouping from a selection puts back exactly the channels it names")
     CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
 }
 
+TEST_CASE("Ungrouping and deleting cover every selected group")
+{
+    // Both used to reach only the group on screen, so selecting several and asking for them to come apart
+    // took apart one of them.
+    SUBCASE("ungrouping")
+    {
+        auto img = make_layered_image();
+        REQUIRE(img->groups.size() == 3); // R,G,B,A -- Z -- normal.R,G,B
+
+        img->selected_group = group_of_channel(img, "R");
+        img->select_group(group_of_channel(img, "R"));
+        img->select_group(group_of_channel(img, "normal.R"));
+
+        TestEditContext ctx{img};
+        auto            explode = find_command("Ungroup channels");
+        REQUIRE(explode);
+        REQUIRE(explode->enabled(ctx));
+        explode->apply(ctx);
+
+        // Both color groups came apart, and the depth channel -- which was not selected -- did not.
+        CHECK(img->groups.size() == 8);
+        for (const char *n : {"R", "G", "B", "A", "normal.R", "normal.G", "normal.B"})
+            CHECK(img->channels[size_t(channel_index(img, n))].ungrouped);
+        CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
+
+        // One entry over the lot, not one per group, so one undo puts all of it back.
+        CHECK(img->history.size() == 1);
+        REQUIRE(img->history.undo(*img));
+        CHECK(img->groups.size() == 3);
+        for (const auto &c : img->channels) CHECK_FALSE(c.ungrouped);
+    }
+
+    SUBCASE("deleting")
+    {
+        auto img            = make_layered_image();
+        img->selected_group = group_of_channel(img, "R");
+        img->select_group(group_of_channel(img, "R"));
+        img->select_group(group_of_channel(img, "normal.R"));
+
+        TestEditContext ctx{img};
+
+        // And the menu says so: one channel, one group, or several.
+        CHECK(delete_channels_label(img, ctx.target_groups()) == "Delete channel groups");
+
+        auto del = find_command("Delete channel group");
+        REQUIRE(del);
+        REQUIRE(del->enabled(ctx));
+        del->apply(ctx);
+
+        // Only the channel whose group was not selected is left.
+        REQUIRE(img->channels.size() == 1);
+        CHECK(img->channels[0].name == "Z");
+
+        REQUIRE(img->history.undo(*img));
+        CHECK(img->channels.size() == 8);
+    }
+
+    SUBCASE("a group pointed at from outside the selection still names itself alone")
+    {
+        auto img            = make_layered_image();
+        img->selected_group = group_of_channel(img, "R");
+        img->select_group(group_of_channel(img, "R"));
+        img->select_group(group_of_channel(img, "normal.R"));
+
+        TestEditContext ctx{img};
+        ctx.set_target_group(group_of_channel(img, "Z"));
+
+        CHECK(ctx.target_groups() == std::vector<int>{group_of_channel(img, "Z")});
+        CHECK(delete_channels_label(img, ctx.target_groups()) == "Delete channel");
+
+        find_command("Delete channel group")->apply(ctx);
+
+        // The depth channel is gone; the two selected color groups it was pointed away from are not.
+        CHECK(img->channels.size() == 7);
+        CHECK(channel_index(img, "Z") == -1);
+    }
+
+    SUBCASE("a group pointed at from inside the selection covers the selection")
+    {
+        auto img            = make_layered_image();
+        img->selected_group = group_of_channel(img, "R");
+        img->select_group(group_of_channel(img, "R"));
+        img->select_group(group_of_channel(img, "normal.R"));
+
+        TestEditContext ctx{img};
+        // Right-clicking one of the selected rows, which is the case the reported bug was about.
+        ctx.set_target_group(group_of_channel(img, "normal.R"));
+
+        CHECK(ctx.target_groups().size() == 2);
+
+        find_command("Ungroup channels")->apply(ctx);
+        for (const char *n : {"R", "G", "B", "A", "normal.R", "normal.G", "normal.B"})
+            CHECK(img->channels[size_t(channel_index(img, n))].ungrouped);
+    }
+}
+
 TEST_CASE("The delete command says whether it is about to take one channel or a group")
 {
     // The label follows the group on screen while the action's name stays put, since the name is what the
     // registry, the palette and these tests address it by.
     auto img = make_image();
-    REQUIRE(delete_channels_label(img, img->selected_group) == "Delete channel group");
+    REQUIRE(delete_channels_label(img, {img->selected_group}) == "Delete channel group");
 
     TestEditContext ctx{img};
     find_command("Ungroup channels")->apply(ctx);
 
     // Now every group is a lone channel, and deleting one is not deleting a group.
     REQUIRE(img->groups[size_t(img->selected_group)].num_channels == 1);
-    CHECK(delete_channels_label(img, img->selected_group) == "Delete channel");
+    CHECK(delete_channels_label(img, {img->selected_group}) == "Delete channel");
 
     // The command is still registered under the one name throughout.
     CHECK(find_command("Delete channel group") != nullptr);
@@ -1160,8 +1250,8 @@ TEST_CASE("A group can be acted on without becoming the one on screen")
     TestEditContext ctx{img};
 
     // What the label says it is about to do differs between the two, which is the point of it varying.
-    CHECK(delete_channels_label(img, color) == "Delete channel group");
-    CHECK(delete_channels_label(img, depth) == "Delete channel");
+    CHECK(delete_channels_label(img, {color}) == "Delete channel group");
+    CHECK(delete_channels_label(img, {depth}) == "Delete channel");
 
     // Point at the depth channel without selecting it.
     ctx.set_target_group(depth);

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -58,6 +58,22 @@ public:
         return m_image ? m_image->active_group_index(Target_Primary) : -1;
     }
 
+    //! The pointed-at group when one has been set, and otherwise the image's selection; mirrors
+    //! HDRViewApp::target_groups(), including its fallback to the group on screen when nothing is
+    //! selected.
+    std::vector<int> target_groups() const override
+    {
+        if (m_target_group >= 0)
+            return {m_target_group};
+        if (!m_image)
+            return {};
+
+        std::vector<int> groups = m_image->selected_groups();
+        if (groups.empty() && m_image->is_valid_group(target_group()))
+            groups.push_back(target_group());
+        return groups;
+    }
+
     //! Point at a group without selecting it, the way the Images panel's context menu does.
     void          set_target_group(int group) { m_target_group = group; }
     Box2i         selection() const override { return m_selection; }
@@ -343,6 +359,44 @@ ImagePtr make_image(int num_channels = 4)
     return img;
 }
 
+//! An image with three channel groups, for the tests that need the scopes to name different channels.
+/*!
+    Two color groups and a depth channel: enough for "the group on screen", "the selected groups" and
+    "every channel" to be three different sets, and for the color-only filter to have something to drop.
+*/
+ImagePtr make_layered_image()
+{
+    auto img = std::make_shared<Image>(
+        k_size, std::vector<std::string>{"R", "G", "B", "A", "Z", "normal.R", "normal.G", "normal.B"});
+
+    for (size_t c = 0; c < img->channels.size(); ++c)
+        for (int y = 0; y < k_size.y; ++y)
+            for (int x = 0; x < k_size.x; ++x)
+                img->channels[c](x, y) = 0.15f + 0.05f * float(c) + 0.01f * float(y * k_size.x + x);
+
+    img->rebuild_layers();
+    return img;
+}
+
+//! The index of the group holding the channel named \p name, or -1.
+int group_of_channel(const ImagePtr &img, const std::string &name)
+{
+    for (size_t g = 0; g < img->groups.size(); ++g)
+        for (int i = 0; i < img->groups[g].num_channels; ++i)
+            if (img->channels[size_t(img->groups[g].channels[i])].name == name)
+                return int(g);
+    return -1;
+}
+
+//! The index of the channel named \p name, or -1.
+int channel_index(const ImagePtr &img, const std::string &name)
+{
+    for (size_t c = 0; c < img->channels.size(); ++c)
+        if (img->channels[c].name == name)
+            return int(c);
+    return -1;
+}
+
 //! Every sample of every channel, as one comparable value.
 std::vector<float> samples(const ImagePtr &img)
 {
@@ -453,51 +507,162 @@ TEST_CASE("Every edit that applies leaves exactly one undo entry, and undoing re
 
 TEST_CASE("An edit covers the subject it was given and nothing else")
 {
-    // Two scopes and a selection, swept over every command rather than checked for one: an edit that
-    // ignores the subject writes outside the rectangle, and an edit that misreads it writes to the wrong
-    // channels. Both show up as a sample changing where none should have.
-    for (auto &cmd : all_edit_commands())
+    // Every scope and a selection, swept over every command rather than checked for one: an edit that
+    // ignores the subject writes outside the rectangle, and an edit that misreads it writes to a channel
+    // the scope never named. Both show up as a sample changing where none should have.
+    //
+    // Run on a three-group image so the scopes are three different channel sets; on the single-group one
+    // they would all name the same channels and only the rectangle would be under test.
+    for (int scope = 0; scope < EditSubject::Scope_COUNT; ++scope)
+        for (auto &cmd : all_edit_commands())
+        {
+            const std::string name = first_name(cmd);
+
+            CAPTURE(name);
+            CAPTURE(scope);
+
+            auto            img = make_layered_image();
+            TestEditContext ctx{img};
+            ctx.set_clipboard(make_image());
+
+            // The color group on screen, and the two color groups selected -- so "selected" is neither
+            // the current group nor every channel, and a resolver that fell through to either is caught.
+            img->selected_group = group_of_channel(img, "R");
+            img->select_group(img->selected_group);
+            img->select_group(group_of_channel(img, "normal.R"));
+
+            // A selection well inside the image, so there is untouched ground on every side of it.
+            const Box2i roi{int2{2, 1}, int2{5, 4}};
+            ctx.set_selection(roi);
+            ctx.mutable_subject().selection_only = true;
+            ctx.mutable_subject().scope          = EditSubject::Scope(scope);
+
+            if (!cmd->enabled(ctx))
+                continue;
+
+            // Worked out here from the scope rather than asked of subject_channels(), so that this
+            // checks the resolver against an independent reading of it instead of against itself.
+            std::vector<int> covered;
+            if (scope == EditSubject::Scope_AllChannels)
+            {
+                covered.resize(img->channels.size());
+                std::iota(covered.begin(), covered.end(), 0);
+            }
+            else
+            {
+                const std::vector<int> groups = scope == EditSubject::Scope_SelectedGroups
+                                                    ? img->selected_groups()
+                                                    : std::vector<int>{img->selected_group};
+                for (int g : groups)
+                    for (int i = 0; i < img->groups[size_t(g)].num_channels; ++i)
+                        covered.push_back(img->groups[size_t(g)].channels[i]);
+            }
+
+            const std::vector<float> before = samples(img);
+            const int                steps  = img->history.size();
+
+            cmd->apply(ctx);
+
+            // Nothing to check unless the edit both happened and went through a chokepoint that takes the
+            // subject: a flip moves every sample by definition, and a resize has no rectangle to stay in.
+            if (img->history.size() == steps || img->size() != k_size || !ctx.last_edit_used_subject())
+                continue;
+
+            for (size_t c = 0; c < img->channels.size(); ++c)
+            {
+                const bool named = std::find(covered.begin(), covered.end(), int(c)) != covered.end();
+                for (int y = 0; y < k_size.y; ++y)
+                    for (int x = 0; x < k_size.x; ++x)
+                    {
+                        if (named && roi.contains(int2{x, y}))
+                            continue;
+
+                        CAPTURE(c);
+                        CAPTURE(x);
+                        CAPTURE(y);
+                        CHECK(img->channels[c](x, y) ==
+                              before[c * size_t(k_size.x * k_size.y) + size_t(y * k_size.x + x)]);
+                    }
+            }
+        }
+}
+
+TEST_CASE("Each scope names the channels it says it does")
+{
+    auto img = make_layered_image();
+
+    const int color = group_of_channel(img, "R");
+    const int depth = group_of_channel(img, "Z");
+    const int other = group_of_channel(img, "normal.R");
+    REQUIRE(img->groups.size() == 3);
+    REQUIRE(color >= 0);
+    REQUIRE(depth >= 0);
+    REQUIRE(other >= 0);
+
+    // The group on screen is the color one, and the selection is that plus the second color group --
+    // deliberately not the depth channel, so the three scopes cover 4, 7 and 8 of the 8 channels.
+    img->selected_group = color;
+    img->select_group(color);
+    img->select_group(other);
+
+    EditSubject subject;
+    subject.selection_only = false;
+
+    auto channels_under = [&](EditSubject::Scope s)
     {
-        const std::string name = first_name(cmd);
+        subject.scope = s;
+        return subject_channels(*img, subject);
+    };
+    auto color_groups_under = [&](EditSubject::Scope s)
+    {
+        subject.scope = s;
+        return subject_color_groups(*img, subject);
+    };
 
-        CAPTURE(name);
+    const auto current  = channels_under(EditSubject::Scope_CurrentGroup);
+    const auto selected = channels_under(EditSubject::Scope_SelectedGroups);
+    const auto all      = channels_under(EditSubject::Scope_AllChannels);
 
-        auto            img = make_image();
-        TestEditContext ctx{img};
-        ctx.set_clipboard(make_image());
+    CHECK(current.size() == 4);  // R,G,B,A
+    CHECK(selected.size() == 7); // and normal.R,G,B, but not Z
+    CHECK(all.size() == img->channels.size());
 
-        // A selection well inside the image, so there is untouched ground on every side of it.
-        const Box2i roi{int2{2, 1}, int2{5, 4}};
-        ctx.set_selection(roi);
-        ctx.mutable_subject().selection_only = true;
-        ctx.mutable_subject().scope          = EditSubject::Scope_CurrentGroup;
+    // Narrower to wider: each scope names everything the one before it did.
+    for (int c : current) CHECK(std::find(selected.begin(), selected.end(), c) != selected.end());
+    for (int c : selected) CHECK(std::find(all.begin(), all.end(), c) != all.end());
 
-        if (!cmd->enabled(ctx))
-            continue;
+    // The one channel the selection leaves out is exactly the one whose group was not selected.
+    CHECK(std::find(selected.begin(), selected.end(), channel_index(img, "Z")) == selected.end());
 
-        const std::vector<float> before = samples(img);
-        const int                steps  = img->history.size();
+    // Selecting every group makes "selected" and "all channels" the same set, since every channel of this
+    // image belongs to a group.
+    img->select_group(depth);
+    CHECK(channels_under(EditSubject::Scope_SelectedGroups).size() == img->channels.size());
+    img->select_group(depth, false);
 
-        cmd->apply(ctx);
+    // The color resolver keeps only the RGB/RGBA groups, whatever the scope, and its channel list is
+    // exactly the union of the groups it kept.
+    for (int s = 0; s < EditSubject::Scope_COUNT; ++s)
+    {
+        CAPTURE(s);
+        auto [groups, channels] = color_groups_under(EditSubject::Scope(s));
 
-        // Nothing to check unless the edit both happened and went through a chokepoint that takes the
-        // subject: a flip moves every sample by definition, and a resize has no rectangle to stay inside.
-        if (img->history.size() == steps || img->size() != k_size || !ctx.last_edit_used_subject())
-            continue;
-
-        for (size_t c = 0; c < img->channels.size(); ++c)
-            for (int y = 0; y < k_size.y; ++y)
-                for (int x = 0; x < k_size.x; ++x)
-                {
-                    if (roi.contains(int2{x, y}))
-                        continue;
-
-                    CAPTURE(c);
-                    CAPTURE(x);
-                    CAPTURE(y);
-                    CHECK(img->channels[c](x, y) == before[c * size_t(k_size.x * k_size.y) + size_t(y * k_size.x + x)]);
-                }
+        size_t expected = 0;
+        for (int g : groups)
+        {
+            const auto t = img->groups[size_t(g)].type;
+            CHECK((t == ChannelGroup::RGB_Channels || t == ChannelGroup::RGBA_Channels));
+            expected += size_t(img->groups[size_t(g)].num_channels);
+        }
+        CHECK(channels.size() == expected);
+        CHECK(std::find(channels.begin(), channels.end(), channel_index(img, "Z")) == channels.end());
     }
+
+    // Which is 1, 2 and 2 groups respectively -- the depth channel is the only thing "all channels" adds
+    // over the selection here, and it is not a color.
+    CHECK(color_groups_under(EditSubject::Scope_CurrentGroup).first.size() == 1);
+    CHECK(color_groups_under(EditSubject::Scope_SelectedGroups).first.size() == 2);
+    CHECK(color_groups_under(EditSubject::Scope_AllChannels).first.size() == 2);
 }
 
 TEST_CASE("A command with no image to work on does nothing rather than crashing")
@@ -896,6 +1061,54 @@ TEST_CASE("Regrouping touches only the channels an explosion marked, not every l
     REQUIRE(img->history.undo(*img));
     CHECK(img->channels[0].ungrouped);
     CHECK_FALSE(img->channels[3].ungrouped);
+}
+
+TEST_CASE("Regrouping from a selection puts back exactly the channels it names")
+{
+    // The case the selection exists for: explode an RGBA group, leave the alpha out of the selection, and
+    // ask for the rest back. Grouping is still derived from the names -- holding the alpha out is what
+    // makes the R,G,B,A pattern come up short so that R,G,B matches instead.
+    auto img = std::make_shared<Image>(k_size, std::vector<std::string>{"R", "G", "B", "A", "Z"});
+    img->rebuild_layers();
+    REQUIRE(img->groups.size() == 2); // the color, and the depth on its own
+
+    TestEditContext ctx{img};
+    auto            regroup = find_command("Regroup channels");
+    REQUIRE(regroup);
+
+    img->selected_group = group_of_channel(img, "R");
+    find_command("Ungroup channels")->apply(ctx);
+    REQUIRE(img->groups.size() == 5); // four singletons, plus the depth
+
+    // Select R, G and B -- and the depth channel, which was never exploded and so carries no mark. A
+    // regroup that cleared a flag it never set would record setting one on the way back.
+    img->deselect_all();
+    for (const char *name : {"R", "G", "B", "Z"}) img->select_group(group_of_channel(img, name));
+    img->selected_group = group_of_channel(img, "R");
+
+    REQUIRE(regroup->enabled(ctx));
+    regroup->apply(ctx);
+
+    // R,G,B are a color again; the alpha stands alone, still marked; the depth is as it always was.
+    CHECK(img->groups.size() == 3);
+    const int rgb = group_of_channel(img, "R");
+    CHECK(img->groups[size_t(rgb)].num_channels == 3);
+    CHECK(img->groups[size_t(group_of_channel(img, "A"))].num_channels == 1);
+    CHECK(img->channels[size_t(channel_index(img, "A"))].ungrouped);
+    CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
+
+    // The viewport follows the group it was showing into whatever swallowed it.
+    CHECK(img->selected_group == rgb);
+
+    // The regrouped channels are still selected, since the flags ride on the channels rather than on the
+    // group indices the rebuild renumbered.
+    CHECK(img->is_group_selected(rgb));
+
+    // Undo marks back exactly what was cleared, and nothing else.
+    REQUIRE(img->history.undo(*img));
+    CHECK(img->groups.size() == 5);
+    for (const char *name : {"R", "G", "B", "A"}) CHECK(img->channels[size_t(channel_index(img, name))].ungrouped);
+    CHECK_FALSE(img->channels[size_t(channel_index(img, "Z"))].ungrouped);
 }
 
 TEST_CASE("The delete command says whether it is about to take one channel or a group")

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -563,8 +563,15 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
 
             cmd->apply(ctx);
 
-            // Nothing to check unless the edit both happened and went through a chokepoint that takes the
-            // subject: a flip moves every sample by definition, and a resize has no rectangle to stay in.
+            // An edit that changed the image without going through a chokepoint that takes the subject
+            // covers the image entire, and has to say so: has_subject is also what decides whether the
+            // edit runs once per selected image or only on the one being looked at.
+            if (img->history.size() != steps && !ctx.last_edit_used_subject())
+                CHECK_FALSE(cmd->info().has_subject);
+
+            // Nothing more to check unless the edit both happened and went through a chokepoint that takes
+            // the subject: a flip moves every sample by definition, and a resize has no rectangle to stay
+            // in.
             if (img->history.size() == steps || img->size() != k_size || !ctx.last_edit_used_subject())
                 continue;
 

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -93,7 +93,7 @@ public:
 
     //! Whether the last edit went through a chokepoint that takes the subject at all.
     /*!
-        Info::has_subject says only whether the dialog draws the "Apply to" controls. A flip has no dialog
+        Info::draws_subject_selector says only whether the dialog draws the "Apply to" controls. A flip has no dialog
         and no subject either way, and asking it to respect a selection would be asking for something it
         does not offer.
     */
@@ -564,10 +564,9 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
                 CHECK_FALSE(cmd->info().fans_out);
 
             // An edit that changed the image without going through a chokepoint that takes the subject
-            // covers the image entire, and has to say so: has_subject is also what decides whether the
-            // edit runs once per selected image or only on the one being looked at.
+            // is not narrowed by it, and so must not offer controls that would change nothing.
             if (img->history.size() != steps && !ctx.last_edit_used_subject())
-                CHECK_FALSE(cmd->info().has_subject);
+                CHECK_FALSE(cmd->info().draws_subject_selector);
 
             // Nothing more to check unless the edit both happened and went through a chokepoint that takes
             // the subject: a flip moves every sample by definition, and a resize has no rectangle to stay


### PR DESCRIPTION
Brings back the multi-selection HDRView had before the 2.0 rewrite, extended from images to
**(image, channel group)** pairs — and uses it to fix regrouping, which had no way to say *which*
channels it was about.

## Terminology

A target — an (image, channel group) pair — can be **deselected**, **selected**, **current** or
**reference**. Multiple targets can be selected, but only one can be current and only one can be
reference; a current target is automatically selected. An image counts as selected when any of its
groups is.

## The model

`bool selected` goes on `Channel`, beside `ungrouped`. `build_layers_and_groups()` clears and
rebuilds the whole group vector, so a flag kept on a `ChannelGroup` would not survive a rebuild —
including one caused by an edit that never touched the channels. It also means sort, drag-drop
reorder and close need no fix-up: they already hand-maintain `m_current`/`m_reference`, and a flag
on a channel moves with the channel.

`set_current_image_index()` becomes a wrapper on `set_current_group()`, which implements v1.8's
rule: **a target that was already selected simply becomes the selection's current member, while one
that was not replaces the whole selection.** Every entry point maintains that, and something is
selected whenever there is an image to select — so toggling refuses to empty the selection and hands
current to whatever is left when current is what leaves.

## Interaction

| chord | action |
|---|---|
| click | set current (per the rule above) |
| **Ctrl/Cmd-click** | toggle; refuses to empty the selection; migrates current if it deselects it |
| Shift-click | reference — unchanged |
| **Ctrl/Cmd+Shift-click** | range select |

Shift alone stays the reference modifier: it matches v1.8, and `PushRowColors()`'s hover preview
depends on it. The range is additive from the current target rather than from a stored anchor, so
there is no anchor to keep valid across a sort, a reorder or a close.

`PushRowColors()` gains a fourth tone for selected-but-not-current: the header color at three
quarters *alpha*. v1.8 scaled the color itself, but both themes here use an opaque header, and a
darker blue reads as *more* emphasis than the current row against the light theme's background.

## Edits

`EditSubject` gains `Scope_SelectedGroups`, between "current channel group" and "all channels".
Nothing else changed, because acting on several groups of one image already worked — `modify_colors()`
loops the groups inside a single `modify_image()` call, producing one undo entry over their union,
which is exactly what "all channels" already did.

**Every edit now runs once per selected image**, each landing as its own undo entry, and each
starting from the same selection. There is no cross-image entry to reverse, and an image that
refuses the edit sits it out rather than taking the others down with it. Copy and Cut are the sole
exception (`Info::fans_out`): there is one clipboard, so running them per image would leave only the
last image's copy in it. Undo and redo step every selected image too, though they are offered and
labeled from the current image alone — and report what *that* image did, which is what the History
window's walk to a clicked entry terminates on.

Fanning out the shape changes needed two fixes. Cropping consumes the rectangle it just made the
whole image, so every image after the first would have found nothing to crop to; and `Crop::apply`
now asks per image what `enabled()` asks once, since running over a selection reaches images the
rectangle misses entirely, or already is.

Only one filter can run at a time (one progress dialog, one Cancel), but a fan-out arrives as one
call per image within a single frame — so the rest queue and each starts as the one before it lands.
Cancelling discards the whole run, and the dialog says how many images remain.

## Regroup — the driving use case

Ungroup an RGBA group, deselect the alpha, group the rest back up. This needs no new grouping
representation: grouping is derived from channel names, so holding A out is what makes the
`R,G,B,A` pattern come up short and `R,G,B` match instead.

`Ungroup`, `Regroup` and `Delete channel group` are addressed by `target_groups()` rather than a
single group index. A group pointed at from the Images panel names itself alone — unless it is one
of the selected ones, in which case the right-click covers the selection, the same way a click
inside a selection keeps it rather than replacing it. And because every image numbers its own
groups while the panel lists every image's rows, the pointed-at group now carries the image it
belongs to; a bare index was being read against whichever image happened to be current.

## Persistence

The session manifest stores the selection **by channel name**, not group index — a group index
means whatever the rebuild after loading makes it mean. A session written before this leaves every
channel unselected, and `update_visibility()` then collapses the selection onto the group each image
is showing, which is where a fresh load starts anyway.

## Notes

- `Info::has_subject` is renamed `draws_subject_selector`, which is all it ever controlled: whether
  a dialog shows the "Apply to" settings. `Info::fans_out` is the separate question of which images
  an edit reaches, and the two deliberately disagree — ungrouping shows no selector but does run over
  the selection; copying shows one but cannot.
- Arbitrary grouping — say, grouping just R and B, which no name pattern matches — is out of scope.
  It would need an explicit group id on `Channel`.
- Drawing a histogram column sorted at most four channels through `std::sort`, whose bounds GCC
  loses once the comparator inlines; it warned about running past the array in release builds. An
  insertion sort over four elements is both plainly bounded and cheaper here.

## Testing

- **doctest**: both resolvers under each scope; the three group commands swept together over a
  two-of-three-groups selection ("every target group changes and nothing outside them does");
  regroup-from-selection including the never-marked-channel case; and two registry-wide invariants —
  an edit that changed the image without a subject-taking chokepoint must not draw the "Apply to"
  controls, and one that filled the clipboard must not fan out.
- **GUI**: the click state machine (toggle, refusing to empty, current migration, click-inside-a-
  selection); range select across three rows; the fan-out and its undo/redo; a filter reaching every
  selected image in turn; cropping a selection of images; right-click covering the selection;
  right-click naming the image whose row it is; and a session round trip through the real manifest
  writer.
- Every new test was mutation-checked by breaking the thing it covers.
- 313 doctests and 104 GUI tests pass in both Debug and Release on `linux-cpm`, with no warnings
  from HDRView's own sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
