### PR TITLE
Three independent fixes: playback pacing, edge sampling, libheif 1.23.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1327,7 +1327,7 @@ if(HDRVIEW_ENABLE_LIBHEIF)
     NAME Libheif
     # GITHUB_REPOSITORY strukturag/libheif
     VERSION 1.17.6 # set minimum version to the one in ubuntu 24.04
-    URL https://github.com/strukturag/libheif/archive/refs/tags/v1.20.2.zip
+    URL https://github.com/strukturag/libheif/archive/refs/tags/v1.23.3.zip
     # GIT_TAG 95428fdf22b2e0ec3ad4515c882fa0d6dd663f0a
     OPTIONS "BUILD_SHARED_LIBS OFF"
             "BUILD_TESTING OFF"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1312,7 +1312,23 @@ if(HDRVIEW_ENABLE_DAV1D AND HDRVIEW_ENABLE_AVIF AND NOT EMSCRIPTEN)
       set(HDRVIEW_DAV1D_FOUND TRUE)
     endif()
   endif()
-  if(NOT HDRVIEW_DAV1D_FOUND)
+  if(HDRVIEW_DAV1D_FOUND)
+    # libheif's dav1d plugin sets Dav1dSettings::n_threads, which arrived in dav1d 1.0.0 when it merged the
+    # separate frame- and tile-thread counts into one; against an older dav1d (Ubuntu 22.04 still ships
+    # 0.9.2) the plugin, and with it all of libheif, fails to compile. Probe the header for the member
+    # rather than compare versions, since the find_path fallback above locates a dav1d without learning
+    # which version it is.
+    include(CheckStructHasMember)
+    set(CMAKE_REQUIRED_INCLUDES ${HDRVIEW_DAV1D_INCLUDE_DIRS} ${HDRVIEW_DAV1D_INCLUDE_DIR})
+    check_struct_has_member("Dav1dSettings" n_threads "dav1d/dav1d.h" HDRVIEW_DAV1D_HAS_N_THREADS LANGUAGE C)
+    unset(CMAKE_REQUIRED_INCLUDES)
+    if(NOT HDRVIEW_DAV1D_HAS_N_THREADS)
+      message(STATUS "dav1d ${HDRVIEW_DAV1D_VERSION} is too old for libheif's dav1d plugin, which needs "
+                     "1.0.0 or newer; AVIF will be decoded with libaom."
+      )
+      set(HDRVIEW_ENABLE_DAV1D OFF)
+    endif()
+  else()
     message(STATUS "dav1d not found; AVIF will be decoded with libaom. Install dav1d's development "
                    "package for roughly twice the AVIF decoding speed."
     )

--- a/assets/shaders/image-shader.sglsl
+++ b/assets/shaders/image-shader.sglsl
@@ -234,7 +234,10 @@ vec4 dither(vec4 color)
 
 float sample_channel(texture2D tex, sampler smp, vec2 uv, bool within_image)
 {
-    return within_image ? texture(sampler2D(tex, smp), uv).r : 0.0;
+    // Sample unconditionally: a fetch reached only on some lanes has undefined implicit derivatives, and
+    // the mip level they select feeds the trilinear minification filter, which shows up at image edges.
+    float value = texture(sampler2D(tex, smp), uv).r;
+    return within_image ? value : 0.0;
 }
 
 void main()

--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -379,13 +379,44 @@ void HDRViewApp::draw_background()
     static auto last_file_changes_check_time = chrono::steady_clock::now();
     auto        this_frame                   = chrono::steady_clock::now();
 
