### PR TITLE
Read premultiplied alpha in the space the file wrote it in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1735,6 +1735,7 @@ endif()
 set(HDRVIEW_SOURCES
     src/imageio/image_loader.cpp
     src/imageio/dds.cpp
+    src/imageio/alpha.cpp
     src/imageio/exif.cpp
     src/imageio/xmp.cpp
     src/imageio/exr.cpp
@@ -1857,7 +1858,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
   list(REMOVE_ITEM HDRVIEW_SOURCES src/hdrview.cpp)
   add_executable(hdrview_tests ${HDRVIEW_SOURCES} tests/test_pixel_stats.cpp tests/test_colorspace.cpp
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
-                                tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
+                                tests/test_alpha.cpp tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_numeric_edge_cases.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_path_helpers.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
                                 tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_cicp_video_range.cpp tests/test_orientation_windows.cpp tests/test_undo.cpp tests/test_edit_commands.cpp tests/test_filters.cpp tests/test_envmap.cpp tests/test_poisson.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_xmp.cpp tests/test_exif.cpp
                                 ${HDRVIEW_IPC_TESTS}

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -67,6 +67,39 @@ Enum id_to_enum(const json &j, const char *key, const char *const (&ids)[N], Enu
     return default_value;
 }
 
+// A session records the alpha override the user chose, not the interpretation it produced: with no override
+// the file is read afresh, so a corrected loader or an edited file is picked up rather than frozen in.
+// Spelled out rather than stored as the enum's ordinal, which would silently reinterpret every session if a
+// value were ever inserted.
+static const char *alpha_override_token(AlphaType_ at)
+{
+    switch (at)
+    {
+    case AlphaType_None: return "none";
+    case AlphaType_PremultipliedLinear: return "premultiplied-linear";
+    case AlphaType_PremultipliedNonLinear: return "premultiplied-nonlinear";
+    default: return "straight";
+    }
+}
+
+static optional<AlphaType_> alpha_override_from_token(const json &j)
+{
+    auto token = j.value<string>("alpha_override", "");
+    if (token.empty())
+        return nullopt;
+    if (token == "none")
+        return AlphaType_None;
+    if (token == "premultiplied-linear")
+        return AlphaType_PremultipliedLinear;
+    if (token == "premultiplied-nonlinear")
+        return AlphaType_PremultipliedNonLinear;
+    if (token == "straight")
+        return AlphaType_Straight;
+
+    spdlog::warn("Unrecognized alpha override '{}'; reading the file's own interpretation instead.", token);
+    return nullopt;
+}
+
 // Checks "type"/"version" on a parsed session manifest, logging as needed (`source_name` is a filename or
 // zip archive name, for the log message only). Returns false if `j` doesn't look like a session at all --
 // callers should treat that as "not a session", not a hard failure.
@@ -690,7 +723,9 @@ void HDRViewApp::reload_image(ImagePtr image, bool should_select)
     spdlog::info("Reloading file '{}' with channel selector '{}'...", image->filename, image->channel_selector);
     auto opts                  = load_image_options();
     opts.channel_selector      = image->channel_selector;
-    opts.alpha_is_transparency = image->alpha_is_transparency;
+    opts.override_alpha        = image->alpha_override.has_value();
+    if (image->alpha_override)
+        opts.alpha_override = *image->alpha_override;
 
 #if defined(__EMSCRIPTEN__)
     // A URL was never on a filesystem to be re-read from; fetch it again instead.
@@ -889,7 +924,8 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
         json entry;
         entry["path"]                  = path_of(img);
         entry["channel_selector"]      = img->channel_selector;
-        entry["alpha_is_transparency"] = img->alpha_is_transparency;
+        if (img->alpha_override)
+            entry["alpha_override"] = alpha_override_token(*img->alpha_override);
         entry["selected_group"]        = img->selected_group;
         entry["reference_group"]       = img->reference_group;
 
@@ -1191,18 +1227,20 @@ void HDRViewApp::begin_session_load(const json &j, const fs::path &dir)
         PendingSession::Entry e;
         e.path                  = resolve(rel);
         e.channel_selector      = entry.value<string>("channel_selector", "");
-        e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
+        e.alpha_override        = alpha_override_from_token(entry);
         e.selected_group        = entry.value<int>("selected_group", 0);
         e.reference_group       = entry.value<int>("reference_group", 0);
         e.selected_channels     = entry.value<vector<string>>("selected_channels", {});
 
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
-        pending.unresolved[{e.path, e.channel_selector, e.alpha_is_transparency}].push_back(idx);
+        pending.unresolved[{e.path, e.channel_selector, e.alpha_override}].push_back(idx);
 
         ImageLoadOptions opts;
-        opts.channel_selector      = e.channel_selector;
-        opts.alpha_is_transparency = e.alpha_is_transparency;
+        opts.channel_selector = e.channel_selector;
+        opts.override_alpha   = e.alpha_override.has_value();
+        if (e.alpha_override)
+            opts.alpha_override = *e.alpha_override;
         load_image(e.path.string(), {}, false, opts);
     }
 
@@ -1236,7 +1274,7 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
         PendingSession::Entry e;
         e.path                  = fs::path(zip_name) / fs::u8path(rel);
         e.channel_selector      = entry.value<string>("channel_selector", "");
-        e.alpha_is_transparency = entry.value<bool>("alpha_is_transparency", true);
+        e.alpha_override        = alpha_override_from_token(entry);
         e.selected_group        = entry.value<int>("selected_group", 0);
         e.reference_group       = entry.value<int>("reference_group", 0);
         e.selected_channels     = entry.value<vector<string>>("selected_channels", {});
@@ -1254,11 +1292,13 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
             continue;
         }
 
-        pending.unresolved[{e.path, e.channel_selector, e.alpha_is_transparency}].push_back(idx);
+        pending.unresolved[{e.path, e.channel_selector, e.alpha_override}].push_back(idx);
 
         ImageLoadOptions opts;
-        opts.channel_selector      = e.channel_selector;
-        opts.alpha_is_transparency = e.alpha_is_transparency;
+        opts.channel_selector = e.channel_selector;
+        opts.override_alpha   = e.alpha_override.has_value();
+        if (e.alpha_override)
+            opts.alpha_override = *e.alpha_override;
         m_image_loader.background_load(e.path.string(), *bytes, false, nullptr, opts);
     }
 

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -259,9 +259,9 @@ void HDRViewApp::apply_ipc_create(const IpcCreateImage &info)
         image->short_name = info.name;
         image->is_live    = true;
 
-        // The samples a renderer sends are its own; nothing here should reinterpret them. Leaving alpha_type
-        // at AlphaType_None keeps finalize() from premultiplying, which would otherwise scale every tile by
-        // an alpha channel that may not have been sent yet.
+        // The samples a renderer sends are its own; nothing here should reinterpret them. The constructor's
+        // default alpha type is already the premultiplied one, so finalize() leaves them alone -- it would
+        // otherwise scale every tile by an alpha channel that may not have been sent yet.
         image->finalize();
     }
     catch (const std::exception &e)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -705,8 +705,8 @@ void HDRViewApp::setup_frame_callbacks()
                     // -- see PendingSession's comment in app.h for why matching by that key (rather than
                     // by request order) is correct even when the same file is loaded more than once in
                     // one session.
-                    auto key = PendingSession::Key{new_image->path, new_image->channel_selector,
-                                                   new_image->alpha_is_transparency};
+                    auto key =
+                        PendingSession::Key{new_image->path, new_image->channel_selector, new_image->alpha_override};
                     if (auto it = m_pending_session->unresolved.find(key); it != m_pending_session->unresolved.end())
                     {
                         if (!it->second.empty())

--- a/src/app.h
+++ b/src/app.h
@@ -1142,10 +1142,10 @@ private:
     {
         struct Entry
         {
-            fs::path       path;
-            string         channel_selector;
-            bool           alpha_is_transparency = true;
-            int            selected_group = 0, reference_group = 0;
+            fs::path             path;
+            string               channel_selector;
+            optional<AlphaType_> alpha_override; ///< Empty when the file's own interpretation was used
+            int                  selected_group = 0, reference_group = 0;
             vector<string> selected_channels; ///< The multi-selection, by channel name; see Channel::selected
             ImagePtr       loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
         };
@@ -1158,8 +1158,8 @@ private:
         // Entries sharing that key are guaranteed content-identical (loaded with identical options), so any
         // valid one-to-one assignment among them is correct regardless of which physical async load happens to
         // finish first -- this is what makes it safe to load the same file more than once in one session (e.g.
-        // to compare two channel groups of it, or the same file with and without alpha as transparency).
-        using Key = std::tuple<fs::path, string, bool>; ///< path, channel_selector, alpha_is_transparency
+        // to compare two channel groups of it, or the same file under two alpha interpretations).
+        using Key = std::tuple<fs::path, string, optional<AlphaType_>>; ///< path, channel_selector, alpha_override
         map<Key, deque<int>> unresolved;
     };
     optional<PendingSession> m_pending_session;

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -485,7 +485,11 @@ static const char *s_alpha_type_names[] = {"None", "Premultiplied Linear", "Prem
 static const char *s_alpha_override_names[] = {"None (channel is data)", "Premultiplied, in linear light",
                                                "Premultiplied, after transfer", "Straight", nullptr};
 
+static const char *s_alpha_source_suffixes[] = {"assumed", "per the format", "from the file", nullptr};
+
 const char *alpha_type_name(AlphaType_ at) { return s_alpha_type_names[at]; }
+
+const char *alpha_source_suffix(AlphaSource_ as) { return s_alpha_source_suffixes[as]; }
 
 const char *alpha_override_name(AlphaType_ at) { return s_alpha_override_names[at]; }
 

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -486,10 +486,13 @@ static const char *s_alpha_override_names[] = {"None (channel is data)", "Premul
                                                "Premultiplied, after transfer", "Straight", nullptr};
 
 static const char *s_alpha_source_suffixes[] = {"assumed", "per the format", "from the file", nullptr};
+static const char *s_alpha_source_phrases[]  = {"assumed", "the format says", "the file said", nullptr};
 
 const char *alpha_type_name(AlphaType_ at) { return s_alpha_type_names[at]; }
 
 const char *alpha_source_suffix(AlphaSource_ as) { return s_alpha_source_suffixes[as]; }
+
+const char *alpha_source_phrase(AlphaSource_ as) { return s_alpha_source_phrases[as]; }
 
 const char *alpha_override_name(AlphaType_ at) { return s_alpha_override_names[at]; }
 

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -479,7 +479,15 @@ static const char *s_transfer_function_names[TransferFunction::Count + 1] = {
 static const char *s_alpha_type_names[] = {"None", "Premultiplied Linear", "Premultiplied Non-Linear", "Straight",
                                            nullptr};
 
+// Spelled out rather than reusing s_alpha_type_names: the metadata panel reports what the file turned out
+// to hold, where one word is enough, while the combo asks the user to choose between kinds they may not
+// have had to think about before.
+static const char *s_alpha_override_names[] = {"None (channel is data)", "Premultiplied, in linear light",
+                                               "Premultiplied, after transfer", "Straight", nullptr};
+
 const char *alpha_type_name(AlphaType_ at) { return s_alpha_type_names[at]; }
+
+const char *alpha_override_name(AlphaType_ at) { return s_alpha_override_names[at]; }
 
 const char **alpha_type_names() { return s_alpha_type_names; }
 

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -28,6 +28,8 @@ enum AlphaType : AlphaType_
 };
 
 const char  *alpha_type_name(AlphaType_ at);
+//! Name for the alpha-override combo, which needs to say more than the metadata panel's one-word label.
+const char  *alpha_override_name(AlphaType_ at);
 const char **alpha_type_names();
 
 /**

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -27,7 +27,26 @@ enum AlphaType : AlphaType_
     AlphaType_Count
 };
 
+//! Where an image's AlphaType_ came from, which is not the same question as what it is.
+/*!
+    A file can state its alpha kind, or its format can settle it for every conforming file, or nothing can
+    say and the loader has to pick. Only the last is a guess, and it is where an override is most likely
+    wanted. An explicit tag is not automatically the most trustworthy of the three -- ImageMagick and vips
+    both write premultiplied TIFF samples tagged unassociated -- so this records provenance rather than
+    confidence.
+*/
+using AlphaSource_ = int;
+enum AlphaSource : AlphaSource_
+{
+    AlphaSource_Assumed = 0, //!< Nothing stated it; the loader picked a default
+    AlphaSource_Format,      //!< The format settles it for every conforming file
+    AlphaSource_File,        //!< This file said so, in a tag or flag of its own
+    AlphaSource_Count
+};
+
 const char  *alpha_type_name(AlphaType_ at);
+//! How the alpha kind was arrived at, phrased to follow it: "Straight (from the file)".
+const char *alpha_source_suffix(AlphaSource_ as);
 //! Name for the alpha-override combo, which needs to say more than the metadata panel's one-word label.
 const char  *alpha_override_name(AlphaType_ at);
 const char **alpha_type_names();

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -47,6 +47,9 @@ enum AlphaSource : AlphaSource_
 const char  *alpha_type_name(AlphaType_ at);
 //! How the alpha kind was arrived at, phrased to follow it: "Straight (from the file)".
 const char *alpha_source_suffix(AlphaSource_ as);
+//! The same, phrased to introduce a kind instead: "the file said Straight". Used where an override has
+//! displaced one and both have to appear, since the suffix form then reads as an idiom.
+const char *alpha_source_phrase(AlphaSource_ as);
 //! Name for the alpha-override combo, which needs to say more than the metadata panel's one-word label.
 const char  *alpha_override_name(AlphaType_ at);
 const char **alpha_type_names();

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1342,16 +1342,16 @@ void Image::draw_info()
 
                 ImGui::BeginDisabled(!reloadable);
                 ImGui::PE::Entry(
-                    "Override",
+                    "Alpha override",
                     [this]
                     {
-                        static constexpr const char *k_from_file = "From file";
+                        static constexpr const char *k_not_overridden = "Not overridden";
 
                         bool changed = false;
                         if (ImGui::BeginCombo("##Alpha override",
-                                              alpha_override ? alpha_override_name(*alpha_override) : k_from_file))
+                                              alpha_override ? alpha_override_name(*alpha_override) : k_not_overridden))
                         {
-                            if (ImGui::Selectable(k_from_file, !alpha_override))
+                            if (ImGui::Selectable(k_not_overridden, !alpha_override))
                             {
                                 alpha_override.reset();
                                 changed = true;

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1315,9 +1315,17 @@ void Image::draw_info()
             filtered_property("Display window",
                               fmt::format("[{}, {}) {} [{}, {})", display_window.min.x, display_window.max.x,
                                           ICON_MY_TIMES, display_window.min.y, display_window.max.y));
-            filtered_property("Alpha", alpha_type_name(alpha_type),
-                              "How this image's alpha is being read: whether the color channels are multiplied "
-                              "by it, and in what space. Reflects the override below when one is set.");
+            // An override says what it displaced, since contradicting a kind the file stated is a different
+            // situation from filling in one nothing ever did.
+            filtered_property(
+                "Alpha",
+                alpha_override ? fmt::format("{} (override; {} {})", alpha_type_name(alpha_type),
+                                             alpha_type_name(alpha_type_from_file), alpha_source_suffix(alpha_source))
+                               : fmt::format("{} ({})", alpha_type_name(alpha_type), alpha_source_suffix(alpha_source)),
+                "How this image's alpha is being read: whether the color channels are multiplied "
+                "by it, and in what space, and where that came from. \"Assumed\" means nothing "
+                "stated it and the loader picked a default, which is where the override below is "
+                "most likely wanted.");
 
             if (filter.PassFilter("Alpha override"))
             {

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1320,7 +1320,7 @@ void Image::draw_info()
             filtered_property(
                 "Alpha",
                 alpha_override ? fmt::format("{} (override; {} {})", alpha_type_name(alpha_type),
-                                             alpha_type_name(alpha_type_from_file), alpha_source_suffix(alpha_source))
+                                             alpha_source_phrase(alpha_source), alpha_type_name(alpha_type_from_file))
                                : fmt::format("{} ({})", alpha_type_name(alpha_type), alpha_source_suffix(alpha_source)),
                 "How this image's alpha is being read: whether the color channels are multiplied "
                 "by it, and in what space, and where that came from. \"Assumed\" means nothing "

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1316,50 +1316,59 @@ void Image::draw_info()
                               fmt::format("[{}, {}) {} [{}, {})", display_window.min.x, display_window.max.x,
                                           ICON_MY_TIMES, display_window.min.y, display_window.max.y));
             filtered_property("Alpha", alpha_type_name(alpha_type),
-                              "Type of alpha channel stored in the file. When treated as transparency, HDRView "
-                              "converts it to premultiplied alpha upon load.");
-            // Only offered when the file declares an alpha channel: a file that states its extra channel
-            // is data (e.g. TIFF's EXTRASAMPLE_UNSPECIFIED) isn't overridden from here.
-            if (alpha_type != AlphaType_None)
-            {
-                if (filter.PassFilter("Alpha is transparency"))
-                {
-                    // draw_info() is only ever drawn for the current image (see the Info window)
-                    const bool reloadable = hdrview()->can_reload(hdrview()->current_image());
-                    string     tooltip =
-                        "Whether the alpha channel means transparency. Turn this off for files whose alpha is "
-                        "really a mask or other data: it is then shown as an ordinary channel of its own and "
-                        "nothing is premultiplied by it.\n\nChanging this re-reads the image from its source.";
-                    if (!reloadable)
-                        tooltip += "\n\nUnavailable for this image: HDRView has nothing left to read it from.";
+                              "How this image's alpha is being read: whether the color channels are multiplied "
+                              "by it, and in what space. Reflects the override below when one is set.");
 
-                    // Drop the vertical frame padding across the whole row, as PE::WrappedText does for the
-                    // text rows: a checkbox is square, so the padding would both make this row taller than
-                    // its neighbors and push the property name below the box.
-                    ImGui::PushStyleVarY(ImGuiStyleVar_FramePadding, 0.f);
-                    ImGui::BeginDisabled(!reloadable);
-                    ImGui::PE::Entry(
-                        "Is transparency",
-                        [this]
+            if (filter.PassFilter("Alpha override"))
+            {
+                // draw_info() is only ever drawn for the current image (see the Info window)
+                const bool reloadable = hdrview()->can_reload(hdrview()->current_image());
+                string     tooltip =
+                    "Read the alpha as something other than what the file says. \"None\" treats a fourth channel "
+                    "as ordinary data rather than transparency, so nothing is multiplied by it.\n\nThe two "
+                    "premultiplied kinds differ in where the multiply happened; pick the other one for an image "
+                    "whose semi-transparent areas read too dark or too bright.\n\nChanging this re-reads the "
+                    "image from its source.";
+                if (!reloadable)
+                    tooltip += "\n\nUnavailable for this image: HDRView has nothing left to read it from.";
+
+                ImGui::BeginDisabled(!reloadable);
+                ImGui::PE::Entry(
+                    "Override",
+                    [this]
+                    {
+                        static constexpr const char *k_from_file = "From file";
+
+                        bool changed = false;
+                        if (ImGui::BeginCombo("##Alpha override",
+                                              alpha_override ? alpha_override_name(*alpha_override) : k_from_file))
                         {
-                            bool       value   = alpha_is_transparency;
-                            const bool toggled = ImGui::Checkbox("##Alpha is transparency", &value);
-                            // A text row is as tall as the smallest child window PE::WrappedText will make,
-                            // one line plus its spacing; reserve the same so the row pitch stays even.
-                            ImGui::SameLine();
-                            ImGui::Dummy(ImVec2(0.f, ImGui::GetTextLineHeightWithSpacing()));
-                            if (!toggled)
-                                return false;
-                            // The premultiply happens in-place on load, so switching interpretation means
-                            // reading the image again; reload_image() carries the new setting through.
-                            alpha_is_transparency = value;
-                            hdrview()->reload_image(hdrview()->current_image());
-                            return true;
-                        },
-                        tooltip);
-                    ImGui::EndDisabled();
-                    ImGui::PopStyleVar();
-                }
+                            if (ImGui::Selectable(k_from_file, !alpha_override))
+                            {
+                                alpha_override.reset();
+                                changed = true;
+                            }
+
+                            for (AlphaType_ a = 0; a < AlphaType_Count; ++a)
+                                if (ImGui::Selectable(alpha_override_name(a), alpha_override && *alpha_override == a))
+                                {
+                                    alpha_override = a;
+                                    changed        = true;
+                                }
+
+                            ImGui::EndCombo();
+                        }
+
+                        if (!changed)
+                            return false;
+
+                        // The premultiply happens in-place on load, so switching interpretation means reading
+                        // the image again; reload_image() carries the new setting through.
+                        hdrview()->reload_image(hdrview()->current_image());
+                        return true;
+                    },
+                    tooltip);
+                ImGui::EndDisabled();
             }
             if (exif.valid())
                 filtered_property("EXIF data", fmt::format("{:.0h}", human_readible{exif.size()}),

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1285,7 +1285,9 @@ ImagePtr Image::duplicate(const Box2i &region) const
     copy->color_space           = color_space;
     copy->white_point           = white_point;
     copy->alpha_type            = alpha_type;
-    copy->alpha_is_transparency = alpha_is_transparency;
+    copy->alpha_type_from_file  = alpha_type_from_file;
+    copy->alpha_source          = alpha_source;
+    copy->alpha_override        = alpha_override;
     copy->metadata              = metadata;
     copy->exif                  = exif;
     copy->xmp_data              = xmp_data;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -882,6 +882,7 @@ Image::Image(int2 size, int num_channels) : Image()
         }
     }
     display_window = data_window = Box2i{int2{0}, channels.front().size()};
+    set_default_alpha_type();
 }
 
 Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
@@ -893,6 +894,19 @@ Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
     for (const auto &name : channel_names) channels.emplace_back(name, size);
 
     display_window = data_window = Box2i{int2{0}, size};
+    set_default_alpha_type();
+}
+
+void Image::set_default_alpha_type()
+{
+    for (const auto &c : channels)
+        if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
+        {
+            alpha_type = AlphaType_PremultipliedLinear;
+            return;
+        }
+
+    alpha_type = AlphaType_None;
 }
 
 map<string, int> Image::channels_in_layer(const string &layer) const
@@ -1023,7 +1037,7 @@ void Image::build_layers_and_groups()
                 continue;
             // Skipping the alpha-bearing patterns lets the alpha-free one match instead, leaving 'A' to
             // fall through to the single-channel groups created below.
-            if (!alpha_is_transparency && group_has_alpha(group_type))
+            if (!alpha_is_transparency() && group_has_alpha(group_type))
                 continue;
             auto found = find_group_channels(layer_channels, layer.name, group_channel_names);
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -897,16 +897,24 @@ Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
     set_default_alpha_type();
 }
 
+void Image::set_alpha(AlphaType_ from_file, AlphaSource_ source, const std::optional<AlphaType_> &override_with)
+{
+    alpha_type_from_file = from_file;
+    alpha_source         = source;
+    alpha_type           = override_with.value_or(from_file);
+}
+
 void Image::set_default_alpha_type()
 {
     for (const auto &c : channels)
         if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
         {
-            alpha_type = AlphaType_PremultipliedLinear;
+            // Assembled rather than read, so nothing declared this; see set_default_alpha_type()'s comment.
+            set_alpha(AlphaType_PremultipliedLinear, AlphaSource_Assumed, std::nullopt);
             return;
         }
 
-    alpha_type = AlphaType_None;
+    set_alpha(AlphaType_None, AlphaSource_Assumed, std::nullopt);
 }
 
 map<string, int> Image::channels_in_layer(const string &layer) const

--- a/src/image.h
+++ b/src/image.h
@@ -465,6 +465,9 @@ public:
     std::string                   filename;
     std::string                   partname;
     std::string                   channel_selector;
+    //! The alpha override this image was loaded under, so a reload or a saved session can repeat it.
+    //! Empty when the file's own interpretation was used, which is then re-derived on reload.
+    std::optional<AlphaType_>     alpha_override;
     Box2i                         data_window;
     Box2i                         display_window;
     std::vector<Channel>          channels;
@@ -476,10 +479,17 @@ public:
     AdaptationMethod              adaptation_method = AdaptationMethod_Bradford;
     ColorGamut_                   color_space       = ColorGamut_Unspecified;
     WhitePoint_                   white_point       = WhitePoint_Unspecified;
-    AlphaType alpha_type            = AlphaType_None; //!< Does the image have straight (unpremultiplied) alpha?
-    bool      alpha_is_transparency = true; //!< When false, an 'A' channel is grouped on its own as ordinary data
-                                            //!< instead of joining an RGBA/YA/YCA/XYZA group, so nothing is
-                                            //!< premultiplied by it. Read by finalize(), so set it before calling.
+    //! How the file's alpha is to be read: whether the color channels are multiplied by it, and in what
+    //! space. Read by finalize(), so set it before calling.
+    AlphaType_ alpha_type = AlphaType_None;
+    //! Whether an 'A' channel is transparency at all.
+    /*!
+        Orthogonal to alpha_type, which says what a *transparency* alpha means: an image can carry alpha
+        whose kind is simply unstated, which is the default and still groups as RGBA. When false the channel
+        is grouped on its own instead of joining an RGBA/YA/YCA/XYZA group, which is also what keeps
+        finalize() from premultiplying anything by it. Read by finalize(), so set it before calling.
+    */
+    bool                 alpha_is_transparency = true;
     json                 metadata = json::object();
     Exif                 exif;     //!< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; //!< The raw XMP data from the file, if any
@@ -768,10 +778,18 @@ public:
         return alpha_type == AlphaType_Straight && group.num_channels > 1 && group_has_alpha(group.type);
     }
 