-    if ((m_play_forward || m_play_backward) &&
-        this_frame - prev_frame >= chrono::milliseconds(int(1000 / m_playback_speed)))
+    if (m_play_forward || m_play_backward)
     {
-        set_current_image_index(
-            next_visible_image_index(m_current, m_play_forward ? Direction_Forward : Direction_Backward));
-        set_image_textures();
-        prev_frame = this_frame;
+        // Keep the period in floating-point seconds. Rounding it to whole milliseconds would quantize the
+        // achievable rates to 1000/n and collapse each broadcast rate onto its nominal neighbor: 23.976 and
+        // 24 fps would both land on 41ms. The clamp matches the slider's range and bounds the catch-up
+        // loop below, since the settings file this is restored from can carry any value at all.
+        const auto period = chrono::duration_cast<chrono::steady_clock::duration>(
+            chrono::duration<float>{1.f / std::clamp(m_playback_speed, 1.f / 20.f, 60.f)});
+        const auto direction = m_play_forward ? Direction_Forward : Direction_Backward;
+
+        // Past this, either playback has just started -- prev_frame still dates from the first frame drawn
+        // -- or the app stalled. Stepping through the whole backlog an image at a time would be a burst of
+        // work whose result is discarded, so drop it and resync instead.
+        const auto resync_after = std::max(period, chrono::steady_clock::duration{1s});
+
+        bool advanced = false;
+        if (this_frame - prev_frame > resync_after)
+        {
+            prev_frame = this_frame;
+            set_current_image_index(next_visible_image_index(m_current, direction));
+            advanced = true;
+        }
+        else
+        {
+            // Accumulating whole periods rather than resetting to now keeps the average rate exact, and
+            // lets a render slower than the playback rate step several images per frame instead of
+            // silently capping playback at the render rate.
+            while (this_frame - prev_frame >= period)
+            {
+                prev_frame += period;
+                set_current_image_index(next_visible_image_index(m_current, direction));
+                advanced = true;
+            }
+        }
+
+        // Only the image left current is ever displayed, so upload textures once no matter how many steps.
+        if (advanced)
+            set_image_textures();
     }
 
     // process_shortcuts();

--- a/src/app-windows.cpp
+++ b/src/app-windows.cpp
@@ -1154,7 +1154,7 @@ void HDRViewApp::draw_file_window()
         ImGui::SameLine();
 
         ImGui::SetNextItemWidth(std::max(EmSize(1.f), ImGui::GetContentRegionAvail().x));