+    //! Flatten the selected group into an interleaved buffer, applying gain and a transfer function.
+    /*!
+        `unpremultiply` divides the color channels by alpha before the transfer function, yielding straight
+        samples. `premultiply_encoded` then multiplies them back once the transfer has been applied, which
+        is the associated-alpha convention every TIFF writer uses -- and is not the same as leaving
+        `unpremultiply` off, which would multiply in linear light instead. See imageio/alpha.h.
+    */
     template <typename T>
     std::unique_ptr<T[]> as_interleaved(int *w, int *h, int *n, float gain = 1.f,
                                         TransferFunction tf = {TransferFunction::Linear, 1.f}, bool dither = true,
-                                        bool unpremultiply = true, bool convert_to_sRGB = true) const;
+                                        bool unpremultiply = true, bool convert_to_sRGB = true,
+                                        bool premultiply_encoded = false) const;
 
     void draw_histogram();
     void draw_layer_groups(const Layer &layer, int img_idx, int &id, bool is_current, bool is_reference,
@@ -825,7 +843,7 @@ std::unique_ptr<uint8_t[]> widen_to_rgb(const uint8_t *src, int w, int h, int n,
 
 template <typename T>
 std::unique_ptr<T[]> Image::as_interleaved(int *w, int *h, int *n, float gain, TransferFunction tf, bool dither,
-                                           bool unpremultiply, bool convert_to_sRGB) const
+                                           bool unpremultiply, bool convert_to_sRGB, bool premultiply_encoded) const
 {
     const ChannelGroup &group = groups[selected_group];
 
@@ -849,7 +867,7 @@ std::unique_ptr<T[]> Image::as_interleaved(int *w, int *h, int *n, float gain, T
         // process RGB channels together
         parallel_for(blocked_range<int>(0, *h, block_size),
                      [this, alpha, w = *w, n = *n, data = pixels.get(), gain, tf, dither, unpremultiply,
-                      convert_to_sRGB, luminance_chroma](int begin_y, int end_y, int, int)
+                      convert_to_sRGB, luminance_chroma, premultiply_encoded](int begin_y, int end_y, int, int)
                      {
                          int y_stride = w * n;
                          for (int y = begin_y; y < end_y; ++y)
@@ -876,6 +894,11 @@ std::unique_ptr<T[]> Image::as_interleaved(int *w, int *h, int *n, float gain, T
                                  // Apply transfer function to RGB triple
                                  float3 rgb_out = from_linear(rgb, tf);
 
+                                 // Associated alpha multiplies the encoded samples, so this follows the
+                                 // transfer function and precedes quantization.
+                                 if (alpha && premultiply_encoded)
+                                     rgb_out *= (*alpha)(x, y);
+
                                  auto rgba_pixel = data + y * y_stride + n * x;
                                  for (int c = 0; c < 3; ++c)
                                      rgba_pixel[c] = (std::is_integral_v<T>)
@@ -894,8 +917,8 @@ std::unique_ptr<T[]> Image::as_interleaved(int *w, int *h, int *n, float gain, T
     {
         // A one- or two-channel group: a lone channel, a U,V pair, or gray plus alpha.
         parallel_for(blocked_range<int>(0, *h, block_size),
-                     [this, alpha, w = *w, n = *n, data = pixels.get(), gain, tf, dither,
-                      unpremultiply](int begin_y, int end_y, int, int)
+                     [this, alpha, w = *w, n = *n, data = pixels.get(), gain, tf, dither, unpremultiply,
+                      premultiply_encoded](int begin_y, int end_y, int, int)
                      {
                          int y_stride  = w * n;
                          int num_color = alpha ? n - 1 : n;
@@ -912,7 +935,10 @@ std::unique_ptr<T[]> Image::as_interleaved(int *w, int *h, int *n, float gain, T
                                      if (alpha && unpremultiply)
                                          v /= std::max(k_small_alpha, (*alpha)(x, y));
 
-                                     v      = from_linear(v, tf);
+                                     v = from_linear(v, tf);
+                                     if (alpha && premultiply_encoded)
+                                         v *= (*alpha)(x, y);
+
                                      out[c] = std::is_integral_v<T> ? quantize_full<T>(v, x, y, dither) : T(v);
                                  }
 

--- a/src/image.h
+++ b/src/image.h
@@ -482,7 +482,15 @@ public:
     //! How an 'A' channel is to be read: whether it is coverage at all, and if so whether the color
     //! channels are multiplied by it and in what space. AlphaType_None keeps the channel out of an
     //! alpha-bearing group, so nothing is multiplied by it. Read by finalize(), so set it before calling.
+    //! Equal to alpha_type_from_file unless alpha_override replaced it.
     AlphaType_ alpha_type = AlphaType_None;
+    //! What the loader concluded before any override, and how it got there.
+    /*!
+        Kept so an override can say what it displaced: contradicting a kind the file stated is a different
+        situation from filling in one it never did. set_alpha() maintains these together with alpha_type.
+    */
+    AlphaType_           alpha_type_from_file = AlphaType_None;
+    AlphaSource_         alpha_source         = AlphaSource_Assumed;
     json                 metadata   = json::object();
     Exif                 exif;     //!< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; //!< The raw XMP data from the file, if any
@@ -557,6 +565,14 @@ public:
         machinery build themselves out of those names in finalize().
     */
     Image(int2 size, const std::vector<std::string> &channel_names);
+
+    //! Record what a loader concluded about the file's alpha, and apply any override to it.
+    /*!
+        The one place alpha_type, alpha_type_from_file and alpha_source are written, so they cannot drift
+        apart. Loaders call this instead of assigning alpha_type, then read back alpha_type for the
+        premultiplication decisions they have to make while the samples are still encoded.
+    */
+    void set_alpha(AlphaType_ from_file, AlphaSource_ source, const std::optional<AlphaType_> &override_with);
 
     //! Set alpha_type from the channel names alone, for an image not built from a file.
     /*!

--- a/src/image.h
+++ b/src/image.h
@@ -479,18 +479,11 @@ public:
     AdaptationMethod              adaptation_method = AdaptationMethod_Bradford;
     ColorGamut_                   color_space       = ColorGamut_Unspecified;
     WhitePoint_                   white_point       = WhitePoint_Unspecified;
-    //! How the file's alpha is to be read: whether the color channels are multiplied by it, and in what
-    //! space. Read by finalize(), so set it before calling.
+    //! How an 'A' channel is to be read: whether it is coverage at all, and if so whether the color
+    //! channels are multiplied by it and in what space. AlphaType_None keeps the channel out of an
+    //! alpha-bearing group, so nothing is multiplied by it. Read by finalize(), so set it before calling.
     AlphaType_ alpha_type = AlphaType_None;
-    //! Whether an 'A' channel is transparency at all.
-    /*!
-        Orthogonal to alpha_type, which says what a *transparency* alpha means: an image can carry alpha
-        whose kind is simply unstated, which is the default and still groups as RGBA. When false the channel
-        is grouped on its own instead of joining an RGBA/YA/YCA/XYZA group, which is also what keeps
-        finalize() from premultiplying anything by it. Read by finalize(), so set it before calling.
-    */
-    bool                 alpha_is_transparency = true;
-    json                 metadata = json::object();
+    json                 metadata   = json::object();
     Exif                 exif;     //!< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; //!< The raw XMP data from the file, if any
     std::vector<uint8_t> icc_data; //!< The raw ICC profile data from the file, if any
@@ -564,6 +557,14 @@ public:
         machinery build themselves out of those names in finalize().
     */
     Image(int2 size, const std::vector<std::string> &channel_names);
+
+    //! Set alpha_type from the channel names alone, for an image not built from a file.
+    /*!
+        An image assembled in memory -- over IPC, by an edit, by a test -- already holds samples in
+        HDRView's working representation, which is premultiplied and linear, so that is what its alpha
+        says. A loader overwrites this the moment it knows what the file declared.
+    */
+    void set_default_alpha_type();
     Image();
     Image(const Image &) = delete;
     Image(Image &&)      = default;
@@ -773,6 +774,9 @@ public:
     //! True when `group`'s values were premultiplied by finalize() and so must be divided back out to
     //! report what the file holds. Straight-alpha files only: a file that stored premultiplied values has
     //! no straight form for its alpha=0 pixels.
+    //! An 'A' channel is coverage rather than ordinary data.
+    bool alpha_is_transparency() const { return alpha_type != AlphaType_None; }
+
     bool unpremultiplies(const ChannelGroup &group) const
     {
         return alpha_type == AlphaType_Straight && group.num_channels > 1 && group_has_alpha(group.type);

--- a/src/imageio/alpha.cpp
+++ b/src/imageio/alpha.cpp
@@ -1,0 +1,53 @@
+/** \file alpha.cpp
+    \author Wojciech Jarosz
+*/
+
+#include "imageio/alpha.h"
+#include <smallthreadpool.h>
+
+using namespace stp;
+
+namespace
+{
+
+//! Scale each pixel's color channels by `factor(alpha)`, leaving alpha itself alone.
+template <typename F>
+void scale_colors_by_alpha(float *pixels, int3 size, F &&factor)
+{
+    int block_size = std::max(1, 1024 * 1024 / size.x);
+    parallel_for(blocked_range<int>(0, size.y, block_size),
+                 [pixels, size, &factor](int begin_y, int end_y, int, int)
+                 {
+                     for (int y = begin_y; y < end_y; ++y)
+                         for (int x = 0; x < size.x; ++x)
+                         {
+                             const size_t scanline = size_t(x + y * size.x) * size.z;
+                             const float  f        = factor(pixels[scanline + size.z - 1]);
+                             for (int c = 0; c < size.z - 1; ++c) pixels[scanline + c] *= f;
+                         }
+                 });
+}
+
+bool needs_undoing(int3 size, AlphaType_ alpha_type)
+{
+    return alpha_type == AlphaType_PremultipliedNonLinear && size.z > 1;
+}
+
+} // namespace
+
+void unpremultiply_before_transfer(float *pixels, int3 size, AlphaType_ alpha_type)
+{
+    if (!needs_undoing(size, alpha_type))
+        return;
+
+    // A fully transparent pixel carries no color to recover, so leave it rather than dividing by zero.
+    scale_colors_by_alpha(pixels, size, [](float a) { return a == 0.f ? 1.f : 1.f / a; });
+}
+
+void repremultiply_after_transfer(float *pixels, int3 size, AlphaType_ alpha_type)
+{
+    if (!needs_undoing(size, alpha_type))
+        return;
+
+    scale_colors_by_alpha(pixels, size, [](float a) { return a; });
+}

--- a/src/imageio/alpha.h
+++ b/src/imageio/alpha.h
@@ -1,0 +1,43 @@
+/** \file alpha.h
+    \author Wojciech Jarosz
+*/
+
+#pragma once
+
+#include "colorspace.h"
+#include "fwd.h"
+#include "imageio/image_loader.h"
+
+//! What the file says its alpha is, unless the load options override it.
+/*!
+    Resolved by each loader rather than stamped on afterwards, because the answer decides whether the color
+    channels have to be divided by alpha before the transfer function is inverted -- which happens while the
+    loader still holds the encoded samples.
+
+    This is only half of an override. AlphaType_None also has to keep the channel out of an alpha-bearing
+    group, and that half is applied centrally, once a loader returns, by BackgroundImageLoader. So a caller
+    that reaches a loader directly rather than through load_image() gets the premultiplication but not the
+    grouping.
+*/
+inline AlphaType_ effective_alpha_type(const ImageLoadOptions &opts, AlphaType_ from_file)
+{
+    return opts.override_alpha ? opts.alpha_override : from_file;
+}
+
+/** \name Premultiplied alpha across a transfer function
+    Multiplying by alpha and applying a transfer function do not commute, so color premultiplied *after*
+    encoding has to be divided by alpha before the transfer is inverted and multiplied back once it is:
+    \f$EOTF(a \cdot C) \neq a \cdot EOTF(C)\f$. Call these in pairs around whatever a loader does to reach
+    linear light. Both are no-ops for every other AlphaType_: color premultiplied in linear light is already
+    what the inverse transfer produces, and straight color is premultiplied later, by Image::finalize(), once
+    every loader has reached the same representation.
+
+    Nearly every format's premultiplied alpha is the post-transfer kind -- Photoshop, OpenImageIO,
+    ImageMagick and vips all write it that way -- but a file can carry either, which is what
+    ImageLoadOptions::alpha_override exists to state. `pixels` is interleaved with `size.z` channels, alpha
+    last. A linear transfer makes the pair cancel, so this stays correct for formats storing linear samples.
+*/
+/**@{*/
+void unpremultiply_before_transfer(float *pixels, int3 size, AlphaType_ alpha_type);
+void repremultiply_after_transfer(float *pixels, int3 size, AlphaType_ alpha_type);
+/**@}*/

--- a/src/imageio/alpha.h
+++ b/src/imageio/alpha.h
@@ -7,21 +7,17 @@
 #include "colorspace.h"
 #include "fwd.h"
 #include "imageio/image_loader.h"
+#include <optional>
 
-//! What the file says its alpha is, unless the load options override it.
+//! The alpha override the load options carry, if any, in the form Image::set_alpha() takes.
 /*!
-    Resolved by each loader rather than stamped on afterwards, because the answer decides whether the color
+    Applied by each loader rather than stamped on afterwards, because the answer decides whether the color
     channels have to be divided by alpha before the transfer function is inverted -- which happens while the
     loader still holds the encoded samples.
-
-    This is only half of an override. AlphaType_None also has to keep the channel out of an alpha-bearing
-    group, and that half is applied centrally, once a loader returns, by BackgroundImageLoader. So a caller
-    that reaches a loader directly rather than through load_image() gets the premultiplication but not the
-    grouping.
 */
-inline AlphaType_ effective_alpha_type(const ImageLoadOptions &opts, AlphaType_ from_file)
+inline std::optional<AlphaType_> alpha_override_of(const ImageLoadOptions &opts)
 {
-    return opts.override_alpha ? opts.alpha_override : from_file;
+    return opts.override_alpha ? std::optional<AlphaType_>{opts.alpha_override} : std::nullopt;
 }
 
 /** \name Premultiplied alpha across a transfer function

--- a/src/imageio/dds.cpp
+++ b/src/imageio/dds.cpp
@@ -25,6 +25,7 @@
 
 #include <smalldds.h>
 
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 
 #if defined(__clang__)
@@ -658,7 +659,7 @@ bool is_dds_image(std::istream &is) noexcept
     }
 }
 
-vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLoadOptions & /*opts*/)
+vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLoadOptions &opts)
 {
     ScopedMDC mdc{"IO", "DDS"};
     DDSFile   dds;
@@ -730,12 +731,38 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
         {
             ImagePtr image = new_images[i];
 
+            // DXT2 and DXT4 are the premultiplied-alpha spellings of DXT3 and DXT5, and a DX9 file carries
+            // that only in its FourCC -- there is no misc_flags2 to read it from. Without this the values,
+            // which arrive already multiplied by alpha, would be premultiplied a second time by finalize().
+            const bool premultiplied = dds.alpha_mode == DDSFile::ALPHA_MODE_PREMULTIPLIED ||
+                                       dds.compression == DDSFile::Compression::BC2_DXT2 ||
+                                       dds.compression == DDSFile::Compression::BC3_DXT4;
+            const int num_ch  = (int)image->channels.size();
+            image->alpha_type = effective_alpha_type(
+                opts, num_ch >= 4 || num_ch == 2 ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
+                                                 : AlphaType_None);
+
             // sRGB to linear for uncompressed sRGB formats
             if (dds.is_sRGB())
             {
                 spdlog::info("Converting sRGB to linear for uncompressed image.");
+
+                // Color premultiplied after encoding has to be divided out across the conversion, which the
+                // channels are laid out for here rather than interleaved; see imageio/alpha.h.
+                const Channel *alpha =
+                    image->alpha_type == AlphaType_PremultipliedNonLinear && (num_ch >= 4 || num_ch == 2)
+                        ? &image->channels[num_ch - 1]
+                        : nullptr;
                 for (int c = 0; c < std::min(3, dds.num_channels); ++c)
-                    image->channels[c].apply([](float v, int, int) { return sRGB_to_linear(v); });
+                    image->channels[c].apply(
+                        [alpha](float v, int x, int y)
+                        {
+                            if (!alpha)
+                                return sRGB_to_linear(v);
+
+                            const float a = (*alpha)(x, y);
+                            return a == 0.f ? sRGB_to_linear(v) : a * sRGB_to_linear(v / a);
+                        });
             }
 
             // rename the channels according to the format type
@@ -745,15 +772,6 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
             image->filename = filename;
             if (image->partname.empty())
                 image->partname = dds.array_size() > 1 ? cubemap_face_names[p % 6] : "";
-            // DXT2 and DXT4 are the premultiplied-alpha spellings of DXT3 and DXT5, and a DX9 file carries
-            // that only in its FourCC -- there is no misc_flags2 to read it from. Without this the values,
-            // which arrive already multiplied by alpha, would be premultiplied a second time by finalize().
-            const bool premultiplied = dds.alpha_mode == DDSFile::ALPHA_MODE_PREMULTIPLIED ||
-                                       dds.compression == DDSFile::Compression::BC2_DXT2 ||
-                                       dds.compression == DDSFile::Compression::BC3_DXT4;
-            image->alpha_type         = image->channels.size() >= 4 || image->channels.size() == 2
-                                            ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
-                                            : AlphaType_None;
             image->metadata["loader"] = "smalldds";
             image->metadata["pixel format"] =
                 dds.bitmasked ? header["bitmask_string"]["string"].get<string>()

--- a/src/imageio/dds.cpp
+++ b/src/imageio/dds.cpp
@@ -737,10 +737,16 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
             const bool premultiplied = dds.alpha_mode == DDSFile::ALPHA_MODE_PREMULTIPLIED ||
                                        dds.compression == DDSFile::Compression::BC2_DXT2 ||
                                        dds.compression == DDSFile::Compression::BC3_DXT4;
-            const int num_ch  = (int)image->channels.size();
-            image->alpha_type = effective_alpha_type(
-                opts, num_ch >= 4 || num_ch == 2 ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
-                                                 : AlphaType_None);
+            const int  num_ch    = (int)image->channels.size();
+            const bool has_alpha = num_ch >= 4 || num_ch == 2;
+            // A DX9 header has no misc_flags2 to read, so outside the DXT2/DXT4 spellings nothing in such a
+            // file states the kind and straight is a guess.
+            const AlphaSource_ alpha_source =
+                !has_alpha || premultiplied || dds.alpha_mode != DDSFile::ALPHA_MODE_UNKNOWN ? AlphaSource_File
+                                                                                             : AlphaSource_Assumed;
+            image->set_alpha(has_alpha ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
+                                       : AlphaType_None,
+                             alpha_source, alpha_override_of(opts));
 
             // sRGB to linear for uncompressed sRGB formats
             if (dds.is_sRGB())

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -10,6 +10,7 @@
 #include "exr_save_options.h"
 #include "exr_std_streams.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 #include "imgui.h"
 #include "imgui_ext.h"
@@ -521,7 +522,7 @@ vector<ImagePtr> load_exr_image(istream &is_, string_view filename, const ImageL
         for (const auto &c : img->channels)
             if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
             {
-                img->alpha_type = AlphaType_PremultipliedLinear;
+                img->alpha_type = effective_alpha_type(opts, AlphaType_PremultipliedLinear);
                 break;
             }
 

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -522,7 +522,8 @@ vector<ImagePtr> load_exr_image(istream &is_, string_view filename, const ImageL
         for (const auto &c : img->channels)
             if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
             {
-                img->alpha_type = effective_alpha_type(opts, AlphaType_PremultipliedLinear);
+                // OpenEXR's spec makes alpha associated, and its samples are linear.
+                img->set_alpha(AlphaType_PremultipliedLinear, AlphaSource_Format, alpha_override_of(opts));
                 break;
             }
 

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -5,6 +5,7 @@
 //
 
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 #include <cstring>
 #include <iostream>
@@ -362,7 +363,8 @@ static auto chroma_name(heif_chroma ch)
 static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_profile_nclx *handle_level_nclx,
                                            const std::vector<uint8_t> &handle_level_icc_profile,
                                            const ImageLoadOptions &opts, int3 &size, int cpp, int num_planes,
-                                           const heif_channel out_planes[], const string &partname)
+                                           const heif_channel out_planes[], const string &partname,
+                                           AlphaType_ alpha_type)
 {
     int img_w = heif_image_get_width(himage, out_planes[0]);
     int img_h = heif_image_get_height(himage, out_planes[0]);
@@ -493,6 +495,10 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
         // interleaved paths hand alpha to linearize_pixels(), which already leaves the last channel alone.
         if (out_planes[p] != heif_channel_Alpha)
         {
+            // Inverting the transfer function does not commute with multiplication by alpha; see
+            // imageio/alpha.h.
+            unpremultiply_before_transfer(float_pixels.get(), int3{size.xy(), cpp}, alpha_type);
+
             if (opts.override_profile)
             {
                 spdlog::info("Ignoring embedded color profile with user-specified profile: {} {}",
@@ -535,6 +541,8 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
 
                 image->metadata["color profile"] = profile_desc;
             }
+
+            repremultiply_after_transfer(float_pixels.get(), int3{size.xy(), cpp}, alpha_type);
         }
 
         // copy the interleaved float pixels into the channels
@@ -859,17 +867,21 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
                         return raw_img;
                     }(),
                     heif_image_release);
+                // Resolved before decoding: the color management inside brackets itself with it.
+                const AlphaType_ alpha_type =
+                    effective_alpha_type(opts, !has_alpha ? AlphaType_None
+                                                          : (heif_image_handle_is_premultiplied_alpha(ihandle.get())
+                                                                 ? AlphaType_PremultipliedLinear
+                                                                 : AlphaType_Straight));
+
                 // create Image from decoded heif_image; process_decoded_heif_image will create and fill pixel data
                 ImagePtr image =
                     process_decoded_heif_image(himage.get(), handle_level_nclx.get(), handle_level_icc_profile, opts,
-                                               size, cpp, num_planes, out_planes, fmt::format("{:d}", id));
+                                               size, cpp, num_planes, out_planes, fmt::format("{:d}", id), alpha_type);
 
                 // preserve file-level metadata that comes from the handle/context
                 image->filename                         = filename;
-                image->alpha_type                       = !has_alpha ? AlphaType_None
-                                                                     : (heif_image_handle_is_premultiplied_alpha(ihandle.get())
-                                                                            ? AlphaType_PremultipliedLinear
-                                                                            : AlphaType_Straight);
+                image->alpha_type                       = alpha_type;
                 image->metadata["header"]["MIME type"]  = {{"value", mime}, {"string", mime}, {"type", "string"}};
                 image->metadata["header"]["Main brand"] = {
                     {"value", main_brand}, {"string", main_brand}, {"type", "string"}};
@@ -1032,8 +1044,8 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
                     HeifImagePtr himage(raw_img, heif_image_release);
 
                     heif_channel out_planes[2] = {heif_channel_interleaved, heif_channel_Alpha};
-                    ImagePtr     image =
-                        process_decoded_heif_image(himage.get(), nullptr, {}, opts, size, 3, 1, out_planes, partname);
+                    ImagePtr image = process_decoded_heif_image(himage.get(), nullptr, {}, opts, size, 3, 1, out_planes,
+                                                                partname, AlphaType_None);
                     image->filename                         = filename;
                     image->metadata["header"]["MIME type"]  = {{"value", mime}, {"string", mime}, {"type", "string"}};
                     image->metadata["header"]["Main brand"] = {

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -950,11 +950,25 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
                         }
                     }
 
+                    // An EXIF item begins with a four-byte big-endian offset to the TIFF header that
+                    // follows it (ISO/IEC 23008-12 Annex A.2.1). Most writers put an "Exif\0\0" marker in
+                    // between and set the offset to 6; the rest set it to zero. Honoring the offset finds
+                    // the header in either case, rather than relying on libexif recognizing and skipping a
+                    // marker it was given by accident.
                     if (exif_data.size() > 4)
                     {
+                        const size_t tiff_header_offset = (size_t(exif_data[0]) << 24) | (size_t(exif_data[1]) << 16) |
+                                                          (size_t(exif_data[2]) << 8) | size_t(exif_data[3]);
+                        const size_t tiff_start = 4 + tiff_header_offset;
+
                         try
                         {
-                            image->exif                = Exif{exif_data.data() + 4, exif_data.size() - 4};
+                            if (tiff_start >= exif_data.size())
+                                throw std::runtime_error{
+                                    fmt::format("EXIF item says its TIFF header is at {}, past the {} bytes it holds",
+                                                tiff_start, exif_data.size())};
+
+                            image->exif = Exif{exif_data.data() + tiff_start, exif_data.size() - tiff_start};
                             image->metadata["exif"]    = image->exif.to_json();
                             image->orientation_applied = true;
                             spdlog::debug("EXIF metadata successfully parsed: {}", image->metadata["exif"].dump(2));

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -867,12 +867,15 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
                         return raw_img;
                     }(),
                     heif_image_release);
+                // MIAF settles this by the presence of a 'prem' reference from the master image to the alpha
+                // one: absent means not premultiplied, for every conforming file, so only its presence is
+                // something this file said.
+                const bool       premultiplied = heif_image_handle_is_premultiplied_alpha(ihandle.get());
+                const AlphaType_ from_file =
+                    !has_alpha ? AlphaType_None : (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight);
+
                 // Resolved before decoding: the color management inside brackets itself with it.
-                const AlphaType_ alpha_type =
-                    effective_alpha_type(opts, !has_alpha ? AlphaType_None
-                                                          : (heif_image_handle_is_premultiplied_alpha(ihandle.get())
-                                                                 ? AlphaType_PremultipliedLinear
-                                                                 : AlphaType_Straight));
+                const AlphaType_ alpha_type = alpha_override_of(opts).value_or(from_file);
 
                 // create Image from decoded heif_image; process_decoded_heif_image will create and fill pixel data
                 ImagePtr image =
@@ -880,8 +883,9 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
                                                size, cpp, num_planes, out_planes, fmt::format("{:d}", id), alpha_type);
 
                 // preserve file-level metadata that comes from the handle/context
-                image->filename                         = filename;
-                image->alpha_type                       = alpha_type;
+                image->filename = filename;
+                image->set_alpha(from_file, premultiplied ? AlphaSource_File : AlphaSource_Format,
+                                 alpha_override_of(opts));
                 image->metadata["header"]["MIME type"]  = {{"value", mime}, {"string", mime}, {"type", "string"}};
                 image->metadata["header"]["Main brand"] = {
                     {"value", main_brand}, {"string", main_brand}, {"type", "string"}};

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -921,11 +921,36 @@ void draw_load_image_options_dialog(bool &open)
                        "only load layers which contain either of these two words, and \"-.A\" would exclude channels "
                        "named \"A\". Leave empty to load all parts.");
 
-        ImGui::Checkbox("Alpha channel is transparency", &s_opts.alpha_is_transparency);
-        ImGui::Tooltip("By default an alpha channel is treated as transparency: HDRView premultiplies the color "
-                       "channels by it on load, and composites the image against the background. Turn this off for "
-                       "files whose fourth channel is really a mask or other data, to load it as an ordinary "
-                       "channel of its own that nothing is multiplied by.");
+        ImGui::Checkbox("Override file's alpha", &s_opts.override_alpha);
+        ImGui::Tooltip("By default HDRView follows what the file says about its alpha channel. Enable this to state "
+                       "the interpretation yourself, for a file whose semi-transparent areas read too dark or too "
+                       "bright, or whose fourth channel is really a mask rather than transparency.");
+
+        if (s_opts.override_alpha)
+        {
+            ImGui::Indent();
+            ImGui::PushItemWidth(ImGui::CalcItemWidth() - ImGui::GetStyle().IndentSpacing);
+            if (ImGui::BeginCombo("Alpha", alpha_override_name(s_opts.alpha_override)))
+            {
+                for (AlphaType_ a = 0; a < AlphaType_Count; ++a)
+                {
+                    const bool is_selected = s_opts.alpha_override == a;
+                    if (ImGui::Selectable(alpha_override_name(a), is_selected))
+                        s_opts.alpha_override = a;
+
+                    if (is_selected)
+                        ImGui::SetItemDefaultFocus();
+                }
+                ImGui::EndCombo();
+            }
+            ImGui::Tooltip("\"None\" loads a fourth channel as ordinary data rather than transparency: it is grouped "
+                           "on its own and nothing is multiplied by it.\n\nThe two premultiplied kinds differ in "
+                           "where the multiply happened. Nearly every application multiplies the encoded values, "
+                           "which is \"after transfer\"; \"in linear light\" is the other order, and the two coincide "
+                           "for formats whose samples are already linear.");
+            ImGui::PopItemWidth();
+            ImGui::Unindent();
+        }
 
         ImGui::Checkbox("Override file's color profile", &s_opts.override_profile);
         ImGui::Tooltip("By default, HDRView tries to detect the color profile of the image from metadata stored in the "
@@ -1204,10 +1229,17 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
 
                 i->filename   = filename;
                 i->size_bytes = static_cast<size_t>(size);
-                // A loader that already knows the file's extra channel isn't alpha keeps that; the option
-                // can only turn transparency off, never assert it against what the file says.
-                i->alpha_is_transparency = i->alpha_is_transparency && opts.alpha_is_transparency;
-
+                if (opts.override_alpha)
+                {
+                    // The loaders have already applied the override to alpha_type, via
+                    // effective_alpha_type(), because they needed it while the samples were still encoded.
+                    // Grouping is the half that can only be settled here: AlphaType_None says the channel
+                    // is not transparency at all, which finalize() below reads to keep it out of an
+                    // alpha-bearing group. Recording the option itself lets a reload or a saved session
+                    // repeat it.
+                    i->alpha_override        = opts.alpha_override;
+                    i->alpha_is_transparency = opts.alpha_override != AlphaType_None;
+                }
                 // If multiple image "parts" were loaded and they have names, store these names in the image's
                 // channel selector. This is useful if we later want to reload a specific image part from the
                 // original file.
@@ -1225,7 +1257,7 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
                 }
                 i->short_name = i->file_and_partname();
 
-                // finalize() consumes alpha_is_transparency, so it runs after the options are stamped on
+                // finalize() reads alpha_type, which each loader has already resolved against the options
                 i->finalize();
                 kept.push_back(i);
             }

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -1229,17 +1229,10 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
 
                 i->filename   = filename;
                 i->size_bytes = static_cast<size_t>(size);
+                // The loaders have already applied the override to alpha_type, via effective_alpha_type();
+                // recording the option itself is what lets a reload or a saved session repeat it.
                 if (opts.override_alpha)
-                {
-                    // The loaders have already applied the override to alpha_type, via
-                    // effective_alpha_type(), because they needed it while the samples were still encoded.
-                    // Grouping is the half that can only be settled here: AlphaType_None says the channel
-                    // is not transparency at all, which finalize() below reads to keep it out of an
-                    // alpha-bearing group. Recording the option itself lets a reload or a saved session
-                    // repeat it.
-                    i->alpha_override        = opts.alpha_override;
-                    i->alpha_is_transparency = opts.alpha_override != AlphaType_None;
-                }
+                    i->alpha_override = opts.alpha_override;
                 // If multiple image "parts" were loaded and they have names, store these names in the image's
                 // channel selector. This is useful if we later want to reload a specific image part from the
                 // original file.

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -27,9 +27,16 @@ struct ImageLoadOptions
     //! Comma-separated list of channel names to include or exclude from the image. If empty, all channels are selected.
     string channel_selector;
 
-    //! When false, an alpha channel is loaded as ordinary data instead of transparency: it is grouped on its own
-    //! and the color channels are not premultiplied by it. See Image::alpha_is_transparency.
-    bool alpha_is_transparency = true;
+    bool override_alpha = false;
+    //! Override what the file says about its alpha and interpret it this way instead.
+    /*!
+        A format states, or its spec implies, whether the color channels are multiplied by alpha and in what
+        space, and files routinely disagree with that: PNG is unassociated by spec but is sometimes written
+        premultiplied, EXR is premultiplied by spec but is sometimes written straight. AlphaType_None loads a
+        fourth channel as ordinary data rather than transparency, so nothing is multiplied by it and it is
+        grouped on its own. See Image::alpha_type.
+    */
+    AlphaType_ alpha_override = AlphaType_Straight;
 
     bool override_profile = false;
     //! Override any metadata in the file and decode pixel values using this color gamut.

--- a/src/imageio/jxl.cpp
+++ b/src/imageio/jxl.cpp
@@ -9,6 +9,7 @@
 #include "endian-utils.h"
 #include "exif.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 #include <cstdint>
 #include <cstdio>
@@ -692,9 +693,10 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
             image                                         = make_shared<Image>(size.xy(), size.z);
             image->filename                               = filename;
             image->partname                               = frame_name;
-            image->alpha_type                             = !info.alpha_bits
-                                                                ? AlphaType_None
-                                                                : (info.alpha_premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight);
+            image->alpha_type                             = effective_alpha_type(
+                opts, !info.alpha_bits
+                                                      ? AlphaType_None
+                                                      : (info.alpha_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight));
             image->metadata["loader"]                     = "libjxl";
             image->metadata["header"]["original profile"] = {
                 {"value", (bool)info.uses_original_profile},
@@ -811,26 +813,11 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
                 continue;
             }
 
-            // for premultiplied files, JPEGL-XL premultiplies by the non-linear alpha value, so we must unpremultiply
-            // before applying the inverse transfer function, then premultiply again
-            if (info.alpha_premultiplied)
-            {
-                int block_size = std::max(1, 1024 * 1024 / size.x);
-                parallel_for(blocked_range<int>(0, size.y, block_size),
-                             [&pixels, &size](int begin_y, int end_y, int, int)
-                             {
-                                 for (int y = begin_y; y < end_y; ++y)
-                                 {
-                                     for (int x = 0; x < size.x; ++x)
-                                     {
-                                         const size_t scanline = (x + y * size.x) * size.z;
-                                         const float  alpha    = pixels[scanline + size.z - 1];
-                                         const float  factor   = alpha == 0.0f ? 1.0f : 1.0f / alpha;
-                                         for (int c = 0; c < size.z - 1; ++c) pixels[scanline + c] *= factor;
-                                     }
-                                 }
-                             });
-            }
+            // JPEG XL says only whether the alpha is premultiplied, not in what space; this assumes the
+            // post-transfer kind, by analogy with the formats where it is established. libjxl's own
+            // JxlDecoderSetUnpremultiplyAlpha() does not act on the main alpha channel, so the samples
+            // arrive exactly as stored and this has to undo it. See imageio/alpha.h.
+            unpremultiply_before_transfer(pixels.data(), size, image->alpha_type);
 
             vector<float> alpha_copy;
 
@@ -919,25 +906,7 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
                 spdlog::info("Swapped alpha channel in interleaved array back with black channel data.");
             }
 
-            // premultiply again
-            if (info.alpha_premultiplied)
-            {
-                int block_size = std::max(1, 1024 * 1024 / size.x);
-                parallel_for(blocked_range<int>(0, size.y, block_size),
-                             [&pixels, &size](int begin_y, int end_y, int, int)
-                             {
-                                 for (int y = begin_y; y < end_y; ++y)
-                                 {
-                                     for (int x = 0; x < size.x; ++x)
-                                     {
-                                         const size_t scanline = (x + y * size.x) * size.z;
-                                         const float  alpha    = pixels[scanline + size.z - 1];
-                                         const float  factor   = alpha == 0.0f ? 1.0f : alpha;
-                                         for (int c = 0; c < size.z - 1; ++c) pixels[scanline + c] *= factor;
-                                     }
-                                 }
-                             });
-            }
+            repremultiply_after_transfer(pixels.data(), size, image->alpha_type);
 
             // copy the interleaved float pixels into the channels
             for (int c = 0; c < size.z; ++c)

--- a/src/imageio/jxl.cpp
+++ b/src/imageio/jxl.cpp
@@ -693,10 +693,13 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
             image                                         = make_shared<Image>(size.xy(), size.z);
             image->filename                               = filename;
             image->partname                               = frame_name;
-            image->alpha_type                             = effective_alpha_type(
-                opts, !info.alpha_bits
-                                                      ? AlphaType_None
-                                                      : (info.alpha_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight));
+            // JxlBasicInfo always carries alpha_premultiplied, so a file with alpha has stated its kind --
+            // though not the space it means, which is why the premultiplied case is the assumed one. See
+            // the note where it is undone below.
+            image->set_alpha(!info.alpha_bits
+                                 ? AlphaType_None
+                                 : (info.alpha_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight),
+                             info.alpha_bits ? AlphaSource_File : AlphaSource_Format, alpha_override_of(opts));
             image->metadata["loader"]                     = "libjxl";
             image->metadata["header"]["original profile"] = {
                 {"value", (bool)info.uses_original_profile},

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -8,6 +8,7 @@
 #include "app.h"
 #include "colorspace.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 
 #include <stdexcept>
@@ -703,7 +704,8 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         int3 size{int(frame_width), int(frame_height), channels};
         auto image            = make_shared<Image>(size.xy(), size.z);
         image->filename       = filename;
-        image->alpha_type     = size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None;
+        image->alpha_type =
+            effective_alpha_type(opts, size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None);
         image->chromaticities = chr;
         image->metadata       = metadata;
         // A palette's IHDR depth counts bits per index; png_set_palette_to_rgb() expands those to 8-bit RGB.
@@ -751,6 +753,10 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
             image->icc_data = icc_profile;
 
         string profile_desc = color_profile_name(chr ? named_color_gamut(*chr) : ColorGamut_Unspecified, tf);
+
+        // Inverting the transfer function does not commute with multiplication by alpha; see imageio/alpha.h.
+        unpremultiply_before_transfer(float_pixels.data(), size, image->alpha_type);
+
         if (opts.override_profile)
         {
             spdlog::info("Ignoring embedded color profile and linearizing using requested transfer function: {}",
@@ -799,6 +805,8 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
             else
                 spdlog::info("Image is already in linear color space.");
         }
+
+        repremultiply_after_transfer(float_pixels.data(), size, image->alpha_type);
 
         image->metadata["color profile"] = profile_desc;
 

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -704,8 +704,9 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         int3 size{int(frame_width), int(frame_height), channels};
         auto image            = make_shared<Image>(size.xy(), size.z);
         image->filename       = filename;
-        image->alpha_type =
-            effective_alpha_type(opts, size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None);
+        // PNG's spec makes alpha unassociated; a file carries no per-file signal to read.
+        image->set_alpha(size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None, AlphaSource_Format,
+                         alpha_override_of(opts));
         image->chromaticities = chr;
         image->metadata       = metadata;
         // A palette's IHDR depth counts bits per index; png_set_palette_to_rgb() expands those to 8-bit RGB.

--- a/src/imageio/qoi.cpp
+++ b/src/imageio/qoi.cpp
@@ -12,6 +12,7 @@
 
 #include <qoi.h>
 
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 
 #include "colorspace.h"
@@ -100,7 +101,7 @@ vector<ImagePtr> load_qoi_image(istream &is, string_view filename, const ImageLo
 
     auto image                      = make_shared<Image>(size.xy(), size.z);
     image->filename                 = filename;
-    image->alpha_type               = size.z > 3 ? AlphaType_Straight : AlphaType_None;
+    image->alpha_type               = effective_alpha_type(opts, size.z > 3 ? AlphaType_Straight : AlphaType_None);
     image->metadata["loader"]       = "qoi";
     image->metadata["pixel format"] = fmt::format("{}-bit (8 bpc)", size.z * 8);
     image->set_bits_per_sample(8);

--- a/src/imageio/qoi.cpp
+++ b/src/imageio/qoi.cpp
@@ -101,7 +101,8 @@ vector<ImagePtr> load_qoi_image(istream &is, string_view filename, const ImageLo
 
     auto image                      = make_shared<Image>(size.xy(), size.z);
     image->filename                 = filename;
-    image->alpha_type               = effective_alpha_type(opts, size.z > 3 ? AlphaType_Straight : AlphaType_None);
+    // QOI's spec makes alpha unassociated.
+    image->set_alpha(size.z > 3 ? AlphaType_Straight : AlphaType_None, AlphaSource_Format, alpha_override_of(opts));
     image->metadata["loader"]       = "qoi";
     image->metadata["pixel format"] = fmt::format("{}-bit (8 bpc)", size.z * 8);
     image->set_bits_per_sample(8);

--- a/src/imageio/stb.cpp
+++ b/src/imageio/stb.cpp
@@ -7,6 +7,7 @@
 #include "stb.h"
 #include "colorspace.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 #include "timer.h"
 #include <cstdint>
@@ -293,7 +294,7 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
 
         image             = make_shared<Image>(size.xy(), size.z);
         image->filename   = filename;
-        image->alpha_type = size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None;
+        image->alpha_type = effective_alpha_type(opts, size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None);
         if (size.w > 1)
             image->partname = fmt::format("frame {:04}", frame);
         image->metadata["loader"] = fmt::format("stb_image ({})", j["format"].get<string>());
@@ -355,6 +356,10 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
             image->icc_data = psd_metadata.icc_profile;
 
         string profile_desc = color_profile_name(cg, tf);
+
+        // Inverting the transfer function does not commute with multiplication by alpha; see imageio/alpha.h.
+        unpremultiply_before_transfer(float_pixels.data(), size.xyz(), image->alpha_type);
+
         if (opts.override_profile)
         {
             Chromaticities c;
@@ -386,6 +391,8 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
             else
                 spdlog::info("Image is already in linear color space.");
         }
+
+        repremultiply_after_transfer(float_pixels.data(), size.xyz(), image->alpha_type);
 
         image->metadata["color profile"] = profile_desc;
 

--- a/src/imageio/stb.cpp
+++ b/src/imageio/stb.cpp
@@ -294,7 +294,9 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
 
         image             = make_shared<Image>(size.xy(), size.z);
         image->filename   = filename;
-        image->alpha_type = effective_alpha_type(opts, size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None);
+        // None of the stb-decoded formats carries an alpha-kind signal; all specify unassociated.
+        image->set_alpha(size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None, AlphaSource_Format,
+                         alpha_override_of(opts));
         if (size.w > 1)
             image->partname = fmt::format("frame {:04}", frame);
         image->metadata["loader"] = fmt::format("stb_image ({})", j["format"].get<string>());

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -375,11 +375,14 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
 
         // Only guess when the file said nothing. An EXTRASAMPLES tag naming something other than alpha
         // (EXTRASAMPLE_UNSPECIFIED) is the file stating the extra sample is arbitrary data, so honor it.
+        AlphaSource_ alpha_source = AlphaSource_File;
         if (!has_alpha && !has_extra_samples && num_channels == 4)
         {
             has_alpha = true;
-            // Default to straight alpha if not specified
+            // Straight is the likelier reading for an unlabeled RGBA TIFF, but it is a guess, and this is
+            // the one place in this loader where nothing in the file settles the question.
             is_premultiplied = false;
+            alpha_source     = AlphaSource_Assumed;
             spdlog::debug("Inferred alpha channel from channel count (assuming straight alpha)");
         }
 
@@ -388,9 +391,9 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         // other than alpha leaves has_alpha false, and AlphaType_None then keeps that sample out of an
         // alpha-bearing group. Associated alpha is multiplied into the encoded samples, which is what every
         // writer that produces one -- Photoshop, OpenImageIO, ImageMagick, vips -- does.
-        image->alpha_type = effective_alpha_type(
-            opts,
-            has_alpha ? (is_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight) : AlphaType_None);
+        image->set_alpha(has_alpha ? (is_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight)
+                                   : AlphaType_None,
+                         alpha_source, alpha_override_of(opts));
         image->metadata["loader"] = "libtiff";
         image->partname           = partname;
 

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -8,6 +8,7 @@
 #include "app.h"
 #include "common.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 
 #include <cmath>
@@ -383,9 +384,12 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         }
 
         auto image = make_shared<Image>(int2{(int)width, (int)height}, num_channels);
-        // Track what type of alpha the file contained (not what we convert it to internally)
-        image->alpha_type =
-            has_alpha ? (is_premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight) : AlphaType_None;
+        // What the file holds, not what it is converted to internally. Associated alpha is multiplied into
+        // the encoded samples, which is what every writer that produces one -- Photoshop, OpenImageIO,
+        // ImageMagick, vips -- does.
+        image->alpha_type = effective_alpha_type(
+            opts,
+            has_alpha ? (is_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight) : AlphaType_None);
         // An EXTRASAMPLES tag that names something other than alpha states the extra sample is arbitrary
         // data, so keep it out of an alpha-bearing group entirely.
         if (has_extra_samples && !has_alpha)
@@ -878,6 +882,10 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         string         profile_desc;
         Chromaticities chr;
 
+        // The color management below inverts the file's transfer function, which does not commute with
+        // multiplication by alpha; see imageio/alpha.h.
+        unpremultiply_before_transfer(float_pixels.data(), size, image->alpha_type);
+
         if (opts.override_profile)
         {
             // Priority 1: User override (highest priority) - use gamut_override and tf_override
@@ -979,6 +987,8 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
                     image->chromaticities = chr;
             }
         }
+
+        repremultiply_after_transfer(float_pixels.data(), size, image->alpha_type);
 
         image->metadata["color profile"] = profile_desc;
 
@@ -1336,8 +1346,9 @@ void save_tiff_image(const Image &img, std::ostream &os, std::string_view filena
     TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, n);
     TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
 
-    // The pixels below are written premultiplied (as_interleaved is asked not to undo it), which is
-    // what EXTRASAMPLE_ASSOCALPHA describes.
+    // EXTRASAMPLE_ASSOCALPHA describes color multiplied into the encoded samples, so as_interleaved() is
+    // asked to divide alpha out before the transfer function and multiply it back after -- not to leave the
+    // linear premultiplication in place, which would encode a different image. See imageio/alpha.h.
     if (n == 2 || n == 4)
     {
         uint16_t extra_samples[] = {EXTRASAMPLE_ASSOCALPHA};
@@ -1381,7 +1392,7 @@ void save_tiff_image(const Image &img, std::ostream &os, std::string_view filena
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
 
         int  w_out, h_out, n_out;
-        auto pixels = img.as_interleaved<float>(&w_out, &h_out, &n_out, opts->gain, opts->tf, false, false, false);
+        auto pixels = img.as_interleaved<float>(&w_out, &h_out, &n_out, opts->gain, opts->tf, false, true, false, true);
 
         for (int y = 0; y < h; ++y)
         {
@@ -1395,7 +1406,8 @@ void save_tiff_image(const Image &img, std::ostream &os, std::string_view filena
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
 
         int  w_out, h_out, n_out;
-        auto pixels = img.as_interleaved<uint16_t>(&w_out, &h_out, &n_out, opts->gain, opts->tf, true, false, false);
+        auto pixels =
+            img.as_interleaved<uint16_t>(&w_out, &h_out, &n_out, opts->gain, opts->tf, true, true, false, true);
 
         for (int y = 0; y < h; ++y)
         {
@@ -1409,7 +1421,8 @@ void save_tiff_image(const Image &img, std::ostream &os, std::string_view filena
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
 
         int  w_out, h_out, n_out;
-        auto pixels = img.as_interleaved<uint8_t>(&w_out, &h_out, &n_out, opts->gain, opts->tf, true, false, false);
+        auto pixels =
+            img.as_interleaved<uint8_t>(&w_out, &h_out, &n_out, opts->gain, opts->tf, true, true, false, true);
 
         for (int y = 0; y < h; ++y)
         {

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -384,16 +384,13 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         }
 
         auto image = make_shared<Image>(int2{(int)width, (int)height}, num_channels);
-        // What the file holds, not what it is converted to internally. Associated alpha is multiplied into
-        // the encoded samples, which is what every writer that produces one -- Photoshop, OpenImageIO,
-        // ImageMagick, vips -- does.
+        // What the file holds, not what it is converted to internally. An EXTRASAMPLES tag naming something
+        // other than alpha leaves has_alpha false, and AlphaType_None then keeps that sample out of an
+        // alpha-bearing group. Associated alpha is multiplied into the encoded samples, which is what every
+        // writer that produces one -- Photoshop, OpenImageIO, ImageMagick, vips -- does.
         image->alpha_type = effective_alpha_type(
             opts,
             has_alpha ? (is_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight) : AlphaType_None);
-        // An EXTRASAMPLES tag that names something other than alpha states the extra sample is arbitrary
-        // data, so keep it out of an alpha-bearing group entirely.
-        if (has_extra_samples && !has_alpha)
-            image->alpha_is_transparency = false;
         image->metadata["loader"] = "libtiff";
         image->partname           = partname;
 

--- a/src/imageio/uhdr.cpp
+++ b/src/imageio/uhdr.cpp
@@ -10,6 +10,7 @@
 #include "exif.h"
 #include "gainmap.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 #include "imgui.h"
 #include "timer.h"
@@ -238,7 +239,7 @@ vector<ImagePtr> load_uhdr_image(istream &is, string_view filename, const ImageL
 
     auto image                = make_shared<Image>(size, 4);
     image->filename           = filename;
-    image->alpha_type         = AlphaType_Straight;
+    image->alpha_type         = effective_alpha_type(opts, AlphaType_Straight);
     image->metadata["loader"] = "libuhdr";
 
     if (auto md = uhdr_dec_get_gainmap_metadata(decoder.get()))

--- a/src/imageio/uhdr.cpp
+++ b/src/imageio/uhdr.cpp
@@ -239,7 +239,7 @@ vector<ImagePtr> load_uhdr_image(istream &is, string_view filename, const ImageL
 
     auto image                = make_shared<Image>(size, 4);
     image->filename           = filename;
-    image->alpha_type         = effective_alpha_type(opts, AlphaType_Straight);
+    image->set_alpha(AlphaType_Straight, AlphaSource_Format, alpha_override_of(opts));
     image->metadata["loader"] = "libuhdr";
 
     if (auto md = uhdr_dec_get_gainmap_metadata(decoder.get()))

--- a/src/imageio/webp.cpp
+++ b/src/imageio/webp.cpp
@@ -330,7 +330,9 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
             auto       frame_image      = make_shared<Image>(int2{img_width, img_height}, num_channels);
             frame_image->filename       = filename;
             frame_image->partname       = partname;
-            frame_image->alpha_type     = effective_alpha_type(opts, has_alpha ? AlphaType_Straight : AlphaType_None);
+            // WebP's spec makes alpha unassociated.
+            frame_image->set_alpha(has_alpha ? AlphaType_Straight : AlphaType_None, AlphaSource_Format,
+                                   alpha_override_of(opts));
             frame_image->icc_data       = icc_data;
             frame_image->exif           = Exif{exif_data};
             frame_image->xmp_data       = xmp_data;

--- a/src/imageio/webp.cpp
+++ b/src/imageio/webp.cpp
@@ -9,6 +9,7 @@
 #include "app.h"
 #include "common.h"
 #include "image.h"
+#include "imageio/alpha.h"
 #include "imageio/image_loader.h"
 #include "webp.h"
 
@@ -329,7 +330,7 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
             auto       frame_image      = make_shared<Image>(int2{img_width, img_height}, num_channels);
             frame_image->filename       = filename;
             frame_image->partname       = partname;
-            frame_image->alpha_type     = has_alpha ? AlphaType_Straight : AlphaType_None;
+            frame_image->alpha_type     = effective_alpha_type(opts, has_alpha ? AlphaType_Straight : AlphaType_None);
             frame_image->icc_data       = icc_data;
             frame_image->exif           = Exif{exif_data};
             frame_image->xmp_data       = xmp_data;
@@ -389,6 +390,11 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
 
             // Apply color profile transformations to fragment
             int3 frame_size{frame_width, frame_height, num_channels};
+
+            // Inverting the transfer function does not commute with multiplication by alpha; see
+            // imageio/alpha.h.
+            unpremultiply_before_transfer(frame_pixels.data(), frame_size, frame_image->alpha_type);
+
             if (opts.override_profile)
             {
                 string         profile_desc = color_profile_name(ColorGamut_Unspecified, TransferFunction::Unspecified);
@@ -413,6 +419,8 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
 
                 frame_image->metadata["color profile"] = profile_desc;
             }
+
+            repremultiply_after_transfer(frame_pixels.data(), frame_size, frame_image->alpha_type);
 
             float        *pixels = frame_pixels.data();
             vector<float> canvas_float;

--- a/tests/gui/test_gui_info.cpp
+++ b/tests/gui/test_gui_info.cpp
@@ -43,57 +43,7 @@ static void load_fixture_and_show_info(ImGuiTestContext *ctx)
 
 void RegisterTests_Info(ImGuiTestEngine *engine)
 {
-    ImGuiTest *t = IM_REGISTER_TEST(engine, "info", "transparency_row_is_as_tall_as_its_neighbors");
-    t->TestFunc  = [](ImGuiTestContext *ctx)
-    {
-        load_fixture_and_show_info(ctx);
-
-        // The fixture is an RGBA PNG carrying both an ICC profile and EXIF, so the General table holds the
-        // "Is transparency" checkbox with text rows on either side of it -- what this test measures against.
-        auto img = hdrview()->current_image();
-        IM_CHECK(img != nullptr);
-        IM_CHECK(img->alpha_type != AlphaType_None);
-        IM_CHECK(img->exif.valid());
-        IM_CHECK(!img->icc_data.empty());
-
-        // Every row is drawn into the scrolling child window PE::Begin("Image info") opens; the items in it
-        // are the checkbox and one child window per text row (PE::WrappedText's "ResizableChild"). Only the
-        // checkbox reports a label, so that is what tells the two apart.
-        ctx->SetRef("");
-        ImGuiTestItemList items;
-        ctx->GatherItems(&items, "//Info", -1);
-
-        struct Row
-        {
-            float y;
-            bool  is_checkbox;
-        };
-        std::vector<Row> rows;
-        for (const ImGuiTestItemInfo &item : items)
-            if (item.Window && strstr(item.Window->Name, "Image info") != nullptr)
-                rows.push_back({item.RectFull.Min.y, strcmp(item.DebugLabel, "##Alpha is transparency") == 0});
-
-        std::sort(rows.begin(), rows.end(), [](const Row &a, const Row &b) { return a.y < b.y; });
-
-        int checkbox_row = -1;
-        for (int i = 0; i < (int)rows.size(); ++i)
-            if (rows[i].is_checkbox)
-            {
-                IM_CHECK_EQ(checkbox_row, -1); // exactly one
-                checkbox_row = i;
-            }
-        IM_CHECK(checkbox_row >= 1);
-        // "EXIF data" and "ICC data" follow it, both single-line text rows
-        IM_CHECK(checkbox_row + 2 < (int)rows.size());
-
-        // A row's height is the distance to the top of the next one. Nothing makes a widget row as tall as a
-        // text row on its own -- the frame padding a checkbox carries and a line of text does not is enough
-        // to set them apart -- so measure it rather than assume.
-        const float checkbox_height = rows[checkbox_row + 1].y - rows[checkbox_row].y;
-        const float text_height     = rows[checkbox_row + 2].y - rows[checkbox_row + 1].y;
-        IM_CHECK(text_height > 0.f);
-        IM_CHECK_LE(std::fabs(checkbox_height - text_height), 0.5f);
-    };
+    ImGuiTest *t;
 
     t           = IM_REGISTER_TEST(engine, "info", "reload_actions_track_what_can_be_reloaded");
     t->TestFunc = [](ImGuiTestContext *ctx)

--- a/tests/test_alpha.cpp
+++ b/tests/test_alpha.cpp
@@ -1,0 +1,155 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "colorspace.h"
+#include "image.h"
+#include "imageio/alpha.h"
+#include "imageio/image_loader.h"
+
+#include <vector>
+
+namespace
+{
+
+// One interleaved RGBA pixel, so a scale by alpha is visible in a single value.
+std::vector<float> pixel(float r, float g, float b, float a) { return {r, g, b, a}; }
+
+// The two conventions a premultiplied file can hold, for straight color `c` under coverage `a`.
+float post_transfer(float c, float a) { return a * from_linear(c, TransferFunction::sRGB); }
+float linear_premult(float c, float a) { return from_linear(a * c, TransferFunction::sRGB); }
+
+} // namespace
+
+TEST_CASE("The alpha pair is a no-op for every kind but post-transfer premultiplication")
+{
+    for (AlphaType_ at : {AlphaType_None, AlphaType_PremultipliedLinear, AlphaType_Straight})
+    {
+        CAPTURE(alpha_type_name(at));
+        auto px = pixel(0.25f, 0.5f, 0.75f, 0.5f);
+
+        unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, at);
+        CHECK(px[0] == doctest::Approx(0.25f));
+        CHECK(px[3] == doctest::Approx(0.5f));
+
+        repremultiply_after_transfer(px.data(), int3{1, 1, 4}, at);
+        CHECK(px[0] == doctest::Approx(0.25f));
+    }
+}
+
+TEST_CASE("Post-transfer premultiplication is divided out and restored around a transfer")
+{
+    const float a = 0.5f, straight = 0.8f;
+
+    // What such a file holds: the encoded color, multiplied by alpha.
+    auto px = pixel(post_transfer(straight, a), post_transfer(straight, a), post_transfer(straight, a), a);
+
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    // Dividing by alpha recovers the encoded straight color, which is what the inverse transfer expects.
+    CHECK(px[0] == doctest::Approx(from_linear(straight, TransferFunction::sRGB)));
+
+    for (int c = 0; c < 3; ++c) px[c] = to_linear(px[c], TransferFunction::sRGB);
+
+    repremultiply_after_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    // Ending in HDRView's working form: linear color, multiplied by alpha.
+    CHECK(px[0] == doctest::Approx(a * straight));
+    CHECK(px[3] == doctest::Approx(a)); // alpha itself is never scaled
+}
+
+TEST_CASE("The two premultiplied conventions disagree, and reading one as the other is visibly wrong")
+{
+    const float a = 0.5f, straight = 1.f;
+
+    // The discriminating case from real files: full-intensity color under half coverage.
+    CHECK(post_transfer(straight, a) == doctest::Approx(0.5f));
+    CHECK(linear_premult(straight, a) == doctest::Approx(0.7354f).epsilon(0.001));
+
+    // Reading a post-transfer file as though it were linear-premultiplied applies the inverse transfer
+    // to the multiplied value, which is the error this whole distinction exists to prevent.
+    const float misread = to_linear(post_transfer(straight, a), TransferFunction::sRGB);
+    CHECK(misread == doctest::Approx(0.2140f).epsilon(0.001));
+    CHECK(misread != doctest::Approx(a * straight)); // the correct answer is 0.5
+}
+
+TEST_CASE("A transfer function that is the identity makes the two premultiplied kinds coincide")
+{
+    // Formats storing linear samples need no special case: the pair cancels arithmetically.
+    const float a = 0.5f, straight = 0.8f;
+    CHECK(from_linear(a * straight, TransferFunction::Linear) ==
+          doctest::Approx(a * from_linear(straight, TransferFunction::Linear)));
+}
+
+TEST_CASE("A fully transparent pixel keeps its color rather than dividing by zero")
+{
+    auto px = pixel(0.25f, 0.5f, 0.75f, 0.f);
+
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    CHECK(px[0] == doctest::Approx(0.25f));
+    CHECK(std::isfinite(px[0]));
+
+    repremultiply_after_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    // Restoring multiplies by the alpha that is there, so a transparent pixel ends at zero either way.
+    CHECK(px[0] == doctest::Approx(0.f));
+}
+
+TEST_CASE("A two-channel gray+alpha buffer is handled like RGBA")
+{
+    const float        a = 0.5f, straight = 0.8f;
+    std::vector<float> px{post_transfer(straight, a), a};
+
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 2}, AlphaType_PremultipliedNonLinear);
+    CHECK(px[0] == doctest::Approx(from_linear(straight, TransferFunction::sRGB)));
+    CHECK(px[1] == doctest::Approx(a));
+}
+
+TEST_CASE("A single-channel buffer has no alpha to divide by and is left alone")
+{
+    std::vector<float> px{0.25f};
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 1}, AlphaType_PremultipliedNonLinear);
+    CHECK(px[0] == doctest::Approx(0.25f));
+}
+
+TEST_CASE("effective_alpha_type reports the file's kind until the options override it")
+{
+    ImageLoadOptions opts;
+    REQUIRE_FALSE(opts.override_alpha);
+
+    // Off: whatever the loader concluded stands, for every kind.
+    for (AlphaType_ at :
+         {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
+        CHECK(effective_alpha_type(opts, at) == at);
+
+    // On: the option replaces it, including asserting alpha over a file that declared none and
+    // declaring data over a file that claimed transparency.
+    opts.override_alpha = true;
+    for (AlphaType_ forced :
+         {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
+    {
+        opts.alpha_override = forced;
+        for (AlphaType_ from_file :
+             {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
+            CHECK(effective_alpha_type(opts, from_file) == forced);
+    }
+}
+
+TEST_CASE("finalize() premultiplies straight alpha and leaves the other kinds alone")
+{
+    auto make = [](AlphaType_ at)
+    {
+        auto img = std::make_shared<Image>(int2{1, 1}, 4);
+        for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
+        img->channels[3](0, 0) = 0.5f;
+        img->alpha_type        = at;
+        img->finalize();
+        return img;
+    };
+
+    CHECK(make(AlphaType_Straight)->channels[0](0, 0) == doctest::Approx(0.5f));
+    // Already multiplied, whichever space it happened in: finalize() would be doing it a second time.
+    CHECK(make(AlphaType_PremultipliedLinear)->channels[0](0, 0) == doctest::Approx(1.f));
+    CHECK(make(AlphaType_PremultipliedNonLinear)->channels[0](0, 0) == doctest::Approx(1.f));
+}

--- a/tests/test_alpha.cpp
+++ b/tests/test_alpha.cpp
@@ -9,7 +9,11 @@
 #include "colorspace.h"
 #include "image.h"
 #include "imageio/alpha.h"
+#include "imageio/exr.h"
 #include "imageio/image_loader.h"
+#include "imageio/png.h"
+
+#include <sstream>
 
 #include <vector>
 
@@ -18,6 +22,16 @@ namespace
 
 // One interleaved RGBA pixel, so a scale by alpha is visible in a single value.
 std::vector<float> pixel(float r, float g, float b, float a) { return {r, g, b, a}; }
+
+// Channels by name: OpenEXR stores them alphabetically, so position says nothing about which is which.
+float channel_value(const ImagePtr &img, const std::string &name)
+{
+    for (const auto &c : img->channels)
+        if (Channel::tail(c.name) == name)
+            return c(0, 0);
+    FAIL("no channel named ", name);
+    return 0.f;
+}
 
 // The two conventions a premultiplied file can hold, for straight color `c` under coverage `a`.
 float post_transfer(float c, float a) { return a * from_linear(c, TransferFunction::sRGB); }
@@ -152,4 +166,83 @@ TEST_CASE("finalize() premultiplies straight alpha and leaves the other kinds al
     // Already multiplied, whichever space it happened in: finalize() would be doing it a second time.
     CHECK(make(AlphaType_PremultipliedLinear)->channels[0](0, 0) == doctest::Approx(1.f));
     CHECK(make(AlphaType_PremultipliedNonLinear)->channels[0](0, 0) == doctest::Approx(1.f));
+}
+
+// The override exists for files that contradict their own format's convention, which is the case no
+// per-format tagging can catch. These two are the ones that motivated it.
+
+TEST_CASE("An associated-alpha PNG can be read as premultiplied, against the PNG spec")
+{
+    // PNG is unassociated by spec, so HDRView premultiplies on load -- doing that to a file someone
+    // wrote premultiplied would multiply twice and darken every semi-transparent pixel.
+    // The PNG writer divides alpha out before encoding, so to land a file whose stored samples are
+    // a*OETF(C) -- half coverage over a fully bright color, encoded as 128 -- the linear color going in
+    // has to be a * EOTF(0.5).
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 0.5f * to_linear(0.5f, TransferFunction::sRGB);
+    img->channels[3](0, 0) = 0.5f;
+    img->finalize();
+
+    std::ostringstream out(std::ios::binary);
+    save_png_image(*img, out, "premul.png", /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
+                   /*sixteen_bit*/ false, TransferFunction::sRGB);
+
+    // Read as the spec says: the samples are taken as straight and multiplied by alpha again.
+    {
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               images = load_image(in, "premul.png", ImageLoadOptions{});
+        REQUIRE(images.size() == 1);
+        CHECK(images[0]->alpha_type == AlphaType_Straight);
+        // Taken as straight: EOTF(0.5) linearized, then multiplied by coverage a second time.
+        CHECK(channel_value(images[0], "R") ==
+              doctest::Approx(0.5f * to_linear(0.5f, TransferFunction::sRGB)).epsilon(0.05));
+    }
+
+    // Read as what it is: divided out across the transfer, then restored, ending where it started.
+    {
+        ImageLoadOptions opts;
+        opts.override_alpha = true;
+        opts.alpha_override = AlphaType_PremultipliedNonLinear;
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               images = load_image(in, "premul.png", opts);
+        REQUIRE(images.size() == 1);
+        CHECK(images[0]->alpha_type == AlphaType_PremultipliedNonLinear);
+        // Divided out across the transfer: the bright color the file really encodes, times its coverage.
+        CHECK(channel_value(images[0], "R") == doctest::Approx(0.5f).epsilon(0.05));
+    }
+}
+
+TEST_CASE("A straight-alpha EXR can be read as straight, against the EXR spec")
+{
+    // EXR is associated by spec, so HDRView leaves its samples alone. A file written straight needs
+    // the multiply that assumption skips.
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f; // straight, linear
+    img->channels[3](0, 0) = 0.5f;
+    img->finalize();
+
+    std::ostringstream out(std::ios::binary);
+    save_exr_image(*img, out, "straight.exr");
+
+    {
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               images = load_image(in, "straight.exr", ImageLoadOptions{});
+        REQUIRE(images.size() == 1);
+        CHECK(images[0]->alpha_type == AlphaType_PremultipliedLinear);
+        CHECK(channel_value(images[0], "R") == doctest::Approx(1.f).epsilon(0.01));
+    }
+
+    {
+        ImageLoadOptions opts;
+        opts.override_alpha = true;
+        opts.alpha_override = AlphaType_Straight;
+
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               images = load_image(in, "straight.exr", opts);
+        REQUIRE(images.size() == 1);
+        CHECK(images[0]->alpha_type == AlphaType_Straight);
+        // finalize() now multiplies by the coverage the file's samples were never scaled by.
+        CHECK(channel_value(images[0], "R") == doctest::Approx(0.5f).epsilon(0.01));
+    }
 }

--- a/tests/test_alpha.cpp
+++ b/tests/test_alpha.cpp
@@ -127,27 +127,31 @@ TEST_CASE("A single-channel buffer has no alpha to divide by and is left alone")
     CHECK(px[0] == doctest::Approx(0.25f));
 }
 
-TEST_CASE("effective_alpha_type reports the file's kind until the options override it")
+TEST_CASE("set_alpha records what the file said, and what an override replaced it with")
 {
-    ImageLoadOptions opts;
-    REQUIRE_FALSE(opts.override_alpha);
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
 
-    // Off: whatever the loader concluded stands, for every kind.
+    // No override: the effective kind is the file's, and the file's is still there to compare against.
     for (AlphaType_ at :
          {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
-        CHECK(effective_alpha_type(opts, at) == at);
+    {
+        img->set_alpha(at, AlphaSource_File, std::nullopt);
+        CHECK(img->alpha_type == at);
+        CHECK(img->alpha_type_from_file == at);
+        CHECK(img->alpha_source == AlphaSource_File);
+    }
 
-    // On: the option replaces it, including asserting alpha over a file that declared none and
-    // declaring data over a file that claimed transparency.
-    opts.override_alpha = true;
+    // Overridden: the effective kind changes, what the file said does not, and neither does how it said it.
     for (AlphaType_ forced :
          {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
-    {
-        opts.alpha_override = forced;
         for (AlphaType_ from_file :
              {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
-            CHECK(effective_alpha_type(opts, from_file) == forced);
-    }
+        {
+            img->set_alpha(from_file, AlphaSource_Assumed, forced);
+            CHECK(img->alpha_type == forced);
+            CHECK(img->alpha_type_from_file == from_file);
+            CHECK(img->alpha_source == AlphaSource_Assumed);
+        }
 }
 
 TEST_CASE("finalize() premultiplies straight alpha and leaves the other kinds alone")
@@ -245,4 +249,48 @@ TEST_CASE("A straight-alpha EXR can be read as straight, against the EXR spec")
         // finalize() now multiplies by the coverage the file's samples were never scaled by.
         CHECK(channel_value(images[0], "R") == doctest::Approx(0.5f).epsilon(0.01));
     }
+}
+
+TEST_CASE("A format that settles alpha for every conforming file says so")
+{
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 0.5f;
+    img->channels[3](0, 0) = 0.5f;
+    img->finalize();
+
+    SUBCASE("PNG is unassociated by spec, with nothing per-file to read")
+    {
+        std::ostringstream out(std::ios::binary);
+        save_png_image(*img, out, "a.png", 1.f, false, false, false, TransferFunction::sRGB);
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               images = load_image(in, "a.png", ImageLoadOptions{});
+        REQUIRE(images.size() == 1);
+        CHECK(images[0]->alpha_source == AlphaSource_Format);
+        CHECK(images[0]->alpha_type_from_file == AlphaType_Straight);
+    }
+
+    SUBCASE("EXR is associated by spec")
+    {
+        std::ostringstream out(std::ios::binary);
+        save_exr_image(*img, out, "a.exr");
+        std::istringstream in(out.str(), std::ios::binary);
+        auto               images = load_image(in, "a.exr", ImageLoadOptions{});
+        REQUIRE(images.size() == 1);
+        CHECK(images[0]->alpha_source == AlphaSource_Format);
+        CHECK(images[0]->alpha_type_from_file == AlphaType_PremultipliedLinear);
+    }
+}
+
+TEST_CASE("An image assembled in memory reports its alpha as assumed")
+{
+    // Nothing read it from anywhere -- the samples are simply already in HDRView's working form, which is
+    // what the IPC path relies on for tiles that arrive before the alpha channel they would be scaled by.
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    CHECK(img->alpha_type == AlphaType_PremultipliedLinear);
+    CHECK(img->alpha_source == AlphaSource_Assumed);
+
+    // And one with no alpha channel says None, still without claiming anyone stated it.
+    auto rgb = std::make_shared<Image>(int2{1, 1}, 3);
+    CHECK(rgb->alpha_type == AlphaType_None);
+    CHECK(rgb->alpha_source == AlphaSource_Assumed);
 }

--- a/tests/test_alpha.cpp
+++ b/tests/test_alpha.cpp
@@ -12,8 +12,13 @@
 #include "imageio/exr.h"
 #include "imageio/image_loader.h"
 #include "imageio/png.h"
+#include "imageio/qoi.h"
+#include "imageio/stb.h"
+#include "imageio/tiff.h"
 
+#include <functional>
 #include <sstream>
+#include <vector>
 
 #include <vector>
 
@@ -251,33 +256,59 @@ TEST_CASE("A straight-alpha EXR can be read as straight, against the EXR spec")
     }
 }
 
-TEST_CASE("A format that settles alpha for every conforming file says so")
+TEST_CASE("Every loader says where its alpha kind came from")
 {
+    // One property asserted of every format that can round-trip alpha, rather than of whichever one
+    // happened to break: a loader must report both what it concluded and how, and the two must agree with
+    // what the format actually settles. A loader that silently claims a file stated something is the
+    // failure this is here to catch, and it is invisible in the pixels.
+    struct Case
+    {
+        const char                                        *name;
+        std::function<void(const Image &, std::ostream &)> save;
+        AlphaSource_                                       source;
+        AlphaType_                                         from_file;
+    };
+
+    const std::vector<Case> cases = {
+        {"a.png", [](const Image &i, std::ostream &o)
+         { save_png_image(i, o, "a.png", 1.f, false, false, false, TransferFunction::sRGB); }, AlphaSource_Format,
+         AlphaType_Straight},
+        {"a.exr", [](const Image &i, std::ostream &o) { save_exr_image(i, o, "a.exr"); }, AlphaSource_Format,
+         AlphaType_PremultipliedLinear},
+        {"a.qoi", [](const Image &i, std::ostream &o) { save_qoi_image(i, o, "a.qoi", 1.f, true, false); },
+         AlphaSource_Format, AlphaType_Straight},
+        {"a.tga", [](const Image &i, std::ostream &o)
+         { save_stb_tga(i, o, "a.tga", 1.f, TransferFunction::sRGB, false); }, AlphaSource_Format, AlphaType_Straight},
+#if HDRVIEW_ENABLE_LIBTIFF
+        // The one format here that carries a per-file signal, so it is the one that may say File.
+        {"a.tif",
+         [](const Image &i, std::ostream &o) { save_tiff_image(i, o, "a.tif", 1.f, TransferFunction::sRGB, 0, 0); },
+         AlphaSource_File, AlphaType_PremultipliedNonLinear},
+#endif
+    };
+
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
-    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 0.5f;
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 0.25f;
     img->channels[3](0, 0) = 0.5f;
     img->finalize();
 
-    SUBCASE("PNG is unassociated by spec, with nothing per-file to read")
+    for (const auto &c : cases)
     {
+        CAPTURE(c.name);
         std::ostringstream out(std::ios::binary);
-        save_png_image(*img, out, "a.png", 1.f, false, false, false, TransferFunction::sRGB);
-        std::istringstream in(out.str(), std::ios::binary);
-        auto               images = load_image(in, "a.png", ImageLoadOptions{});
-        REQUIRE(images.size() == 1);
-        CHECK(images[0]->alpha_source == AlphaSource_Format);
-        CHECK(images[0]->alpha_type_from_file == AlphaType_Straight);
-    }
+        c.save(*img, out);
+        REQUIRE(out.str().size() > 8);
 
-    SUBCASE("EXR is associated by spec")
-    {
-        std::ostringstream out(std::ios::binary);
-        save_exr_image(*img, out, "a.exr");
         std::istringstream in(out.str(), std::ios::binary);
-        auto               images = load_image(in, "a.exr", ImageLoadOptions{});
+        auto               images = load_image(in, c.name, ImageLoadOptions{});
         REQUIRE(images.size() == 1);
-        CHECK(images[0]->alpha_source == AlphaSource_Format);
-        CHECK(images[0]->alpha_type_from_file == AlphaType_PremultipliedLinear);
+
+        CHECK(images[0]->alpha_source == c.source);
+        CHECK(images[0]->alpha_type_from_file == c.from_file);
+        // With nothing overridden the effective kind is the file's, and no override is recorded.
+        CHECK(images[0]->alpha_type == c.from_file);
+        CHECK_FALSE(images[0]->alpha_override.has_value());
     }
 }
 

--- a/tests/test_image_groups.cpp
+++ b/tests/test_image_groups.cpp
@@ -14,13 +14,12 @@ namespace
 {
 
 // A 1x1 RGBA image whose color channels are 1 and whose alpha is 0.5, so a premultiply is visible.
-ImagePtr make_rgba_image(AlphaType_ alpha_type, bool alpha_is_transparency = true)
+ImagePtr make_rgba_image(AlphaType_ alpha_type)
 {
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
     for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
     img->channels[3](0, 0)      = 0.5f;
     img->alpha_type             = alpha_type;
-    img->alpha_is_transparency  = alpha_is_transparency;
     img->finalize();
     return img;
 }
@@ -48,9 +47,9 @@ TEST_CASE("straight alpha is premultiplied into one RGBA group by default")
     CHECK(img->channels[0](0, 0) == doctest::Approx(0.5f));
 }
 
-TEST_CASE("alpha_is_transparency=false splits alpha off and skips the premultiply")
+TEST_CASE("AlphaType_None splits alpha off and skips the premultiply")
 {
-    auto img = make_rgba_image(AlphaType_Straight, /*alpha_is_transparency*/ false);
+    auto img = make_rgba_image(AlphaType_None);
 
     // R,G,B group next in the table, with A left over as its own single-channel group.
     REQUIRE(img->groups.size() == 2);
@@ -93,12 +92,17 @@ TEST_CASE("raw_pixel reports the file's values for a straight-alpha image")
     }
 }
 
-TEST_CASE("alpha_is_transparency=false leaves premultiplied files untouched too")
+TEST_CASE("An image whose default alpha type is left alone keeps its samples")
 {
-    auto img = make_rgba_image(AlphaType_PremultipliedLinear, /*alpha_is_transparency*/ false);
+    // The constructor's default for an image with an 'A' channel: already in HDRView's working form.
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
+    img->channels[3](0, 0) = 0.5f;
+    REQUIRE(img->alpha_type == AlphaType_PremultipliedLinear);
+    img->finalize();
 
-    REQUIRE(img->groups.size() == 2);
-    CHECK(find_group(img, "R,G,B") != nullptr);
-    CHECK(find_group(img, "A") != nullptr);
+    // Coverage, so it groups as RGBA -- but already multiplied, so finalize() does not do it again.
+    REQUIRE(img->groups.size() == 1);
+    CHECK(find_group(img, "R,G,B,A") != nullptr);
     CHECK(img->channels[0](0, 0) == doctest::Approx(1.f));
 }

--- a/tests/test_image_groups.cpp
+++ b/tests/test_image_groups.cpp
@@ -14,7 +14,7 @@ namespace
 {
 
 // A 1x1 RGBA image whose color channels are 1 and whose alpha is 0.5, so a premultiply is visible.
-ImagePtr make_rgba_image(AlphaType alpha_type, bool alpha_is_transparency)
+ImagePtr make_rgba_image(AlphaType_ alpha_type, bool alpha_is_transparency = true)
 {
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
     for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
@@ -37,7 +37,7 @@ const ChannelGroup *find_group(const ImagePtr &img, const std::string &name)
 
 TEST_CASE("straight alpha is premultiplied into one RGBA group by default")
 {
-    auto img = make_rgba_image(AlphaType_Straight, /*alpha_is_transparency*/ true);
+    auto img = make_rgba_image(AlphaType_Straight);
 
     REQUIRE(img->groups.size() == 1);
     auto *rgba = find_group(img, "R,G,B,A");
@@ -73,7 +73,7 @@ TEST_CASE("raw_pixel reports the file's values for a straight-alpha image")
 {
     SUBCASE("straight alpha is divided back out")
     {
-        auto img = make_rgba_image(AlphaType_Straight, /*alpha_is_transparency*/ true);
+        auto img = make_rgba_image(AlphaType_Straight);
 
         // Stored premultiplied as 0.5; the file held 1.0.
         CHECK(img->channels[0](0, 0) == doctest::Approx(0.5f));
@@ -85,7 +85,7 @@ TEST_CASE("raw_pixel reports the file's values for a straight-alpha image")
     SUBCASE("a premultiplied file is reported as stored")
     {
         // Its alpha=0 pixels have no straight form, so its values are what the author intended.
-        auto img = make_rgba_image(AlphaType_PremultipliedLinear, /*alpha_is_transparency*/ true);
+        auto img = make_rgba_image(AlphaType_PremultipliedLinear);
 
         auto p = img->raw_pixel(int2{0, 0});
         CHECK(p.x == doctest::Approx(1.f));

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -116,7 +116,7 @@ TEST_CASE("TIFF tagged EXTRASAMPLE_UNSPECIFIED keeps its fourth sample as data")
 
     REQUIRE(img->channels.size() == 4);
     CHECK(img->alpha_type == AlphaType_None);
-    CHECK_FALSE(img->alpha_is_transparency);
+    CHECK_FALSE(img->alpha_is_transparency());
     CHECK(img->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
     CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
 
@@ -178,7 +178,7 @@ TEST_CASE("Overriding to AlphaType_None loads a declared alpha channel as data")
     REQUIRE(images.size() == 1);
 
     CHECK(images[0]->alpha_type == AlphaType_None);
-    CHECK_FALSE(images[0]->alpha_is_transparency);
+    CHECK_FALSE(images[0]->alpha_is_transparency());
     CHECK(images[0]->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
     REQUIRE(images[0]->groups.size() == 2);
     CHECK(images[0]->groups[1].type == ChannelGroup::Single_Channel);

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -8,6 +8,7 @@
 
 #include "endian-utils.h"
 #include "image.h"
+#include "imageio/image_loader.h"
 #include "imageio/tiff.h"
 
 #include <initializer_list>
@@ -62,6 +63,20 @@ std::string tiff_with_extra_samples(uint16_t value)
     return bytes;
 }
 
+// The same fixture with pixel 1's color samples replaced. Associated alpha stores a*OETF(C), which can
+// never exceed alpha, so the unmodified fixture's opaque-white-under-half-coverage cannot describe a
+// genuinely associated file -- it is straight-alpha data, and reading it as associated says the straight
+// color was brighter than white.
+std::string tiff_with_second_pixel_color(uint16_t extra_samples, unsigned char value)
+{
+    std::string bytes = tiff_with_extra_samples(extra_samples);
+    // Pixel 1's RGB, immediately before its alpha at the end of the single strip.
+    bytes[bytes.size() - 4] = char(value);
+    bytes[bytes.size() - 3] = char(value);
+    bytes[bytes.size() - 2] = char(value);
+    return bytes;
+}
+
 ImagePtr load_tiff(const std::string &bytes)
 {
     std::istringstream in(bytes, std::ios::binary);
@@ -109,6 +124,64 @@ TEST_CASE("TIFF tagged EXTRASAMPLE_UNSPECIFIED keeps its fourth sample as data")
     REQUIRE(img->groups.size() == 2);
     CHECK(img->groups[0].type == ChannelGroup::RGB_Channels);
     CHECK(img->groups[1].type == ChannelGroup::Single_Channel);
+}
+
+TEST_CASE("TIFF associated alpha is read as multiplied into the encoded samples")
+{
+    // EXTRASAMPLE_ASSOCALPHA == 1, with pixel 1 holding 128/255 under alpha 128/255: the encoded form
+    // of a fully bright color at half coverage, which is what every writer of associated alpha produces
+    // (Photoshop, OpenImageIO, ImageMagick, vips all store a*OETF(C)).
+    auto img = load_tiff(tiff_with_second_pixel_color(1, 0x80));
+
+    REQUIRE(img->channels.size() == 4);
+    CHECK(img->alpha_type == AlphaType_PremultipliedNonLinear);
+    CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
+
+    // Dividing alpha out before the inverse transfer recovers straight 1.0, and multiplying back leaves
+    // HDRView's working form: linear 1.0 times alpha. Applying the transfer to the stored value instead
+    // would give EOTF(0.502) = 0.214, markedly darker.
+    CHECK(img->channels[0](1, 0) == doctest::Approx(k_half).epsilon(0.005));
+    CHECK(img->channels[0](1, 0) != doctest::Approx(0.214f).epsilon(0.01));
+
+    // The opaque pixel is unaffected by any of this, which is what makes it a control.
+    CHECK(img->channels[0](0, 0) == doctest::Approx(1.f).epsilon(0.001));
+}
+
+TEST_CASE("An alpha override replaces what the TIFF declared")
+{
+    // The file says associated; read it as straight instead, so finalize() multiplies rather than the
+    // loader dividing. This is the escape hatch for a file whose tag is wrong -- ImageMagick and vips
+    // both write premultiplied samples tagged unassociated.
+    ImageLoadOptions opts;
+    opts.override_alpha = true;
+    opts.alpha_override = AlphaType_Straight;
+
+    std::istringstream in(tiff_with_second_pixel_color(1, 0x80), std::ios::binary);
+    auto               images = load_image(in, "rgba.tif", opts);
+    REQUIRE(images.size() == 1);
+
+    CHECK(images[0]->alpha_type == AlphaType_Straight);
+    // Straight 128/255 linearizes to 0.216, which finalize() then multiplies by alpha.
+    CHECK(images[0]->channels[0](1, 0) == doctest::Approx(0.216f * k_half).epsilon(0.02));
+}
+
+TEST_CASE("Overriding to AlphaType_None loads a declared alpha channel as data")
+{
+    // The reverse of EXTRASAMPLE_UNSPECIFIED: the file declares real alpha and the user says it is a
+    // mask. Nothing is multiplied by it and the channel stands on its own.
+    ImageLoadOptions opts;
+    opts.override_alpha = true;
+    opts.alpha_override = AlphaType_None;
+
+    std::istringstream in(tiff_with_extra_samples(2), std::ios::binary);
+    auto               images = load_image(in, "rgba.tif", opts);
+    REQUIRE(images.size() == 1);
+
+    CHECK(images[0]->alpha_type == AlphaType_None);
+    CHECK_FALSE(images[0]->alpha_is_transparency);
+    CHECK(images[0]->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
+    REQUIRE(images[0]->groups.size() == 2);
+    CHECK(images[0]->groups[1].type == ChannelGroup::Single_Channel);
 }
 
 TEST_CASE("TIFF save/load round-trips alpha without repeated premultiplication")

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -109,6 +109,34 @@ std::vector<unsigned char> tiff_raw_samples(const std::string &bytes)
     return {bytes.begin() + offset, bytes.begin() + offset + count};
 }
 
+// The fixture with nothing left saying what its fourth sample is, which is how most RGBA TIFFs in the wild
+// look. The entry is renumbered to a private tag rather than erased: removing it would shift every
+// out-of-line value in the file without shifting the offsets that point at them. EXTRASAMPLES is the
+// highest tag here, so the IFD stays sorted.
+std::string tiff_without_extra_samples()
+{
+    std::string bytes = tiff_with_extra_samples(2);
+
+    auto read_u16 = [&](size_t o) { return uint16_t(uint8_t(bytes[o]) | (uint8_t(bytes[o + 1]) << 8)); };
+    auto read_u32 = [&](size_t o) { return uint32_t(read_u16(o)) | (uint32_t(read_u16(o + 2)) << 16); };
+
+    const uint32_t ifd     = read_u32(4);
+    const uint16_t entries = read_u16(ifd);
+    for (uint16_t i = 0; i < entries; ++i)
+    {
+        const size_t entry = ifd + 2 + size_t(i) * 12;
+        if (read_u16(entry) != k_extra_samples_tag)
+            continue;
+
+        constexpr uint16_t k_private_tag = 65000;
+        bytes[entry]                     = char(k_private_tag & 0xff);
+        bytes[entry + 1]                 = char(k_private_tag >> 8);
+        return bytes;
+    }
+    FAIL("fixture has no EXTRASAMPLES tag");
+    return bytes;
+}
+
 ImagePtr load_tiff(const std::string &bytes)
 {
     std::istringstream in(bytes, std::ios::binary);
@@ -214,6 +242,40 @@ TEST_CASE("Overriding to AlphaType_None loads a declared alpha channel as data")
     CHECK(images[0]->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
     REQUIRE(images[0]->groups.size() == 2);
     CHECK(images[0]->groups[1].type == ChannelGroup::Single_Channel);
+}
+
+TEST_CASE("A TIFF says where its alpha kind came from")
+{
+    // EXTRASAMPLES settles it, whichever value it carries -- including the one saying the sample is data.
+    for (uint16_t tag : {uint16_t(0), uint16_t(1), uint16_t(2)})
+    {
+        CAPTURE(tag);
+        auto img = load_tiff(tiff_with_extra_samples(tag));
+        CHECK(img->alpha_source == AlphaSource_File);
+    }
+
+    // With the tag gone, nothing in the file states a kind and straight is the loader's guess. This is
+    // the one case in this format where an override is answering a question rather than contradicting one.
+    auto guessed = load_tiff(tiff_without_extra_samples());
+    CHECK(guessed->alpha_source == AlphaSource_Assumed);
+    CHECK(guessed->alpha_type == AlphaType_Straight);
+}
+
+TEST_CASE("An override leaves what the file said intact")
+{
+    ImageLoadOptions opts;
+    opts.override_alpha = true;
+    opts.alpha_override = AlphaType_PremultipliedNonLinear;
+
+    std::istringstream in(tiff_with_extra_samples(2), std::ios::binary); // unassociated
+    auto               images = load_image(in, "rgba.tif", opts);
+    REQUIRE(images.size() == 1);
+
+    // What is used, what the file declared, and how it declared it -- all three still answerable, which
+    // is what lets the Info panel say the override is contradicting rather than filling a gap.
+    CHECK(images[0]->alpha_type == AlphaType_PremultipliedNonLinear);
+    CHECK(images[0]->alpha_type_from_file == AlphaType_Straight);
+    CHECK(images[0]->alpha_source == AlphaSource_File);
 }
 
 TEST_CASE("A saved TIFF multiplies alpha into its encoded samples")

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -77,6 +77,38 @@ std::string tiff_with_second_pixel_color(uint16_t extra_samples, unsigned char v
     return bytes;
 }
 
+// Reads the samples of an uncompressed, single-strip TIFF straight out of its strip, so a written file
+// can be checked against what other applications produce rather than against HDRView's own reader. A
+// save/load round trip cannot do that: writer and reader share a convention and agree either way.
+std::vector<unsigned char> tiff_raw_samples(const std::string &bytes)
+{
+    auto read_u16 = [&](size_t o) { return uint16_t(uint8_t(bytes[o]) | (uint8_t(bytes[o + 1]) << 8)); };
+    auto read_u32 = [&](size_t o) { return uint32_t(read_u16(o)) | (uint32_t(read_u16(o + 2)) << 16); };
+
+    REQUIRE(bytes.compare(0, 2, "II") == 0);
+    const uint32_t ifd     = read_u32(4);
+    const uint16_t entries = read_u16(ifd);
+
+    uint32_t offset = 0, count = 0, compression = 1;
+    for (uint16_t i = 0; i < entries; ++i)
+    {
+        const size_t   entry = ifd + 2 + size_t(i) * 12;
+        const uint16_t tag   = read_u16(entry);
+        const uint32_t value = read_u16(entry + 8); // every tag read here is a single SHORT or LONG
+        if (tag == 273)
+            offset = read_u32(entry + 8);
+        else if (tag == 279)
+            count = read_u32(entry + 8);
+        else if (tag == 259)
+            compression = value;
+    }
+
+    REQUIRE(compression == 1); // the fixtures below ask for none
+    REQUIRE(offset != 0);
+    REQUIRE(count != 0);
+    return {bytes.begin() + offset, bytes.begin() + offset + count};
+}
+
 ImagePtr load_tiff(const std::string &bytes)
 {
     std::istringstream in(bytes, std::ios::binary);
@@ -182,6 +214,40 @@ TEST_CASE("Overriding to AlphaType_None loads a declared alpha channel as data")
     CHECK(images[0]->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
     REQUIRE(images[0]->groups.size() == 2);
     CHECK(images[0]->groups[1].type == ChannelGroup::Single_Channel);
+}
+
+TEST_CASE("A saved TIFF multiplies alpha into its encoded samples")
+{
+    // The writer's half of the associated-alpha convention, checked on the bytes. HDRView holds
+    // premultiplied linear color, so a straight color of 1.0 under half coverage is stored linear as 0.5;
+    // the file has to hold alpha * OETF(1.0) = alpha, not OETF(0.5) = 0.735.
+    auto img = std::make_shared<Image>(int2{1, 1}, 4);
+    for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 0.5f; // premultiplied linear
+    img->channels[3](0, 0) = 0.5f;
+    img->finalize();
+
+    std::ostringstream out(std::ios::binary);
+    save_tiff_image(*img, out, "assoc.tif", /*gain*/ 1.f, TransferFunction::sRGB, /*compression*/ 0,
+                    /*data_type*/ 0);
+
+    auto samples = tiff_raw_samples(out.str());
+    REQUIRE(samples.size() >= 4);
+
+    const unsigned char alpha = samples[3];
+    CHECK(int(alpha) == doctest::Approx(127).epsilon(0.02)); // 0.5 quantized over 8 bits
+    // a*OETF(C) == 0.5 * 1.0
+    CHECK(int(samples[0]) == doctest::Approx(127).epsilon(0.02));
+    // Not OETF(a*C) == 0.735, which is what leaving the premultiply in place across the transfer gives.
+    CHECK(int(samples[0]) != doctest::Approx(188).epsilon(0.02));
+
+    // The invariant that identifies the convention in a real file: a stored color can never exceed its
+    // alpha, since it is that alpha times an encoded value of at most one.
+    for (int c = 0; c < 3; ++c) CHECK(samples[c] <= alpha);
+
+    // And it reads back as what it started as.
+    auto reloaded = load_tiff(out.str());
+    CHECK(reloaded->alpha_type == AlphaType_PremultipliedNonLinear);
+    CHECK(reloaded->channels[0](0, 0) == doctest::Approx(0.5f).epsilon(0.02));
 }
 
 TEST_CASE("TIFF save/load round-trips alpha without repeated premultiplication")


### PR DESCRIPTION
Multiplying by alpha and applying a transfer function do not commute, so a file whose color was
premultiplied *after* encoding cannot be linearized directly: `EOTF(a·C) ≠ a·EOTF(C)`. HDRView read
and wrote associated-alpha TIFF as `OETF(a·C_linear)` while the rest of the world writes
`a·OETF(C)`, so semi-transparent areas came out wrong against every other application's files — by
up to 3× at low coverage.

This fixes TIFF in both directions, routes every loader's alpha handling through one rule, and adds
an override for the files that contradict their own format's convention.

## Establishing which convention is right

TIFF 6.0 does not say whether associated alpha is multiplied before or after the transfer function,
and neither does MIAF or JPEG XL. So this was settled empirically rather than from specs — writing
one known image with each producer and reading the stored bytes back.

The discriminating case is full-intensity color under half coverage, where the two conventions are
far apart:

| straight input | (a) `a·OETF(C)` | (b) `OETF(a·C_lin)` |
|---|---|---|
| (255,0,0) α=32 | (32,0,0) | (99,0,0) |
| (255,255,255) α=64 | (64,64,64) | (137,137,137) |
| (255,128,0) α=128 | (128,64,0) | (188,93,0) |

Six independent producers, unanimous on **(a)**:

| producer | tags it | convention |
|---|---|---|
| **Adobe Photoshop 27.2** | `Associated Alpha` ✓ | (a), exact on all 8 swatches |
| **OpenImageIO 3.1.15** (default) | `Associated Alpha` ✓ | (a), exact |
| **ImageMagick 7.1.2** | `Unassociated` ✗ | (a), exact |
| **libvips 8.18.3** | `Unassociated` ✗ | (a), exact |
| **GraphicsMagick** | `Associated Alpha` | (a) — `grid.tif` in a local corpus |
| **Blender** | — | un-premultiplies **encoded** values on read |

OpenImageIO needs `linear_premult=1` to do otherwise, and documents why: *"Many existing PNG files
are apparently encoded with the assumption that any premultiplication will be performed directly on
the encoded values, so that is the default behavior for OpenImageIO's PNG reader and writer."*

Blender's [`readimage.cc`](https://github.com/blender/blender/blob/main/source/blender/imbuf/intern/readimage.cc)
holds a strict invariant — byte buffers straight, float buffers premultiplied — and its byte path in
[`filter.cc`](https://github.com/blender/blender/blob/main/source/blender/imbuf/intern/filter.cc)
multiplies encoded values directly, `cp[0] = (cp[0] * val) >> 8`, with no linearization.

**The dissent agrees about the files.** In [OpenImageIO #2887](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/2887)
Larry Gritz works the same example and concludes the opposite is *theoretically* correct:

> If you premultiply first, you get (0.5, 0.0, 0.0, 0.5), and then linearize … to get (0.25, 0.0,
> 0.0, 0.5), a dark red. If we linearize first, we get (1.0, 0.0, 0.0, 0.5) … This is more of a
> medium red. I believe the second choice (linearize first) must be correct … the color correction /
> linearization should happen **before** the premultiplication, otherwise things can look too dark.

Frédéric Devernay puts the principle sharply in the same thread: *"sRGB values cannot be multiplied
by anything: it is a nonlinear space where any arithmetic is forbidden."* Gritz then declined to
change OIIO's defaults, for compatibility: *"changing people's images is going to be really
inconvenient … quite often changing people's images is much more painful thing than having errors,
as long as those errors are subtle and consistent."*

So (a) is what files contain and (b) is what is arguably correct. HDRView was doing (b) — right in
principle, mismatched with every file it is handed. This adopts (a), which is what reading a file
means, and exposes (b) through the override.

## What the other formats turned out to be

Deliberately **not** changed, because no producer tested emits them:

- **HEIF/AVIF** — Photoshop writes straight; ImageMagick never sets the `prem` iref even with
  `-alpha associate`; vips never sets it; `heif-enc --premultiplied-alpha` only sets a flag and
  expects already-premultiplied input. 0 of 603 corpus files use it.
  [libheif #471](https://github.com/strukturag/libheif/issues/471) establishes only *whether*, via
  MIAF's `prem` reference, never in what space.
- **DDS** — [DirectXTex's `PremultiplyAlpha`](https://github.com/microsoft/DirectXTex/wiki/PremultiplyAlpha)
  picks the space from `TEX_PMALPHA_SRGB_IN/_OUT`, and `GetSRGBFlags()` only masks what the caller
  passed — never derived from the DXGI format. So a `.dds` records the convention nowhere.
- **JPEG XL** — the reader already did the right thing; only its tag was wrong. libjxl's
  `alpha_premultiplied` says whether, not in what space, and `JxlDecoderSetUnpremultiplyAlpha()` is
  a **no-op** for the main alpha channel in 0.11.2 (verified by encoding a premultiplied file and
  decoding it both ways), which is why the loader must undo it itself.
  [libjxl #1869](https://github.com/libjxl/libjxl/issues/1869), which reports premultiplied encoding
  as unsupported, was closed in 2022 — such files are producible.
- **EXR** — linear, so both conventions coincide. Already correct.

## The override

Formats disagree with their own files often enough to matter: **two of six** TIFF producers above
write premultiplied samples tagged `Unassociated`. And the spec-mandated cases get violated in both
directions — an associated-alpha PNG (which HDRView would premultiply a second time), a
straight-alpha EXR (which it would never multiply at all).

So `ImageLoadOptions` gains `override_alpha` / `alpha_override`, honored by **every** loader, shaped
like the existing `override_profile` / `gamut_override`. `AlphaType_None` reads a fourth channel as
data, which is what the old `alpha_is_transparency` load option said, so that option folds into this
one.

## Provenance

The panel now says *how* an interpretation was arrived at, because the three ways call for different
responses: `AlphaSource_{File, Format, Assumed}` — this file said so; the format settles it for
every conforming file; or nothing said and the loader guessed. Only the last is a guess, and it is
where the override is worth reaching for. Two loaders reach it: a TIFF with four samples and no
`EXTRASAMPLES`, and a DX9 DDS outside the DXT2/DXT4 spellings.

Deliberately provenance and not a confidence ranking — an explicit tag is *not* the most trustworthy
of the three, per the ImageMagick and vips mislabeling above.

An override no longer hides what it replaced, so the panel distinguishes contradicting a stated kind
from filling in one nothing stated.

## Also here

`alpha_type` previously defaulted to `AlphaType_None` purely because it is the enum's zero value —
neither constructor set it — so a four-channel image claimed to have no alpha, survivable only
because a second field grouped the channel as RGBA anyway. Setting the default from the channel
names says what such an image holds: samples already in HDRView's working representation. That
lets `alpha_is_transparency` collapse into a question asked of `alpha_type`, and leaves
`AlphaType_None` meaning one thing.

Unrelated, and separable: a HEIF EXIF item opens with a four-byte offset to the TIFF header, and the
loader skipped a fixed four bytes. 125 of 198 corpus files with EXIF set that offset to 6 and put an
`Exif\0\0` marker in the gap, which parsed only because libexif recognizes that marker and skips it
itself. **No output changes** — this stops depending on a tolerance never asked for.

## Testing

`hdrview_tests` gains 21 cases (329 total, all passing).

The writer is checked **against the bytes, not against ourselves**: a save/load round trip agrees
with itself whichever convention both halves use, which is the exact reason this had to be settled
from other applications' files. `tiff_raw_samples()` walks the IFD and reads the strip, asserting
`a·OETF(C)` ≈ 127 rather than `OETF(a·C)` ≈ 188 — plus the invariant that identifies the convention
in a real file: **a stored color can never exceed its alpha**. That check is what exposed
`libtiffpic/strike.tif` as straight-alpha data mislabeled `ASSOCALPHA` — 43% of its partial-alpha
pixels have a color sample above their alpha, up to 255×.

The override is exercised end to end on both spec-violation cases, and a sweep asserts every
alpha-capable format reports what it concluded and how.

Every test was mutation-checked — eleven mutations, all caught. Worth noting the asymmetry:
mutating a *kind* fails 14 assertions across 4 cases because premultiplication depends on it;
mutating a *source* fails 1, because it is display-only and carries one bit per loader. The sweep's
value is breadth — QOI's and TGA's classification were previously asserted nowhere.

## Sources

- [OpenImageIO #2887](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/2887) — Gritz and Devernay on which order is correct, and why OIIO kept the other one
- [OpenImageIO plugin docs](https://openimageio.readthedocs.io/en/latest/builtinplugins.html) — `linear_premult`, default 0
- [libheif #471](https://github.com/strukturag/libheif/issues/471) — MIAF `prem`, and that absence is unambiguous
- [libjxl #1869](https://github.com/libjxl/libjxl/issues/1869) — closed 2022; premultiplied encoding is supported
- [DirectXTex `PremultiplyAlpha`](https://github.com/microsoft/DirectXTex/wiki/PremultiplyAlpha) — `TEX_PMALPHA_SRGB_IN/_OUT`
- [Blender `readimage.cc`](https://github.com/blender/blender/blob/main/source/blender/imbuf/intern/readimage.cc), [`filter.cc`](https://github.com/blender/blender/blob/main/source/blender/imbuf/intern/filter.cc) — byte buffers straight, float buffers premultiplied
- [Gamma Correction vs. Premultiplied Pixels](https://ssp.impulsetrain.com/gamma-premult.html), [sRGB, Pre-Multiplied Alpha, and Compression](http://hacksoflife.blogspot.com/2022/06/srgb-pre-multiplied-alpha-and.html)

## Notes for review

- **Photoshop's associated-alpha TIFF is the reference file.** Its samples match `a·OETF(C)` exactly
  on all eight discriminating swatches, and it is the only tested producer that both premultiplies
  correctly *and* tags it correctly.
- **HDRView's own older TIFFs will read differently.** Reader and writer moved together, so it still
  round-trips itself; only files it wrote before this shift, and the override recovers them.
- **The `Assumed` guess is unchanged, only labeled.** An unlabeled four-sample TIFF is still read as
  straight — the likelier reading — but now says so.
- **JPEG XL's kind is inference, not evidence.** By analogy with TIFF, where it is proven. If a
  premultiplied JXL ever reads wrong, the override is the answer and the comment says where the
  assumption came from.