-        if (ImGui::SliderFloat("##Playback speed", &m_playback_speed, 0.1f, 60.f, "%.1f fps",
+        if (ImGui::SliderFloat("##Playback speed", &m_playback_speed, 0.1f, 60.f, "%.3f fps",
                                ImGuiInputTextFlags_EnterReturnsTrue))
             m_playback_speed = clamp(m_playback_speed, 1.f / 20.f, 60.f);
     }

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -1266,6 +1266,16 @@ spdlog::info("Saved image to '{}' in {} seconds.", filename, (timer.elapsed() / 
 catch (const std::exception &err) { throw std::runtime_error(fmt::format("HEIF error: {}", err.what())); }
 }
 
+// libaom accepts lossless coding only with chroma delta-q off, and the tuning metric libheif's aom plugin
+// picks by default for a still image ("auto", which becomes AOM_TUNE_IQ) turns delta-q on -- so the two
+// have to be set together. Under lossless coding the tuning metric has nothing to trade off, the output
+// being bit-exact either way, so pinning it costs nothing. Plugins with no "tune" parameter reject the call.
+static void set_heif_lossless(heif_encoder *enc, bool lossless)
+{
+    heif_encoder_set_lossless(enc, lossless);
+    (void)heif_encoder_set_parameter_string(enc, "tune", lossless ? "ssim" : "auto");
+}
+
 void save_heif_image(const Image &img, std::ostream &os, std::string_view filename, float gain, int quality,
                      bool lossless, bool use_alpha, HEIFCodec codec, TransferFunction tf)
 {
@@ -1283,7 +1293,7 @@ void save_heif_image(const Image &img, std::ostream &os, std::string_view filena
     params.tf        = tf;
     params.codec     = codec;
     params.encoder   = default_encoder_for(codec, use_alpha);
-    heif_encoder_set_lossless(s_encoders[params.encoder].get(), lossless);
+    set_heif_lossless(s_encoders[params.encoder].get(), lossless);
     heif_encoder_set_lossy_quality(s_encoders[params.encoder].get(), quality);
 
     save_heif_image(img, os, filename, &params);
@@ -1419,7 +1429,7 @@ HEIFSaveOptions *heif_parameters_gui(HEIFCodec codec)
                 if (ImGui::PE::Checkbox("Lossless", &lossless, "Use lossless compression."))
                 {
                     s_opts.lossless = lossless;
-                    heif_encoder_set_lossless(enc, lossless);
+                    set_heif_lossless(enc, lossless);
                 }
                 ImGui::EndDisabled();
             }


### PR DESCRIPTION
Three unrelated fixes, each reviewable on its own. The libheif update takes two commits: the version bump and a guard for one of its build-side consequences.

## Pace playback at the rate that was asked for

The frame period was rounded to whole milliseconds, quantizing the achievable rates to `1000/n`.
Every broadcast rate collapsed onto its nominal neighbor:

| requested | period | actual |
|---|---|---|
| 23.976 | 41.708 → 41 ms | 24.39 |
| 24 | 41.667 → 41 ms | 24.39 |
| 29.97 | 33.367 → 33 ms | 30.30 |
| 59.94 | 16.683 → 16 ms | 62.5 |

23.976 and 24 fps were bit-identical in behavior, and truncation always ran fast.

Two further errors sat in the same three lines: the timestamp was reset to *now* on each step rather
than advanced by one period, so the wait was really a period plus whatever remained of the render
tick and the error accumulated; and at most one image advanced per rendered frame, silently capping
playback at the render rate. Advancing by whole periods in a loop fixes both, with a resync
threshold above which the backlog is dropped — playback starting long after the first frame was
drawn is otherwise a long catch-up whose result is discarded. Textures upload once per frame rather
than once per step.

The rate is clamped to the slider's range at the point of use, which also bounds the loop: it is
restored from a settings file that can carry any value. The slider shows three decimals so an
entered fractional rate is also visible.

## Sample the image texture outside the bounds check

`sample_channel()` fetched inside a ternary, so the fetch was reached on only some lanes of a quad,
where implicit derivatives are undefined. The mip level those select feeds the trilinear
minification filter (`image.cpp:629`), so texels at an image's edge could come from the wrong level.
Hoisting the fetch above the branch makes the derivatives well-defined. The shader is
cross-compiled, so this covers Metal as well as GL.

## Update libheif to 1.23.3

The pinned 1.20.2 dated from August 2025 — three minor releases and ~1100 commits back, including a
fix for security limits rejecting cropped images.

Newer libheif defaults its aom encoder's tuning metric to `auto`, which resolves to `AOM_TUNE_IQ`
for still images; IQ enables chroma delta-q, which libaom refuses to combine with lossless coding,
so saving a lossless AVIF failed outright (caught by two export round-trip tests). The tuning metric
has nothing to trade off when output is bit-exact, so pinning it to `ssim` under lossless costs
nothing and restores what 1.20.2 did by default.

**Note on default AVIF output:** under `tune=auto`→IQ, libheif also switches the quality→quantizer
mapping. At HDRView's default quality 95, `cq_level` goes 3 → 4. Default lossy AVIF files will
differ in size and character from previous releases. This is upstream's considered default (its
table is copied from libavif), taken deliberately rather than pinned back.

### dav1d 1.0.0 or newer

1.23.3's dav1d plugin sets `Dav1dSettings::n_threads`, which dav1d 1.0.0 introduced when it merged
the separate frame- and tile-thread counts into one. HDRView accepted whatever dav1d the system
happened to have, so on Ubuntu 22.04 — still on 0.9.2 — the plugin, and with it all of libheif,
stopped compiling. The probe now checks the header for that member and leaves libheif on libaom's
AV1 decoder when it is absent. Probing the member rather than comparing versions covers the
`find_path` fallback, which locates a dav1d without learning which version it is.

### Decode verification

All 603 AVIF/HEIF/HEIC files in a local corpus were decoded against both versions. Five status
changes:

- **Gained:** a Netflix alpha video sequence now reads (was a read failure).
- **Lost:** `quebec_3layer_op2.avif`, a layered AVIF. 1.23.3 added `tighten_image_size_limit_for_ispe()`,
  deriving a per-decode pixel cap from the primary item's `ispe` — here 360×182, giving a limit of
  exactly 151,280 — but operating point 2 legitimately decodes 718×366. Upstream bug: the tightening
  doesn't account for a higher operating point exceeding the base layer it declares.
- Three conformance files failed before and still fail, just further along.

## Testing

`ctest`: 182/182 pass. Build clean, `--help` smoke check passes, `git clang-format` reports no changes.
The full CI matrix is green across all 41 checks.

Not verified: the shader change on Metal (no macOS available) and the playback change under
`hdrview_gui_tests` (no playback coverage exists in `tests/gui/`, and the suite needs a display).
