### PR TITLE
Make EditContext a struct, and the chokepoints free functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,15 +160,15 @@ Addressing quirks worth knowing before writing new tests here:
   should look it up by filename after loading (see `find_image_index_containing()` in
   `tests/gui/test_gui_filtering.cpp`).
 - A test's body runs on the Test Engine's own coroutine thread, and the GL context is current on the main
-  thread only, so **any GL call made directly from a test is a no-op**. Calling `modify_structure()` (or
-  anything else that rebuilds textures) straight from a test therefore builds them with no context:
-  `glGenTextures` quietly yields a handle of 0, the channel is marked clean anyway, and the *next* edit
-  throws `Texture::upload_sub_region(): not implemented for render targets!` — or, more often, nothing
-  visibly fails and the shader merely logs `unbound argument "primary_0_texture..."` for a few frames.
-  Driving the same edit through `MenuClick()` is safe, because the action then runs inside the main
-  thread's frame, which is also how the application reaches it. Prefer the menu for anything that changes
-  an image's shape; calling the chokepoints directly is fine for edits that only write samples into
-  textures that already exist.
+  thread only, so **any GL call made directly from a test is a no-op**. Calling `modify_image()` with a
+  structural extent (or anything else that rebuilds textures) straight from a test therefore builds them
+  with no context: `glGenTextures` quietly yields a handle of 0, the channel is marked clean anyway, and
+  the *next* edit throws `Texture::upload_sub_region(): not implemented for render targets!` — or, more
+  often, nothing visibly fails and the shader merely logs `unbound argument "primary_0_texture..."` for a
+  few frames. Driving the same edit through `MenuClick()` is safe, because the action then runs inside the
+  main thread's frame, which is also how the application reaches it. Prefer the menu for anything that
+  changes an image's shape; calling the edit functions directly is fine for edits that only write pixels
+  into textures that already exist.
 
 Like `hdrview_tests`' EXR/PNG doctests, `tests/gui/test_gui_multipart.cpp` builds real assertions against a
 vendored multi-part OpenEXR fixture (`HDRVIEW_TEST_OPENEXR_DIR`, only set on `-cpm`/`-universal` presets) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,9 @@ constantly, and a slow one stops being run.
   assertions fail: one out of forty thousand means the test barely detects it and wants broadening. This has
   caught tests that could never have failed, such as a symmetric input that agreed with an asymmetric bug.
 - **Prefer the cheapest level that can see the failure.** Logic in `hdrview_tests` runs in milliseconds; a
-  GUI test spins a real window and frame loop. Edit commands are written against `EditContext`
-  (`src/edit/command.h`) so their logic can be driven from a test implementation of it without a GUI; see
+  GUI test spins a real window and frame loop. Edit commands are written against the plain `EditContext`
+  struct (`src/edit/command.h`) and apply through the free functions in `src/edit/edit_ops.h`, so a test
+  fills in the same struct the app does and drives the same code without a GUI; see
   `tests/test_edit_commands.cpp`. Reserve `hdrview_gui_tests` for what only the GUI can show: menus and
   shortcuts, dialog wiring, progress and cancellation, undo through the app.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1741,6 +1741,7 @@ set(HDRVIEW_SOURCES
     src/edit/envmap.cpp
     src/edit/poisson.cpp
     src/edit/filters.cpp
+    src/edit/edit_ops.cpp
     src/edit/undo.cpp
     src/dithermatrix256.cpp
     src/platform_utils.cpp

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -99,8 +99,8 @@ EditContext HDRViewApp::edit_context(ImagePtr img)
     const EditSubject subject       = ctx.subject;
     ctx.modify_channels_async       = [this, subject_image, subject](const string &name, const ChannelFilter &filter)
     { modify_channels_async(subject_image, name, subject, filter); };
-    ctx.modify_image_async = [this, subject_image](const string &name, int2 size, const ImageFilter &op)
-    { modify_image_async(subject_image, name, size, op); };
+    ctx.resample_image_async = [this, subject_image](const string &name, int2 size, const ChannelResampler &op)
+    { resample_image_async(subject_image, name, size, op); };
 
     return ctx;
 }
@@ -112,15 +112,14 @@ void HDRViewApp::apply_edit_command(EditCommand &cmd)
     const Box2i roi = m_roi;
     for (const auto &img : edit_command_images(cmd))
     {
-        m_roi    = roi;
-        auto ctx = edit_context(img);
-        cmd.apply(ctx);
+        m_roi = roi;
+        cmd.apply(edit_context(img));
     }
 }
 
 void HDRViewApp::invoke_edit_command(EditCommand &cmd)
 {
-    if (cmd.has_dialog())
+    if (cmd.info().has_dialog)
     {
         dialog(cmd.info().names.front()).open = true;
         return;
@@ -131,10 +130,9 @@ void HDRViewApp::invoke_edit_command(EditCommand &cmd)
 
 bool HDRViewApp::edit_command_enabled(const EditCommand &cmd)
 {
-    auto ctx = edit_context();
-    if (cmd.info().needs_editable && !can_edit(ctx.image))
+    if (cmd.info().needs_editable && !can_edit(target_image()))
         return false;
-    return cmd.enabled(ctx);
+    return cmd.enabled(edit_context());
 }
 
 void HDRViewApp::draw_edit_command_dialog(EditCommand &cmd, bool &open)
@@ -158,7 +156,7 @@ void HDRViewApp::draw_edit_command_dialog(EditCommand &cmd, bool &open)
             draw_edit_subject_selector();
 
         // applied on confirm, not as the controls move: an edit per frame of a drag would fill the
-        // history and rewrite every sample it covers
+        // history and rewrite every pixel it covers
         const auto result = ImGui::DialogButtons(info.confirm.c_str());
         if (result == ImGui::DialogResult::Confirm)
         {
@@ -348,14 +346,14 @@ void HDRViewApp::modify_channels_async(const ImagePtr &img, const string &name, 
     start_filter(std::move(running));
 }
 
-void HDRViewApp::modify_image_async(const ImagePtr &img, const string &name, int2 size, const ImageFilter &op)
+void HDRViewApp::resample_image_async(const ImagePtr &img, const string &name, int2 size, const ChannelResampler &op)
 {
     if (!can_edit(img) || size.x <= 0 || size.y <= 0)
         return;
 
     if (m_running_filter)
     {
-        m_filter_queue.push_back([this, img, name, size, op] { modify_image_async(img, name, size, op); });
+        m_filter_queue.push_back([this, img, name, size, op] { resample_image_async(img, name, size, op); });
         return;
     }
 
@@ -373,7 +371,7 @@ void HDRViewApp::modify_image_async(const ImagePtr &img, const string &name, int
 
 void HDRViewApp::start_filter(std::unique_ptr<RunningFilter> running)
 {
-    // the statistics tasks read the very samples the filter is about to
+    // the statistics tasks read the very pixels the filter is about to
     for (auto &c : running->image->channels) c.cancel_stats();
 
     running->results.resize(running->channels.size());

--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -21,110 +21,13 @@
 using std::function;
 using std::string;
 
-bool HDRViewApp::can_edit(const ConstImagePtr &img) { return img && !img->is_live; }
-
-namespace
-{
-
-/// HDRViewApp seen through the narrow opening edit commands are written against; see edit/command.h.
-/**
-    Cheap enough to build on the stack wherever one is needed. Every method supplies the current image and
-    subject, so a command names only what it is doing.
-*/
-struct AppEditContext final : EditContext
-{
-    HDRViewApp *app;
-
-    /// The image this run of the command is against; see HDRViewApp::apply_edit_command().
-    /**
-        The current one, unless the command is fanning out over the selection.
-    */
-    ImagePtr img;
-
-    explicit AppEditContext(HDRViewApp *a) : app(a), img(a->target_image()) {}
-    AppEditContext(HDRViewApp *a, ImagePtr i) : app(a), img(std::move(i)) {}
-
-    ImagePtr           image() const override { return img; }
-    const EditSubject &subject() const override { return app->edit_subject(); }
-
-    std::vector<int> target_groups() const override { return app->target_groups(img); }
-    Box2i            selection() const override { return app->roi(); }
-    void             set_selection(const Box2i &box) override { app->set_selection(box); }
-    float4           background_color() const override { return app->background_color(); }
-    ConstImagePtr    clipboard() const override { return app->clipboard(); }
-    void             set_clipboard(ImagePtr img) override { app->set_clipboard(std::move(img)); }
-
-    bool modify_pixels(const string &name, const function<float(float, int2, int)> &op) override
-    {
-        return app->modify_pixels(img, name, app->edit_subject(), op);
-    }
-    bool modify_colors(const string &name, const function<float4(const float4 &, int2)> &op,
-                       const function<void(Image &)> &retag) override
-    {
-        return app->modify_colors(img, name, app->edit_subject(), op, retag);
-    }
-    bool modify_neighborhood(const string &name, const function<float4(const function<float4(int2)> &, int2)> &op,
-                             int border_x, int border_y) override
-    {
-        return app->modify_neighborhood(img, name, app->edit_subject(), op, border_x, border_y);
-    }
-    bool modify_channels(const string &name, const function<Array2Df(const Array2Df &, const Box2i &)> &filter) override
-    {
-        return app->modify_channels(img, name, app->edit_subject(), filter);
-    }
-    void modify_channels_async(
-        const string &name, const function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &f) override
-    {
-        app->modify_channels_async(img, name, app->edit_subject(), f);
-    }
-    void modify_image_async(const string &name, int2 size,
-                            const function<Array2Df(const Array2Df &, AtomicProgress)> &op) override
-    {
-        app->modify_image_async(img, name, size, op);
-    }
-    bool modify_structure(const string &name, const function<void(Image &)> &op) override
-    {
-        return app->modify_structure(img, name, op);
-    }
-    bool modify_reversibly(const string &name, const function<void(Image &)> &forward,
-                           const function<void(Image &)> &backward) override
-    {
-        return app->modify_image_reversibly(img, name, forward, backward);
-    }
-
-    void add_image(ImagePtr img, const std::string &partname) override { app->add_image_beside_current(img, partname); }
-
-    void draw_subject_selector() override { app->draw_edit_subject_selector(); }
-};
-
-} // namespace
-
 ImagePtr HDRViewApp::target_image() { return m_target_image_override ? m_target_image_override : current_image(); }
 
 std::vector<int> HDRViewApp::target_groups(const ConstImagePtr &img) const
 {
     // the override names a group of one image, and every image numbers its own groups, so it says
     // nothing about the others a fan-out reaches
-    return target_groups(img, img == m_target_image_override ? m_target_group_override : -1);
-}
-
-std::vector<int> HDRViewApp::target_groups(const ConstImagePtr &img, int pointed_at) const
-{
-    if (!img)
-        return {};
-
-    // a group pointed at from the Images panel names itself alone, unless it is one of the selected
-    // ones, in which case the right-click covers the selection, the same way a click inside one does
-    if (pointed_at >= 0 && !img->is_group_selected(pointed_at))
-        return {pointed_at};
-
-    // the fallback is for an image the panel has never had a say over: one a command just produced, or
-    // a test driving a command directly
-    std::vector<int> groups = img->selected_groups();
-    if (groups.empty() && img->is_valid_group(img->active_group_index(Target_Primary)))
-        groups.push_back(img->active_group_index(Target_Primary));
-
-    return groups;
+    return ::target_groups(img, img == m_target_image_override ? m_target_group_override : -1);
 }
 
 void HDRViewApp::with_target_group(int image_index, int group, const std::function<void()> &body)
@@ -166,6 +69,42 @@ std::vector<ImagePtr> HDRViewApp::edit_command_images(const EditCommand &cmd)
     return selected_images();
 }
 
+EditContext HDRViewApp::edit_context(ImagePtr img)
+{
+    if (!img)
+        img = target_image();
+
+    EditContext ctx;
+    ctx.target_groups = target_groups(img);
+    ctx.image         = std::move(img);
+    ctx.subject       = m_edit_subject;
+    ctx.roi           = m_roi;
+    ctx.background    = m_bg_color;
+    ctx.clipboard     = &m_clipboard;
+
+    ctx.add_image             = [this](ImagePtr i, string partname) { add_image_beside_current(i, partname); };
+    ctx.set_selection         = [this](const Box2i &box) { set_selection(box); };
+    ctx.draw_subject_selector = [this] { draw_edit_subject_selector(); };
+    ctx.edited                = [this](EditExtent extent)
+    {
+        // recomputes each group's visibility and the layer tree's counts, then rebinds the textures
+        update_visibility();
+
+        // the view was framing an image of a different size
+        if (extent == Extent_Structure)
+            fit_display_window();
+    };
+
+    const ImagePtr    subject_image = ctx.image;
+    const EditSubject subject       = ctx.subject;
+    ctx.modify_channels_async       = [this, subject_image, subject](const string &name, const ChannelFilter &filter)
+    { modify_channels_async(subject_image, name, subject, filter); };
+    ctx.modify_image_async = [this, subject_image](const string &name, int2 size, const ImageFilter &op)
+    { modify_image_async(subject_image, name, size, op); };
+
+    return ctx;
+}
+
 void HDRViewApp::apply_edit_command(EditCommand &cmd)
 {
     // one context and one apply() per image, so each lands as its own undo entry. Each starts from the
@@ -173,8 +112,8 @@ void HDRViewApp::apply_edit_command(EditCommand &cmd)
     const Box2i roi = m_roi;
     for (const auto &img : edit_command_images(cmd))
     {
-        m_roi = roi;
-        AppEditContext ctx{this, img};
+        m_roi    = roi;
+        auto ctx = edit_context(img);
         cmd.apply(ctx);
     }
 }
@@ -192,16 +131,16 @@ void HDRViewApp::invoke_edit_command(EditCommand &cmd)
 
 bool HDRViewApp::edit_command_enabled(const EditCommand &cmd)
 {
-    AppEditContext ctx{this};
-    if (cmd.info().needs_editable && !can_edit(target_image()))
+    auto ctx = edit_context();
+    if (cmd.info().needs_editable && !can_edit(ctx.image))
         return false;
     return cmd.enabled(ctx);
 }
 
 void HDRViewApp::draw_edit_command_dialog(EditCommand &cmd, bool &open)
 {
-    const auto     info = cmd.info();
-    AppEditContext ctx{this};
+    const auto &info = cmd.info();
+    auto        ctx  = edit_context();
 
     // before BeginModalDialog(), which consumes `open`: this is the frame the dialog was asked for
     if (open)
@@ -242,310 +181,9 @@ void HDRViewApp::after_modify(const ImagePtr &img)
 {
     ++img->content_version; // invalidates the cached statistics and histograms
 
-    // not finalize(): that would premultiply a straight-alpha image a second time. An edit that changes
-    // the channel set rebuilds the layer tree itself; see modify_structure().
+    // not finalize(): that would premultiply a straight-alpha image a second time. A structural entry has
+    // rebuilt the layer tree itself by the time this runs.
     update_visibility();
-}
-
-bool HDRViewApp::modify_image(const ImagePtr &img, const string &name, const function<void(Image &)> &op,
-                              const function<UndoPtr(const Image &)> &make_undo)
-{
-    if (!can_edit(img))
-    {
-        spdlog::warn("Cannot edit '{}': its pixels come from a running process.", img ? img->filename : "");
-        return false;
-    }
-
-    spdlog::debug("Editing '{}': {}", img->filename, name);
-
-    // a statistics task reads these samples from a worker thread, so it has to be off them before the
-    // write, and before the undo entry reads them
-    for (auto &c : img->channels) c.cancel_stats();
-
-    // built first: an entry that stores pixels has to see them as they were
-    auto entry = make_undo(*img);
-
-    op(*img);
-
-    if (entry)
-        img->history.add(std::move(entry));
-
-    after_modify(img);
-    return true;
-}
-
-bool HDRViewApp::modify_image_reversibly(const ImagePtr &img, const string &name,
-                                         const function<void(Image &)> &forward,
-                                         const function<void(Image &)> &backward)
-{
-    return modify_image(img, name, forward,
-                        [&name, forward, backward](const Image &) -> UndoPtr
-                        {
-                            // nothing to remember but the two functions
-                            return std::make_unique<LambdaUndo>(name, backward, forward);
-                        });
-}
-
-bool HDRViewApp::modify_channels(const ImagePtr &img, const string &name, const EditSubject &subject,
-                                 const function<Array2Df(const Array2Df &, const Box2i &)> &filter)
-{
-    if (!can_edit(img))
-        return false;
-
-    auto [channels, bounds] = resolve_subject(img, subject);
-    if (channels.empty() || !bounds.has_volume())
-        return false;
-
-    return modify_image(
-        img, name,
-        [&channels, &bounds, &filter](Image &image)
-        {
-            const int2 offset = bounds.min - image.data_window.min;
-            const int2 extent = bounds.size();
-
-            for (int c : channels)
-            {
-                Channel &channel = image.channels[size_t(c)];
-
-                // the filter sees the whole channel but produces only this rectangle, so a selection
-                // costs the selection and not the image
-                const Box2i    local    = Box2i{offset, offset + extent};
-                const Array2Df filtered = filter(channel, local);
-
-                channel.upload_tile(local, filtered.data());
-            }
-        },
-        [&channels, &bounds, &name](const Image &image) -> UndoPtr
-        { return std::make_unique<ChannelRectUndo>(image, channels, bounds, name); });
-}
-
-/// The groups \p subject's scope names, before any filtering by what they contain.
-static std::vector<int> subject_groups(const Image &img, const EditSubject &subject)
-{
-    std::vector<int> groups;
-    if (subject.scope == EditSubject::Scope_AllChannels)
-    {
-        for (int g = 0; g < int(img.groups.size()); ++g) groups.push_back(g);
-    }
-    else if (subject.scope == EditSubject::Scope_SelectedGroups)
-        groups = img.selected_groups();
-    else if (int g = img.active_group_index(Target_Primary); img.is_valid_group(g))
-        groups.push_back(g);
-
-    return groups;
-}
-
-std::vector<int> subject_channels(const Image &img, const EditSubject &subject)
-{
-    // every channel, not the union of every group's, so one belonging to no group is still covered
-    if (subject.scope == EditSubject::Scope_AllChannels)
-    {
-        std::vector<int> channels(img.channels.size());
-        std::iota(channels.begin(), channels.end(), 0);
-        return channels;
-    }
-
-    std::vector<int> channels;
-    for (int g : subject_groups(img, subject))
-    {
-        const auto &group = img.groups[size_t(g)];
-        for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
-    }
-    return channels;
-}
-
-std::pair<std::vector<int>, std::vector<int>> subject_color_groups(const Image &img, const EditSubject &subject)
-{
-    std::vector<int> groups = subject_groups(img, subject);
-
-    groups.erase(std::remove_if(groups.begin(), groups.end(),
-                                [&img](int g)
-                                {
-                                    const auto t = img.groups[size_t(g)].type;
-                                    return t != ChannelGroup::RGB_Channels && t != ChannelGroup::RGBA_Channels;
-                                }),
-                 groups.end());
-
-    // every channel of every covered group, which is the set an undo entry has to hold
-    std::vector<int> channels;
-    for (int g : groups)
-    {
-        const auto &group = img.groups[size_t(g)];
-        for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
-    }
-
-    return {groups, channels};
-}
-
-bool HDRViewApp::modify_colors(const ImagePtr &img, const string &name, const EditSubject &subject,
-                               const function<float4(const float4 &, int2)> &op, const function<void(Image &)> &retag)
-{
-    if (!can_edit(img))
-        return false;
-
-    auto [groups, channels] = subject_color_groups(*img, subject);
-    if (groups.empty())
-    {
-        // e.g. an ungrouped image or a depth pass: nothing here is color
-        spdlog::warn("'{}' covers no color channel group of '{}'.", name, img->file_and_partname());
-        return false;
-    }
-
-    Box2i bounds = img->data_window;
-    if (subject.selection_only && m_roi.has_volume())
-        bounds.intersect(m_roi);
-    if (!bounds.has_volume())
-        return false;
-
-    return modify_image(
-        img, name,
-        [&groups, &bounds, &op, &retag](Image &image)
-        {
-            const int2 offset = bounds.min - image.data_window.min;
-            const int2 extent = bounds.size();
-
-            for (int g : groups)
-            {
-                const auto &group = image.groups[size_t(g)];
-                const int   n     = group.num_channels;
-
-                // the op sees the components together, so all of them are staged before any is written
-                std::array<Array2Df, 4> staging;
-                for (int c = 0; c < n; ++c) staging[size_t(c)] = Array2Df{extent};
-
-                const int block_size = std::max(1, 1024 * 1024 / std::max(1, extent.x));
-                stp::parallel_for(stp::blocked_range<int>(0, extent.y, block_size),
-                                  [&](int y0, int y1, int, int)
-                                  {
-                                      for (int y = y0; y < y1; ++y)
-                                          for (int x = 0; x < extent.x; ++x)
-                                          {
-                                              // opaque where the group has no alpha, so an op may read the
-                                              // fourth component whatever kind of group it was handed
-                                              float4 c{0.f, 0.f, 0.f, 1.f};
-                                              for (int k = 0; k < n; ++k)
-                                                  c[k] = image.channels[size_t(group.channels[k])](offset.x + x,
-                                                                                                   offset.y + y);
-
-                                              const float4 out = op(c, int2{bounds.min.x + x, bounds.min.y + y});
-
-                                              for (int k = 0; k < n; ++k) staging[size_t(k)](x, y) = out[k];
-                                          }
-                                  });
-
-                for (int c = 0; c < n; ++c)
-                    image.channels[size_t(group.channels[c])].upload_tile(Box2i{offset, offset + extent},
-                                                                          staging[size_t(c)].data());
-            }
-
-            if (retag)
-                retag(image);
-        },
-        [&channels, &bounds, &name, &retag](const Image &image) -> UndoPtr
-        {
-            auto pixels = std::make_unique<ChannelRectUndo>(image, channels, bounds, name);
-            if (!retag)
-                return pixels;
-
-            // the samples and what they mean changed together, so they are taken back together
-            std::vector<UndoPtr> both;
-            both.push_back(std::move(pixels));
-            both.push_back(std::make_unique<ColorMetadataUndo>(image, name));
-            return std::make_unique<CompositeUndo>(name, std::move(both));
-        });
-}
-
-bool HDRViewApp::modify_neighborhood(const ImagePtr &img, const string &name, const EditSubject &subject,
-                                     const function<float4(const function<float4(int2)> &, int2)> &op, int border_x,
-                                     int border_y)
-{
-    if (!can_edit(img))
-        return false;
-
-    auto [groups, channels] = subject_color_groups(*img, subject);
-    if (groups.empty())
-    {
-        spdlog::warn("'{}' covers no color channel group of '{}'.", name, img->file_and_partname());
-        return false;
-    }
-
-    Box2i bounds = img->data_window;
-    if (subject.selection_only && m_roi.has_volume())
-        bounds.intersect(m_roi);
-    if (!bounds.has_volume())
-        return false;
-
-    return modify_image(
-        img, name,
-        [&groups, &bounds, &op, border_x, border_y](Image &image)
-        {
-            const int2 offset = bounds.min - image.data_window.min;
-            const int2 extent = bounds.size();
-
-            for (int g : groups)
-            {
-                const auto &group = image.groups[size_t(g)];
-                const int   n     = group.num_channels;
-
-                // the whole group is staged before any of it is written, so an op reading its neighbors
-                // never finds one this pass has already replaced
-                std::array<Array2Df, 4> staging;
-                for (int c = 0; c < n; ++c) staging[size_t(c)] = Array2Df{extent};
-
-                // reads anywhere in the channel, not merely the selection; only past the image itself
-                // does the border mode decide what is there
-                auto read = [&image, &group, n, border_x, border_y](int2 p)
-                {
-                    const Channel &first = image.channels[size_t(group.channels[0])];
-                    const int      x     = wrap_coord(p.x - image.data_window.min.x, first.size().x, border_x);
-                    const int      y     = wrap_coord(p.y - image.data_window.min.y, first.size().y, border_y);
-
-                    // opaque where the group has no alpha; where the border mode says there is nothing,
-                    // transparent black
-                    if (x < 0 || y < 0)
-                        return float4{0.f, 0.f, 0.f, n >= 4 ? 0.f : 1.f};
-
-                    float4 c{0.f, 0.f, 0.f, 1.f};
-                    for (int k = 0; k < n; ++k) c[k] = image.channels[size_t(group.channels[k])](x, y);
-                    return c;
-                };
-
-                const int block_size = std::max(1, 1024 * 1024 / std::max(1, extent.x));
-                stp::parallel_for(stp::blocked_range<int>(0, extent.y, block_size),
-                                  [&](int y0, int y1, int, int)
-                                  {
-                                      for (int y = y0; y < y1; ++y)
-                                          for (int x = 0; x < extent.x; ++x)
-                                          {
-                                              const float4 out = op(read, int2{bounds.min.x + x, bounds.min.y + y});
-                                              for (int k = 0; k < n; ++k) staging[size_t(k)](x, y) = out[k];
-                                          }
-                                  });
-
-                for (int c = 0; c < n; ++c)
-                    image.channels[size_t(group.channels[c])].upload_tile(Box2i{offset, offset + extent},
-                                                                          staging[size_t(c)].data());
-            }
-        },
-        [&channels, &bounds, &name](const Image &image) -> UndoPtr
-        { return std::make_unique<ChannelRectUndo>(image, channels, bounds, name); });
-}
-
-bool HDRViewApp::modify_structure(const ImagePtr &img, const string &name, const function<void(Image &)> &op)
-{
-    const bool applied = modify_image(img, name, op, [&name](const Image &image) -> UndoPtr
-                                      { return std::make_unique<StructureUndo>(image, name); });
-    if (!applied)
-        return false;
-
-    // the channel list changed wholesale, so the layers and groups built from its names are rebuilt
-    img->rebuild_layers();
-    update_visibility();
-
-    // the view was framing an image of a different size
-    fit_display_window();
-
-    return true;
 }
 
 bool HDRViewApp::step_selected_histories(bool forward)
@@ -616,62 +254,6 @@ bool HDRViewApp::scope_matters(const ConstImagePtr &img)
     return img && img->groups.size() > 1;
 }
 
-std::pair<std::vector<int>, Box2i> HDRViewApp::resolve_subject(const ConstImagePtr &img,
-                                                               const EditSubject   &subject) const
-{
-    if (!img)
-        return {std::vector<int>{}, Box2i{}};
-
-    std::vector<int> channels = subject_channels(*img, subject);
-
-    Box2i bounds = img->data_window;
-    // an empty selection means "no selection", not "select nothing"
-    if (subject.selection_only && m_roi.has_volume())
-        bounds.intersect(m_roi);
-
-    return {channels, bounds};
-}
-
-bool HDRViewApp::modify_pixels(const ImagePtr &img, const string &name, const EditSubject &subject,
-                               const function<float(float, int2, int)> &op)
-{
-    if (!can_edit(img))
-        return false;
-
-    auto [channels, bounds] = resolve_subject(img, subject);
-    if (channels.empty() || !bounds.has_volume())
-        return false;
-
-    return modify_image(
-        img, name,
-        [&channels, &bounds, &op](Image &image)
-        {
-            const int2 offset = bounds.min - image.data_window.min;
-            const int2 extent = bounds.size();
-
-            for (size_t slot = 0; slot < channels.size(); ++slot)
-            {
-                Channel &channel = image.channels[size_t(channels[slot])];
-
-                // upload_tile() writes the samples and pushes just this rectangle to the GPU
-                Array2Df  staging{extent};
-                const int block_size = std::max(1, 1024 * 1024 / std::max(1, extent.x));
-                stp::parallel_for(stp::blocked_range<int>(0, extent.y, block_size),
-                                  [&](int y0, int y1, int, int)
-                                  {
-                                      for (int y = y0; y < y1; ++y)
-                                          for (int x = 0; x < extent.x; ++x)
-                                              staging(x, y) = op(channel(offset.x + x, offset.y + y),
-                                                                 int2{bounds.min.x + x, bounds.min.y + y}, int(slot));
-                                  });
-
-                channel.upload_tile(Box2i{offset, offset + extent}, staging.data());
-            }
-        },
-        [&channels, &bounds, &name](const Image &image) -> UndoPtr
-        { return std::make_unique<ChannelRectUndo>(image, channels, bounds, name); });
-}
-
 bool HDRViewApp::any_image_modified() const
 {
     for (const auto &img : m_images)
@@ -733,9 +315,8 @@ void HDRViewApp::draw_edit_subject_selector()
         ImGui::Tooltip("There is no selection, so edits cover the whole image.");
 }
 
-void HDRViewApp::modify_channels_async(
-    const ImagePtr &img, const string &name, const EditSubject &subject,
-    const function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &filter)
+void HDRViewApp::modify_channels_async(const ImagePtr &img, const string &name, const EditSubject &subject,
+                                       const ChannelFilter &filter)
 {
     if (!can_edit(img))
         return;
@@ -747,7 +328,7 @@ void HDRViewApp::modify_channels_async(
         return;
     }
 
-    auto [channels, bounds] = resolve_subject(img, subject);
+    auto [channels, bounds] = resolve_subject(img, subject, m_roi);
     if (channels.empty() || !bounds.has_volume())
         return;
 
@@ -756,27 +337,60 @@ void HDRViewApp::modify_channels_async(
     running->name     = name;
     running->channels = channels;
     running->bounds   = bounds;
-    running->results.resize(channels.size());
 
+    // the filter sees the whole channel but produces only this rectangle, so a selection costs the
+    // selection and not the image
+    const int2  offset = bounds.min - img->data_window.min;
+    const Box2i local{offset, offset + bounds.size()};
+    running->filter = [filter, local](const Array2Df &channel, int slot, AtomicProgress p)
+    { return filter(channel, local, slot, p); };
+
+    start_filter(std::move(running));
+}
+
+void HDRViewApp::modify_image_async(const ImagePtr &img, const string &name, int2 size, const ImageFilter &op)
+{
+    if (!can_edit(img) || size.x <= 0 || size.y <= 0)
+        return;
+
+    if (m_running_filter)
+    {
+        m_filter_queue.push_back([this, img, name, size, op] { modify_image_async(img, name, size, op); });
+        return;
+    }
+
+    auto running      = std::make_unique<RunningFilter>();
+    running->image    = img;
+    running->name     = name;
+    running->bounds   = img->data_window;
+    running->new_size = size;
+    running->channels.resize(img->channels.size());
+    for (size_t i = 0; i < img->channels.size(); ++i) running->channels[i] = int(i);
+    running->filter = [op](const Array2Df &channel, int, AtomicProgress p) { return op(channel, p); };
+
+    start_filter(std::move(running));
+}
+
+void HDRViewApp::start_filter(std::unique_ptr<RunningFilter> running)
+{
     // the statistics tasks read the very samples the filter is about to
-    for (auto &c : img->channels) c.cancel_stats();
+    for (auto &c : running->image->channels) c.cancel_stats();
+
+    running->results.resize(running->channels.size());
 
     RunningFilter *raw = running.get();
     m_running_filter   = std::move(running);
 
     // filters every channel into raw->results; runs on a worker where there is one, see below
-    auto do_the_work = [raw, filter]
+    auto do_the_work = [raw]
     {
-        const Box2i local{raw->bounds.min - raw->image->data_window.min,
-                          raw->bounds.min - raw->image->data_window.min + raw->bounds.size()};
-
         const float share = 1.f / float(raw->channels.size());
         for (size_t i = 0; i < raw->channels.size() && !raw->progress.canceled(); ++i)
         {
             // a share of the same total, not a copy, so Cancel reaches the filter partway through a
             // channel and not only between channels
-            raw->results[i] = filter(raw->image->channels[size_t(raw->channels[i])], local, int(i),
-                                     AtomicProgress{raw->progress, share});
+            raw->results[i] = raw->filter(raw->image->channels[size_t(raw->channels[i])], int(i),
+                                          AtomicProgress{raw->progress, share});
         }
 
         if (!raw->progress.canceled())
@@ -806,59 +420,6 @@ void HDRViewApp::modify_channels_async(
 #endif
 }
 
-void HDRViewApp::modify_image_async(const ImagePtr &img, const string &name, int2 size,
-                                    const function<Array2Df(const Array2Df &, AtomicProgress)> &op)
-{
-    if (!can_edit(img) || size.x <= 0 || size.y <= 0)
-        return;
-
-    if (m_running_filter)
-    {
-        m_filter_queue.push_back([this, img, name, size, op] { modify_image_async(img, name, size, op); });
-        return;
-    }
-
-    auto running    = std::make_unique<RunningFilter>();
-    running->image  = img;
-    running->name   = name;
-    running->bounds = img->data_window;
-    running->channels.resize(img->channels.size());
-    for (size_t i = 0; i < img->channels.size(); ++i) running->channels[i] = int(i);
-    running->results.resize(img->channels.size());
-
-    for (auto &c : img->channels) c.cancel_stats();
-
-    RunningFilter *raw       = running.get();
-    m_running_filter         = std::move(running);
-    m_running_filter_resizes = true;
-    m_running_filter_size    = size;
-
-    auto do_the_work = [raw, op]
-    {
-        const float share = 1.f / float(raw->channels.size());
-        for (size_t i = 0; i < raw->channels.size() && !raw->progress.canceled(); ++i)
-            raw->results[i] = op(raw->image->channels[i], AtomicProgress{raw->progress, share});
-
-        if (!raw->progress.canceled())
-            raw->progress.set_done();
-
-        raw->done.store(true);
-    };
-
-#if defined(__EMSCRIPTEN__)
-    do_the_work();
-    drain_running_filter();
-#else
-    dialog("Applying filter...").open = true;
-    raw->worker                       = std::thread(
-        [this, do_the_work]
-        {
-            do_the_work();
-            wake_event_loop();
-        });
-#endif
-}
-
 void HDRViewApp::drain_running_filter()
 {
     if (!m_running_filter || !m_running_filter->done.load())
@@ -871,34 +432,8 @@ void HDRViewApp::drain_running_filter()
     if (running->progress.canceled())
     {
         spdlog::debug("Filter '{}' was canceled.", running->name);
-        m_running_filter_resizes = false;
         // cancel means the whole run, not just the image it had reached
         m_filter_queue.clear();
-        return;
-    }
-
-    if (m_running_filter_resizes)
-    {
-        // the results are a different size than what they were computed from, so the channels are
-        // replaced outright and the windows moved to match
-        const int2 size          = m_running_filter_size;
-        m_running_filter_resizes = false;
-        auto &results            = running->results;
-
-        modify_structure(running->image, running->name,
-                         [size, &results](Image &image)
-                         {
-                             for (size_t i = 0; i < image.channels.size(); ++i)
-                             {
-                                 image.channels[i].resize(size);
-                                 std::copy(results[i].data(), results[i].data() + results[i].num_elements(),
-                                           image.channels[i].data());
-                                 image.channels[i].texture_is_dirty = true;
-                             }
-                             image.data_window    = Box2i{image.data_window.min, image.data_window.min + size};
-                             image.display_window = image.data_window;
-                         });
-        start_next_filter();
         return;
     }
 
@@ -906,8 +441,33 @@ void HDRViewApp::drain_running_filter()
     const Box2i bounds   = running->bounds;
     auto       &results  = running->results;
 
+    auto ctx = edit_context(running->image);
+
+    if (const int2 size = running->new_size; size.x > 0 && size.y > 0)
+    {
+        // the results are a different size than what they were computed from, so the channels are
+        // replaced outright and the windows moved to match
+        modify_image(
+            ctx, running->name,
+            [size, &results](Image &image)
+            {
+                for (size_t i = 0; i < image.channels.size(); ++i)
+                {
+                    image.channels[i].resize(size);
+                    std::copy(results[i].data(), results[i].data() + results[i].num_elements(),
+                              image.channels[i].data());
+                    image.channels[i].texture_is_dirty = true;
+                }
+                image.data_window    = Box2i{image.data_window.min, image.data_window.min + size};
+                image.display_window = image.data_window;
+            },
+            structure_undo, Extent_Structure);
+        start_next_filter();
+        return;
+    }
+
     modify_image(
-        running->image, running->name,
+        ctx, running->name,
         [&channels, &bounds, &results](Image &image)
         {
             const int2 offset = bounds.min - image.data_window.min;
@@ -915,8 +475,8 @@ void HDRViewApp::drain_running_filter()
             for (size_t i = 0; i < channels.size(); ++i)
                 image.channels[size_t(channels[i])].upload_tile(Box2i{offset, offset + extent}, results[i].data());
         },
-        [&channels, &bounds, &running](const Image &image) -> UndoPtr
-        { return std::make_unique<ChannelRectUndo>(image, channels, bounds, running->name); });
+        [&channels, &bounds](const Image &image, const string &n) -> UndoPtr
+        { return std::make_unique<ChannelRectUndo>(image, channels, bounds, n); });
 
     start_next_filter();
 }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1642,9 +1642,9 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
         for (auto &cmd : m_edit_commands)
         {
             EditCommand *c    = cmd.get();
-            const auto   info = c->info();
-            add(Action{info.names, info.icon, info.chord, info.flags, [this, c]() { invoke_edit_command(*c); },
-                       [this, c]() { return edit_command_enabled(*c); }});
+            const auto  &info = c->info();
+            add(Action{info.names, info.icon, info.chord, ImGuiInputFlags_None,
+                       [this, c]() { invoke_edit_command(*c); }, [this, c]() { return edit_command_enabled(*c); }});
         }
 
         add(Action{{"Select all", "Select the entire image"},

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -745,7 +745,7 @@ void HDRViewApp::setup_dialogs(const vector<string> &in_files)
     // Every command that has one, so a dialog cannot be forgotten when a command is added, and all of
     // them wear the same shell, subject selector and footer; see draw_edit_command_dialog().
     for (auto &cmd : m_edit_commands)
-        if (cmd->has_dialog())
+        if (cmd->info().has_dialog)
         {
             EditCommand *c = cmd.get();
             m_dialogs.push_back(make_unique<PopupDialog>(c->info().names.front(), [this, c](bool &open)

--- a/src/app.h
+++ b/src/app.h
@@ -203,25 +203,18 @@ public:
     /// What an edit command runs against: \p img, or the image being pointed at when none is given.
     EditContext edit_context(ImagePtr img = nullptr);
 
-    /// Replace the image wholesale with something computed from it, off the main thread.
+    /// Resample every channel of \p img into a new \p size, replacing the image as one undoable step.
     /**
-        For the environment-map operations, which resample every channel into a new \p size. \p op produces
-        one channel's new samples; the results are swapped in together on the main thread, as one undoable
-        step.
+        On a worker behind a cancellable progress bar, since a resampler costs seconds a channel; a resize
+        fast enough to run synchronously goes through Image::resample() instead.
     */
-    void modify_image_async(const ImagePtr &img, const std::string &name, int2 size, const ImageFilter &op);
+    void resample_image_async(const ImagePtr &img, const std::string &name, int2 size, const ChannelResampler &op);
 
+    /// Filter the subject's channels of \p img, likewise on a worker, as one undoable step.
     /**
-        Apply a neighborhood filter to the subject's channels, computed on a worker with a progress bar that
-        can cancel it. The image is only touched once every channel is done, back on the main thread and
-        through modify_image(), so the edit still lands as one undoable step.
-
-        \p filter is handed the whole channel, the rectangle of it to produce in channel-local coordinates,
-        and which of the subject's channels it is -- 0 for the first, so a group's R, G, B, A arrive as 0, 1,
-        2, 3. It sees the whole channel because its kernel reads past the rectangle's edges.
-
-        Returns having only started the work. A canceled filter discards its partial result and changes
-        nothing.
+        \p filter produces one rectangle but is handed the whole channel, since its kernel reads past the
+        rectangle's edges, and which of the subject's channels it is -- 0 for the first, so a group's R, G,
+        B, A arrive as 0, 1, 2, 3. Returns having only started the work; a canceled filter changes nothing.
     */
     void modify_channels_async(const ImagePtr &img, const std::string &name, const EditSubject &subject,
                                const ChannelFilter &filter);
@@ -642,14 +635,11 @@ private:
         std::string      name;
         std::vector<int> channels;
         Box2i            bounds;
+
         /// Filters one of `channels`, given its index among them and a share of the progress bar.
         std::function<Array2Df(const Array2Df &, int, AtomicProgress)> filter;
-        /// The size the results are, when the work replaces the image rather than a rectangle of it.
-        /**
-            Zero for a filter that keeps the image's shape; when it is set, drain_running_filter() swaps the
-            channels in instead of uploading tiles.
-        */
-        int2                  new_size{0};
+
+        int2                  new_size{0}; ///< The size of the results; zero keeps the image's shape.
         std::vector<Array2Df> results;
         AtomicProgress        progress{true};
         std::atomic<bool>     done{false};

--- a/src/app.h
+++ b/src/app.h
@@ -8,6 +8,7 @@
 #include "colormap.h"
 #include "display_colorspace.h"
 #include "edit/commands.h"
+#include "edit/edit_ops.h"
 #include "edit/envmap.h"
 #include "edit/filters.h"
 #include "edit/subject.h"
@@ -123,8 +124,6 @@ public:
         Falls back to the group on screen for an image with nothing selected.
     */
     std::vector<int> target_groups(const ConstImagePtr &img) const;
-    /// The same, for a group named by the caller rather than by what is currently pointed at.
-    std::vector<int> target_groups(const ConstImagePtr &img, int pointed_at) const;
     /// Put \p img into the list just after the current image, named \p partname, and select it.
     void add_image_beside_current(ImagePtr img, const std::string &partname);
     /// Whether `image` came from somewhere reload_image() could read it again.
@@ -201,97 +200,8 @@ public:
     //-----------------------------------------------------------------------------
     // editing images (see src/app-edit.cpp)
     //-----------------------------------------------------------------------------
-    /**
-        Apply one edit to \p img and record how to reverse it. The only thing that writes image pixels: it
-        also refuses images that cannot be edited, stops the statistics tasks reading the samples,
-        invalidates the caches keyed on them, and pushes the undo entry.
-
-        \param img       Image to change
-        \param name      Shown beside "Undo"/"Redo", e.g. "Rotate 90 CW"
-        \param op        Makes the change
-        \param make_undo Builds the entry that reverses it, called before `op` so it can capture whatever
-                         `op` is about to overwrite
-        \returns Whether the edit was applied; false when the image refuses edits (see can_edit()).
-    */
-    bool modify_image(const ImagePtr &img, const std::string &name, const std::function<void(Image &)> &op,
-                      const std::function<UndoPtr(const Image &)> &make_undo);
-
-    /// A geometric edit, reversed by performing its opposite instead of storing pixels.
-    /**
-        \p forward and \p backward must be inverses of each other, as flips and quarter turns are.
-    */
-    bool modify_image_reversibly(const ImagePtr &img, const std::string &name,
-                                 const std::function<void(Image &)> &forward,
-                                 const std::function<void(Image &)> &backward);
-
-    /// Whether \p img accepts edits at all.
-    /**
-        False while a renderer is streaming into it, since the next tile would overwrite the edit.
-    */
-    static bool can_edit(const ConstImagePtr &img);
-
-    /// The channels \p subject names, and the rectangle of them it covers, in image coordinates.
-    /**
-        The rectangle is the data window, narrowed to the selection when the subject asks for it. Empty
-        means there is nothing to edit.
-    */
-    std::pair<std::vector<int>, Box2i> resolve_subject(const ConstImagePtr &img, const EditSubject &subject) const;
-
-    /**
-        Apply \p op to every sample the subject covers, as one undoable edit.
-
-        \p op is handed a sample, its position in image coordinates, and which of the subject's channels it
-        belongs to -- 0 for the first, so a group's R, G, B, A arrive as 0, 1, 2, 3 -- and returns what to
-        replace it with. Both the GPU upload and the undo entry cover only the subject's rectangle.
-
-        \returns Whether anything was edited; false for an image that refuses edits or a subject that
-                 names nothing.
-    */
-    bool modify_pixels(const ImagePtr &img, const std::string &name, const EditSubject &subject,
-                       const std::function<float(float, int2, int)> &op);
-
-    /**
-        Apply \p op to each covered group's channels together -- its value and its position in image
-        coordinates -- as one undoable edit. Unlike modify_pixels(), which sees one sample at a time, this
-        can mix channels into each other, as a color-space conversion or a channel mixer does.
-
-        Only color groups are covered, RGB and RGBA; the subject's other channels are left alone. A group
-        without alpha gets 1 in that slot and whatever \p op returns there is dropped.
-
-        \p retag, if given, updates the image's color metadata to describe what \p op produced, recorded in
-        the same history entry as the pixels so undoing takes back both.
-
-        \returns Whether anything was edited; false when the subject names no color group.
-    */
-    bool modify_colors(const ImagePtr &img, const std::string &name, const EditSubject &subject,
-                       const std::function<float4(const float4 &, int2)> &op,
-                       const std::function<void(Image &)>                &retag = {});
-
-    /// As modify_colors(), but \p op is handed a reader instead of a value.
-    /**
-        `read(p)` gives the group's components at any position, with \p border_x and \p border_y deciding
-        what lies outside the image. The reader sees the image as it was before the edit.
-    */
-    bool modify_neighborhood(const ImagePtr &img, const std::string &name, const EditSubject &subject,
-                             const std::function<float4(const std::function<float4(int2)> &, int2)> &op,
-                             int border_x = BorderMode_Edge, int border_y = BorderMode_Edge);
-
-    /// Apply an edit that changes the image's shape, as one undoable step.
-    /**
-        For crop, canvas resize, or a change to the channel list. The whole channel list is saved for undo,
-        and the layer tree is rebuilt and the view refit afterwards.
-    */
-    bool modify_structure(const ImagePtr &img, const std::string &name, const std::function<void(Image &)> &op);
-
-    /**
-        Apply a neighborhood filter to the subject's channels, as one undoable edit.
-
-        \p filter is handed a whole channel and the rectangle of it to produce, in channel-local
-        coordinates, and returns an array of just that rectangle. It sees the whole channel because its
-        kernel reads past the rectangle's edges, but only has to compute the rectangle.
-    */
-    bool modify_channels(const ImagePtr &img, const std::string &name, const EditSubject &subject,
-                         const std::function<Array2Df(const Array2Df &, const Box2i &)> &filter);
+    /// What an edit command runs against: \p img, or the image being pointed at when none is given.
+    EditContext edit_context(ImagePtr img = nullptr);
 
     /// Replace the image wholesale with something computed from it, off the main thread.
     /**
@@ -299,23 +209,22 @@ public:
         one channel's new samples; the results are swapped in together on the main thread, as one undoable
         step.
     */
-    void modify_image_async(const ImagePtr &img, const std::string &name, int2 size,
-                            const std::function<Array2Df(const Array2Df &, AtomicProgress)> &op);
+    void modify_image_async(const ImagePtr &img, const std::string &name, int2 size, const ImageFilter &op);
 
     /**
-        As modify_channels(), but computed on a worker, with a progress bar that can cancel it. The image is
-        only touched once every channel is done, back on the main thread and through the same chokepoint, so
-        the edit still lands as one undoable step.
+        Apply a neighborhood filter to the subject's channels, computed on a worker with a progress bar that
+        can cancel it. The image is only touched once every channel is done, back on the main thread and
+        through modify_image(), so the edit still lands as one undoable step.
 
-        \p filter is handed the channel, the rectangle of it to produce, and which of the subject's channels
-        it is -- 0 for the first, so a group's R, G, B, A arrive as 0, 1, 2, 3.
+        \p filter is handed the whole channel, the rectangle of it to produce in channel-local coordinates,
+        and which of the subject's channels it is -- 0 for the first, so a group's R, G, B, A arrive as 0, 1,
+        2, 3. It sees the whole channel because its kernel reads past the rectangle's edges.
 
         Returns having only started the work. A canceled filter discards its partial result and changes
         nothing.
     */
-    void modify_channels_async(
-        const ImagePtr &img, const std::string &name, const EditSubject &subject,
-        const std::function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &filter);
+    void modify_channels_async(const ImagePtr &img, const std::string &name, const EditSubject &subject,
+                               const ChannelFilter &filter);
 
     /// Draws the progress bar for a filter started by modify_channels_async(), and its Cancel button.
     void draw_filter_progress_dialog(bool &open);
@@ -352,10 +261,9 @@ public:
     /// Reapply the edit undo() last reversed, across the selection. False if the current image had none.
     bool redo();
 
-    /// Everything a completed edit invalidates, applied to \p img.
+    /// What stepping \p img's history invalidates: the statistics cache and the GPU textures.
     /**
-        The statistics cache, the GPU textures, and, when the channels themselves changed, the layer and
-        group tree built from them.
+        An edit arriving through modify_image() invalidates the same things through EditContext::edited.
     */
     void after_modify(const ImagePtr &img);
     //-----------------------------------------------------------------------------
@@ -730,10 +638,18 @@ private:
     */
     struct RunningFilter
     {
-        ImagePtr              image;
-        std::string           name;
-        std::vector<int>      channels;
-        Box2i                 bounds;
+        ImagePtr         image;
+        std::string      name;
+        std::vector<int> channels;
+        Box2i            bounds;
+        /// Filters one of `channels`, given its index among them and a share of the progress bar.
+        std::function<Array2Df(const Array2Df &, int, AtomicProgress)> filter;
+        /// The size the results are, when the work replaces the image rather than a rectangle of it.
+        /**
+            Zero for a filter that keeps the image's shape; when it is set, drain_running_filter() swaps the
+            channels in instead of uploading tiles.
+        */
+        int2                  new_size{0};
         std::vector<Array2Df> results;
         AtomicProgress        progress{true};
         std::atomic<bool>     done{false};
@@ -750,12 +666,6 @@ private:
                 worker.join();
         }
     };
-    /// Set when the running work replaces the image rather than a rectangle of it; see modify_image_async().
-    /**
-        drain_running_filter() then swaps the channels instead of uploading tiles.
-    */
-    bool m_running_filter_resizes = false;
-    int2 m_running_filter_size{0};
 
     std::unique_ptr<RunningFilter> m_running_filter;
 
@@ -765,6 +675,11 @@ private:
     */
     std::vector<std::function<void()>> m_filter_queue;
 
+    /// Take \p running as the filter in flight and set it going.
+    /**
+        On a worker with a progress dialog, or inline where there are no threads.
+    */
+    void start_filter(std::unique_ptr<RunningFilter> running);
     /// Applies a finished filter's results, or clears an abandoned one. Called once a frame.
     void drain_running_filter();
     /// Starts the next queued filter, if a fan-out left any waiting.

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -77,15 +77,15 @@ public:
         /// Shown in the menu; the first is also the key the action registry and the tests address it by.
         std::vector<std::string> names;
         std::string              icon;
-        ImGuiKeyChord            chord = ImGuiKey_None;
+        ImGuiKeyChord            chord      = ImGuiKey_None;
+        bool                     has_dialog = false; ///< Whether invoking this opens a dialog rather than editing.
 
         std::string confirm  = "Apply"; ///< What the confirming button says. Ignored without a dialog.
         float       width_em = 24.f;    ///< Least dialog width in em; an Info predates the ImGui context.
 
-        bool draws_subject_selector = true;  ///< Whether "Apply to" means anything here, and so is shown.
-        bool has_dialog             = false; ///< Whether invoking this opens a dialog rather than editing at once.
-        bool fans_out               = true;  ///< Whether a multi-selection runs this once per image.
-        bool needs_editable         = true;  ///< Whether the image has to accept edits for this to be offered.
+        bool draws_subject_selector = true; ///< Whether "Apply to" means anything here, and so is shown.
+        bool fans_out               = true; ///< Whether a multi-selection runs this once per image.
+        bool needs_editable         = true; ///< Whether the image has to accept edits for this to be offered.
     };
 
     explicit EditCommand(Info info) : m_info(std::move(info)) {}

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -18,65 +18,71 @@
 #include <string>
 #include <vector>
 
+/// What an edit changed besides sample values, which says what has to be rebuilt afterwards.
+enum EditExtent : int
+{
+    Extent_Samples = 0, ///< Samples within the channels the image already had
+    Extent_Structure    ///< The channel list or the windows: the layer tree is rebuilt and the view refit
+};
+
+/// Filters one channel of an image.
+/**
+    Handed the whole channel, the rectangle of it to produce in channel-local coordinates, which of the
+    covered channels it is, and a share of the progress bar.
+*/
+using ChannelFilter = std::function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)>;
+/// Computes one channel of a whole new image from the channel it replaces.
+using ImageFilter = std::function<Array2Df(const Array2Df &, AtomicProgress)>;
+
 /// What an edit command sees of the application: the image, the subject, and the ways to change it.
 /**
-    Each modify_* method names the edit for the history and takes the subject from the context; see the
-    corresponding HDRViewApp methods for what they guarantee.
+    Filled in by HDRViewApp::edit_context(), and by the tests directly. The ways of changing an image are
+    free functions over this; see edit/edit_ops.h. The two here are the ones needing the application's
+    worker thread and progress dialog.
 */
 struct EditContext
 {
-    virtual ~EditContext() = default;
-
     /// The image being edited; null when there is none.
-    virtual ImagePtr image() const = 0;
-    /// Which of that image's samples the edit covers.
-    virtual const EditSubject &subject() const = 0;
-
-    /// The channel groups an operation acts on: normally the selected ones.
+    ImagePtr image;
+    /// Which of that image's samples an edit covers.
+    EditSubject subject;
+    /// The rectangular selection, in image coordinates; empty when there is none.
+    Box2i roi;
+    /// The channel groups a group edit acts on: normally the selected ones.
     /**
-        See HDRViewApp::target_groups() for how a right-clicked group overrides that. Empty when there are
-        none.
+        A group pointed at from outside the selection names itself alone; see HDRViewApp::target_groups().
     */
-    virtual std::vector<int> target_groups() const = 0;
-
-    virtual Box2i selection() const               = 0;
-    virtual void  set_selection(const Box2i &box) = 0;
+    std::vector<int> target_groups;
     /// The color the viewport draws behind the image, for the edits that composite against it.
-    virtual float4 background_color() const = 0;
+    float4 background{0.f, 0.f, 0.f, 1.f};
+    /// The image last cut or copied, shared by every open image; the pointee is null until one has been.
+    ImagePtr *clipboard = nullptr;
 
-    /// The image last cut or copied, or null when nothing has been. Shared by every open image.
-    virtual ConstImagePtr clipboard() const       = 0;
-    virtual void          set_clipboard(ImagePtr) = 0;
-
-    //
-    // The ways an image can be changed. All but the async pair return whether anything was edited.
-    //
-    virtual bool modify_pixels(const std::string &name, const std::function<float(float, int2, int)> &op) = 0;
-    virtual bool modify_colors(const std::string &name, const std::function<float4(const float4 &, int2)> &op,
-                               const std::function<void(Image &)> &retag = {})                            = 0;
-    virtual bool modify_neighborhood(const std::string                                                      &name,
-                                     const std::function<float4(const std::function<float4(int2)> &, int2)> &op,
-                                     int border_x, int border_y)                                          = 0;
-    virtual bool modify_channels(const std::string                                              &name,
-                                 const std::function<Array2Df(const Array2Df &, const Box2i &)> &filter)  = 0;
-    virtual void modify_channels_async(
-        const std::string                                                                   &name,
-        const std::function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &f)          = 0;
-    virtual void modify_image_async(const std::string &name, int2 size,
-                                    const std::function<Array2Df(const Array2Df &, AtomicProgress)> &op) = 0;
-    virtual bool modify_structure(const std::string &name, const std::function<void(Image &)> &op)       = 0;
-    virtual bool modify_reversibly(const std::string &name, const std::function<void(Image &)> &forward,
-                                   const std::function<void(Image &)> &backward)                         = 0;
-
-    /// Put \p img into the image list beside the one being edited, and select it.
+    /// Put an image into the list beside the one being edited, and select it.
     /**
-        \p partname is what the Images panel shows beside the file name, to tell several images made from
-        one file apart.
+        The second argument is what the Images panel shows beside the file name, to tell several images made
+        from one file apart.
     */
-    virtual void add_image(ImagePtr img, const std::string &partname) = 0;
-
+    std::function<void(ImagePtr, std::string)> add_image;
+    /// Set the selection, which cropping clears.
+    std::function<void(const Box2i &)> set_selection;
     /// Draw the shared "Apply to" controls.
-    virtual void draw_subject_selector() = 0;
+    std::function<void()> draw_subject_selector;
+    /// Called once an edit has landed, so the application can rebind its textures and refit the view.
+    std::function<void(EditExtent)> edited;
+
+    /// Filter the subject's channels on a worker, with a progress bar that can cancel it.
+    /**
+        The image is only touched once every channel is done, back on the main thread and through
+        modify_image(), so the edit still lands as one undoable step. Returns having only started the work;
+        a canceled filter discards its partial result and changes nothing.
+    */
+    std::function<void(const std::string &name, const ChannelFilter &filter)> modify_channels_async;
+    /// Replace the image wholesale with something computed from it at a new size, off the main thread.
+    /**
+        For the environment-map operations. The results are swapped in together, as one undoable step.
+    */
+    std::function<void(const std::string &name, int2 size, const ImageFilter &op)> modify_image_async;
 };
 
 /// One undoable edit: what it is called, what it draws, and what it does.
@@ -100,7 +106,6 @@ public:
         std::vector<std::string> names;
         std::string              icon;
         ImGuiKeyChord            chord = ImGuiKey_None;
-        ImGuiInputFlags          flags = ImGuiInputFlags_None;
 
         /// What the confirming button says. Ignored by a command with no dialog.
         std::string confirm = "Apply";
@@ -125,15 +130,16 @@ public:
         bool needs_editable = true;
     };
 
+    explicit EditCommand(Info info) : m_info(std::move(info)) {}
     virtual ~EditCommand() = default;
 
-    virtual Info info() const = 0;
+    /// Built once, in the constructor: the menu, the palette and the action registry read it every frame.
+    const Info &info() const { return m_info; }
 
     /// True when this is a dialog rather than an edit applied the moment it is chosen.
     bool has_dialog() const
     {
-        // by value: info() returns a temporary
-        const std::string n = info().names.front();
+        const std::string &n = m_info.names.front();
         return n.size() >= 3 && n.compare(n.size() - 3, 3, "...") == 0;
     }
 
@@ -150,6 +156,10 @@ public:
     virtual void on_open(EditContext &) {}
     /// Called as it closes, either way, for anything that must not be carried to the next image.
     virtual void on_close(EditContext &) {}
+
+protected:
+    /// A subclass constructor may adjust the fields it would rather set by name than pass positionally.
+    Info m_info;
 };
 
 using EditCommandPtr = std::unique_ptr<EditCommand>;

--- a/src/edit/command.h
+++ b/src/edit/command.h
@@ -18,80 +18,55 @@
 #include <string>
 #include <vector>
 
-/// What an edit changed besides sample values, which says what has to be rebuilt afterwards.
+/// How far an edit reached, which says what has to be rebuilt afterwards.
 enum EditExtent : int
 {
-    Extent_Samples = 0, ///< Samples within the channels the image already had
-    Extent_Structure    ///< The channel list or the windows: the layer tree is rebuilt and the view refit
+    Extent_Pixels = 0, ///< Pixels within the channels the image already had
+    Extent_Structure   ///< The channel list or the windows: the layer tree is rebuilt and the view refit
 };
 
-/// Filters one channel of an image.
+/// Produces a rectangle of one channel, in channel-local coordinates.
 /**
-    Handed the whole channel, the rectangle of it to produce in channel-local coordinates, which of the
-    covered channels it is, and a share of the progress bar.
+    Given the whole channel to read from, its index among those covered, and a share of the progress bar.
 */
 using ChannelFilter = std::function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)>;
-/// Computes one channel of a whole new image from the channel it replaces.
-using ImageFilter = std::function<Array2Df(const Array2Df &, AtomicProgress)>;
+/// Produces a whole channel at the image's new size, from the channel it replaces.
+using ChannelResampler = std::function<Array2Df(const Array2Df &, AtomicProgress)>;
 
 /// What an edit command sees of the application: the image, the subject, and the ways to change it.
 /**
-    Filled in by HDRViewApp::edit_context(), and by the tests directly. The ways of changing an image are
-    free functions over this; see edit/edit_ops.h. The two here are the ones needing the application's
-    worker thread and progress dialog.
+    Filled in by HDRViewApp::edit_context(), and by the tests directly. Most ways of changing an image are
+    free functions over this (see edit/edit_ops.h); the two here need the worker thread and progress dialog.
 */
 struct EditContext
 {
-    /// The image being edited; null when there is none.
-    ImagePtr image;
-    /// Which of that image's samples an edit covers.
-    EditSubject subject;
-    /// The rectangular selection, in image coordinates; empty when there is none.
-    Box2i roi;
-    /// The channel groups a group edit acts on: normally the selected ones.
-    /**
-        A group pointed at from outside the selection names itself alone; see HDRViewApp::target_groups().
-    */
-    std::vector<int> target_groups;
-    /// The color the viewport draws behind the image, for the edits that composite against it.
-    float4 background{0.f, 0.f, 0.f, 1.f};
-    /// The image last cut or copied, shared by every open image; the pointee is null until one has been.
-    ImagePtr *clipboard = nullptr;
+    ImagePtr         image;                          ///< The image being edited; null when there is none.
+    EditSubject      subject;                        ///< Which of the image's pixels an edit covers.
+    Box2i            roi;                            ///< The selection, in image coordinates; may be empty.
+    std::vector<int> target_groups;                  ///< The groups a group edit acts on; see target_groups().
+    float4           background{0.f, 0.f, 0.f, 1.f}; ///< The color the viewport draws behind the image.
+    ImagePtr        *clipboard = nullptr;            ///< The image last cut or copied, shared by every image.
 
-    /// Put an image into the list beside the one being edited, and select it.
-    /**
-        The second argument is what the Images panel shows beside the file name, to tell several images made
-        from one file apart.
-    */
+    /// Put an image into the list beside the one being edited and select it; the string is its partname.
     std::function<void(ImagePtr, std::string)> add_image;
-    /// Set the selection, which cropping clears.
-    std::function<void(const Box2i &)> set_selection;
-    /// Draw the shared "Apply to" controls.
-    std::function<void()> draw_subject_selector;
+
+    std::function<void(const Box2i &)> set_selection;         ///< Set the selection, which cropping clears.
+    std::function<void()>              draw_subject_selector; ///< Draw the shared "Apply to" controls.
+
     /// Called once an edit has landed, so the application can rebind its textures and refit the view.
     std::function<void(EditExtent)> edited;
 
-    /// Filter the subject's channels on a worker, with a progress bar that can cancel it.
-    /**
-        The image is only touched once every channel is done, back on the main thread and through
-        modify_image(), so the edit still lands as one undoable step. Returns having only started the work;
-        a canceled filter discards its partial result and changes nothing.
-    */
+    /// Filter the subject's channels on a worker, behind a cancellable progress bar; one undoable step.
     std::function<void(const std::string &name, const ChannelFilter &filter)> modify_channels_async;
-    /// Replace the image wholesale with something computed from it at a new size, off the main thread.
-    /**
-        For the environment-map operations. The results are swapped in together, as one undoable step.
-    */
-    std::function<void(const std::string &name, int2 size, const ImageFilter &op)> modify_image_async;
+    /// The same, resampling every channel into a new size, which replaces the image.
+    std::function<void(const std::string &name, int2 size, const ChannelResampler &op)> resample_image_async;
 };
 
 /// One undoable edit: what it is called, what it draws, and what it does.
 /**
-    Add one by writing a subclass and naming it in the table in commands.cpp.
-
-    The dialog shell, the "Apply to" selector and the Cancel/Confirm footer are drawn around draw() by
-    HDRViewApp::draw_edit_command_dialog(); a command that leaves draw() alone has no dialog and is applied
-    the moment it is invoked. Parameters live as members, so they persist between openings.
+    Add one by writing a subclass and naming it in the table in commands.cpp. Parameters live as members, so
+    they persist between openings; HDRViewApp::draw_edit_command_dialog() draws the dialog shell, the
+    "Apply to" selector and the Cancel/Confirm footer around draw().
 */
 class EditCommand
 {
@@ -100,34 +75,17 @@ public:
     struct Info
     {
         /// Shown in the menu; the first is also the key the action registry and the tests address it by.
-        /**
-            A name ending in "..." is a dialog, as everywhere else in the interface.
-        */
         std::vector<std::string> names;
         std::string              icon;
         ImGuiKeyChord            chord = ImGuiKey_None;
 
-        /// What the confirming button says. Ignored by a command with no dialog.
-        std::string confirm = "Apply";
-        /// Least width of the dialog, in em; content wider than this widens it further.
-        /**
-            In em because an Info is built before there is an ImGui context to ask for a size.
-        */
-        float width_em = 24.f;
-        /// Whether the "Apply to" settings mean anything for this edit, and so whether its dialog shows them.
-        /**
-            False for the edits that replace or reshape the whole image.
-        */
-        bool draws_subject_selector = true;
+        std::string confirm  = "Apply"; ///< What the confirming button says. Ignored without a dialog.
+        float       width_em = 24.f;    ///< Least dialog width in em; an Info predates the ImGui context.
 
-        /// With several images selected, whether this runs on all of them or only the current one.
-        /**
-            Each gets its own invocation and undo entry.
-        */
-        bool fans_out = true;
-
-        /// Whether the image has to accept edits for this to be offered.
-        bool needs_editable = true;
+        bool draws_subject_selector = true;  ///< Whether "Apply to" means anything here, and so is shown.
+        bool has_dialog             = false; ///< Whether invoking this opens a dialog rather than editing at once.
+        bool fans_out               = true;  ///< Whether a multi-selection runs this once per image.
+        bool needs_editable         = true;  ///< Whether the image has to accept edits for this to be offered.
     };
 
     explicit EditCommand(Info info) : m_info(std::move(info)) {}
@@ -136,18 +94,11 @@ public:
     /// Built once, in the constructor: the menu, the palette and the action registry read it every frame.
     const Info &info() const { return m_info; }
 
-    /// True when this is a dialog rather than an edit applied the moment it is chosen.
-    bool has_dialog() const
-    {
-        const std::string &n = m_info.names.front();
-        return n.size() >= 3 && n.compare(n.size() - 3, 3, "...") == 0;
-    }
-
     /// Draw the command's own parameter controls; the chrome is drawn around this.
     virtual void draw(EditContext &) {}
 
     /// Perform the edit. Called on confirm, or immediately for a command with no dialog.
-    virtual void apply(EditContext &) = 0;
+    virtual void apply(const EditContext &) = 0;
 
     /// Whether the command can run at all, beyond the image accepting edits.
     virtual bool enabled(const EditContext &) const { return true; }

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -13,6 +13,7 @@
 
 #include "edit/commands.h"
 
+#include "edit/edit_ops.h"
 #include "fonts.h"
 #include "image.h"
 #include "imgui_ext.h"
@@ -57,8 +58,8 @@ std::vector<int> group_channels(const ImagePtr &img, int group)
 std::vector<int> target_channels(const EditContext &ctx)
 {
     std::vector<int> out;
-    for (int g : ctx.target_groups())
-        for (int c : group_channels(ctx.image(), g)) out.push_back(c);
+    for (int g : ctx.target_groups)
+        for (int c : group_channels(ctx.image, g)) out.push_back(c);
     return out;
 }
 
@@ -89,11 +90,11 @@ std::string layer_of(const ImagePtr &img, int group)
 */
 std::vector<int> regroup_channels(const EditContext &ctx)
 {
-    auto img = ctx.image();
+    auto img = ctx.image;
     if (!img)
         return {};
 
-    const std::vector<int> groups = ctx.target_groups();
+    const std::vector<int> groups = ctx.target_groups;
     if (groups.size() == 1)
         return ungrouped_in_layer(img, layer_of(img, groups.front()));
 
@@ -121,6 +122,22 @@ void select_channels_group(Image &img, int channel)
             }
 }
 
+/// Mark \p channels as standing alone or not and rebuild the groups derived from their names.
+/**
+    Leaves the viewport on whichever group now holds \p follow. Ungrouping and regrouping are this in both
+    directions.
+*/
+std::function<void(Image &)> mark_ungrouped(std::vector<int> channels, int follow, bool ungrouped)
+{
+    return [channels = std::move(channels), follow, ungrouped](Image &img)
+    {
+        for (int c : channels) img.channels[size_t(c)].ungrouped = ungrouped;
+        img.rebuild_layers();
+        if (follow >= 0)
+            select_channels_group(img, follow);
+    };
+}
+
 /// Show a group's channels one at a time rather than as a color.
 /**
     Groups are derived from channel names, so this marks the channels and the rebuild that follows declines
@@ -129,15 +146,14 @@ void select_channels_group(Image &img, int channel)
 class UngroupChannels final : public EditCommand
 {
 public:
-    Info info() const override
+    UngroupChannels() :
+        EditCommand({{"Ungroup channels", "Explode channel group", "Split channel group"},
+                     ICON_MY_NO_CHANNEL_GROUP,
+                     ImGuiKey_None,
+                     "Ungroup",
+                     24.f,
+                     /* draws_subject_selector */ false})
     {
-        return {{"Ungroup channels", "Explode channel group", "Split channel group"},
-                ICON_MY_NO_CHANNEL_GROUP,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Ungroup",
-                24.f,
-                /* draws_subject_selector */ false};
     }
 
     /// Only worth offering while one of the target groups holds more than one channel.
@@ -145,7 +161,7 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -155,22 +171,9 @@ public:
 
         const int follow = followed_channel(img, channels);
 
-        ctx.modify_reversibly(
-            "Ungroup channels",
-            [channels, follow](Image &img2)
-            {
-                for (int c : channels) img2.channels[size_t(c)].ungrouped = true;
-                img2.rebuild_layers();
-                if (follow >= 0)
-                    select_channels_group(img2, follow);
-            },
-            [channels, follow](Image &img2)
-            {
-                for (int c : channels) img2.channels[size_t(c)].ungrouped = false;
-                img2.rebuild_layers();
-                if (follow >= 0)
-                    select_channels_group(img2, follow);
-            });
+        auto forward  = mark_ungrouped(channels, follow, true);
+        auto backward = mark_ungrouped(channels, follow, false);
+        modify_image(ctx, "Ungroup channels", forward, reversible(forward, backward));
     }
 
 private:
@@ -182,9 +185,9 @@ private:
     static std::vector<int> ungroupable_channels(const EditContext &ctx)
     {
         std::vector<int> out;
-        for (int g : ctx.target_groups())
+        for (int g : ctx.target_groups)
         {
-            const std::vector<int> channels = group_channels(ctx.image(), g);
+            const std::vector<int> channels = group_channels(ctx.image, g);
             if (channels.size() > 1)
                 out.insert(out.end(), channels.begin(), channels.end());
         }
@@ -202,22 +205,21 @@ private:
 class RegroupChannels final : public EditCommand
 {
 public:
-    Info info() const override
+    RegroupChannels() :
+        EditCommand({{"Regroup channels", "Rejoin exploded channels"},
+                     ICON_MY_CHANNEL_GROUP,
+                     ImGuiKey_None,
+                     "Regroup",
+                     24.f,
+                     /* draws_subject_selector */ false})
     {
-        return {{"Regroup channels", "Rejoin exploded channels"},
-                ICON_MY_CHANNEL_GROUP,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Regroup",
-                24.f,
-                /* draws_subject_selector */ false};
     }
 
     bool enabled(const EditContext &ctx) const override { return !regroup_channels(ctx).empty(); }
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -227,22 +229,9 @@ public:
 
         const int follow = followed_channel(img, marked);
 
-        ctx.modify_reversibly(
-            "Regroup channels",
-            [marked, follow](Image &img2)
-            {
-                for (int c : marked) img2.channels[size_t(c)].ungrouped = false;
-                img2.rebuild_layers();
-                if (follow >= 0)
-                    select_channels_group(img2, follow);
-            },
-            [marked, follow](Image &img2)
-            {
-                for (int c : marked) img2.channels[size_t(c)].ungrouped = true;
-                img2.rebuild_layers();
-                if (follow >= 0)
-                    select_channels_group(img2, follow);
-            });
+        auto forward  = mark_ungrouped(marked, follow, false);
+        auto backward = mark_ungrouped(marked, follow, true);
+        modify_image(ctx, "Regroup channels", forward, reversible(forward, backward));
     }
 };
 
@@ -253,21 +242,20 @@ public:
 class DeleteChannelGroup final : public EditCommand
 {
 public:
-    Info info() const override
+    DeleteChannelGroup() :
+        EditCommand({{"Delete channel group", "Remove channels"},
+                     ICON_MY_TRASH_CAN,
+                     ImGuiKey_None,
+                     "Delete",
+                     24.f,
+                     /* draws_subject_selector */ false})
     {
-        return {{"Delete channel group", "Remove channels"},
-                ICON_MY_TRASH_CAN,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Delete",
-                24.f,
-                /* draws_subject_selector */ false};
     }
 
     /// Never every group: an image with no channels is not an image.
     bool enabled(const EditContext &ctx) const override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img || img->groups.size() < 2)
             return false;
 
@@ -277,7 +265,7 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -288,16 +276,15 @@ public:
         // erase from the back, so the indices still to be erased are not shifted
         std::sort(channels.begin(), channels.end(), std::greater<int>());
 
-        ctx.modify_structure("Delete channel group",
-                             [channels](Image &image)
-                             {
-                                 for (int c : channels)
-                                     if (c >= 0 && c < int(image.channels.size()))
-                                         image.channels.erase(image.channels.begin() + c);
-
-                                 // the groups and layer tree are derived from the channel names
-                                 image.rebuild_layers();
-                             });
+        modify_image(
+            ctx, "Delete channel group",
+            [channels](Image &image)
+            {
+                for (int c : channels)
+                    if (c >= 0 && c < int(image.channels.size()))
+                        image.channels.erase(image.channels.begin() + c);
+            },
+            structure_undo, Extent_Structure);
     }
 };
 

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -159,7 +159,7 @@ public:
     /// Only worth offering while one of the target groups holds more than one channel.
     bool enabled(const EditContext &ctx) const override { return !ungroupable_channels(ctx).empty(); }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)
@@ -217,7 +217,7 @@ public:
 
     bool enabled(const EditContext &ctx) const override { return !regroup_channels(ctx).empty(); }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)
@@ -263,7 +263,7 @@ public:
         return !channels.empty() && channels.size() < img->channels.size();
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)

--- a/src/edit/commands/channels.cpp
+++ b/src/edit/commands/channels.cpp
@@ -150,6 +150,7 @@ public:
         EditCommand({{"Ungroup channels", "Explode channel group", "Split channel group"},
                      ICON_MY_NO_CHANNEL_GROUP,
                      ImGuiKey_None,
+                     /* has_dialog */ false,
                      "Ungroup",
                      24.f,
                      /* draws_subject_selector */ false})
@@ -209,6 +210,7 @@ public:
         EditCommand({{"Regroup channels", "Rejoin exploded channels"},
                      ICON_MY_CHANNEL_GROUP,
                      ImGuiKey_None,
+                     /* has_dialog */ false,
                      "Regroup",
                      24.f,
                      /* draws_subject_selector */ false})
@@ -246,6 +248,7 @@ public:
         EditCommand({{"Delete channel group", "Remove channels"},
                      ICON_MY_TRASH_CAN,
                      ImGuiKey_None,
+                     /* has_dialog */ false,
                      "Delete",
                      24.f,
                      /* draws_subject_selector */ false})

--- a/src/edit/commands/clipboard.cpp
+++ b/src/edit/commands/clipboard.cpp
@@ -24,7 +24,6 @@
 
 namespace
 {
-
 /// The rectangle these operate on: the selection when the subject asks for it, else the whole image.
 Box2i target_region(const EditContext &ctx)
 {
@@ -127,10 +126,10 @@ public:
         EditCommand({{"Seamless paste...", "Poisson paste", "Gradient-domain paste"},
                      ICON_MY_SEAMLESS_PASTE,
                      ImGuiMod_Ctrl | ImGuiMod_Shift | ImGuiKey_V,
+                     true,
                      "Paste",
                      27.f})
     {
-        m_info.has_dialog = true;
     }
 
     bool enabled(const EditContext &ctx) const override { return ctx.clipboard && *ctx.clipboard; }

--- a/src/edit/commands/clipboard.cpp
+++ b/src/edit/commands/clipboard.cpp
@@ -49,7 +49,7 @@ public:
 
     bool enabled(const EditContext &ctx) const override { return ctx.image && ctx.clipboard; }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         if (ctx.image && ctx.clipboard)
             *ctx.clipboard = ctx.image->duplicate(target_region(ctx));
@@ -65,7 +65,7 @@ public:
         m_info.fans_out = false;
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img || !ctx.clipboard)
@@ -87,7 +87,7 @@ public:
 
     bool enabled(const EditContext &ctx) const override { return ctx.clipboard && *ctx.clipboard; }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto clip = ctx.clipboard ? *ctx.clipboard : nullptr;
         auto img  = ctx.image;
@@ -130,6 +130,7 @@ public:
                      "Paste",
                      27.f})
     {
+        m_info.has_dialog = true;
     }
 
     bool enabled(const EditContext &ctx) const override { return ctx.clipboard && *ctx.clipboard; }
@@ -154,7 +155,7 @@ public:
             ImGui::TextDisabled("Clipboard: %d x %d", clip->size().x, clip->size().y);
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto clip = ctx.clipboard ? *ctx.clipboard : nullptr;
         auto img  = ctx.image;

--- a/src/edit/commands/clipboard.cpp
+++ b/src/edit/commands/clipboard.cpp
@@ -13,6 +13,7 @@
 
 #include "edit/commands.h"
 
+#include "edit/edit_ops.h"
 #include "edit/poisson.h"
 
 #include "fonts.h"
@@ -27,73 +28,69 @@ namespace
 /// The rectangle these operate on: the selection when the subject asks for it, else the whole image.
 Box2i target_region(const EditContext &ctx)
 {
-    auto img = ctx.image();
+    auto img = ctx.image;
     if (!img)
         return Box2i{};
 
     Box2i box = img->data_window;
-    if (ctx.subject().selection_only && ctx.selection().has_volume())
-        box.intersect(ctx.selection());
+    if (ctx.subject.selection_only && ctx.roi.has_volume())
+        box.intersect(ctx.roi);
     return box;
 }
 
 class Copy final : public EditCommand
 {
 public:
-    Info info() const override
+    Copy() : EditCommand({{"Copy", "Copy selection"}, ICON_MY_COPY, ImGuiMod_Ctrl | ImGuiKey_C})
     {
-        Info i{{"Copy", "Copy selection"}, ICON_MY_COPY, ImGuiMod_Ctrl | ImGuiKey_C};
-        i.needs_editable = false; // copying a live image is fine
-        i.fans_out       = false; // one clipboard
-        return i;
+        m_info.needs_editable = false; // copying a live image is fine
+        m_info.fans_out       = false; // one clipboard
     }
 
-    bool enabled(const EditContext &ctx) const override { return ctx.image() != nullptr; }
+    bool enabled(const EditContext &ctx) const override { return ctx.image && ctx.clipboard; }
 
     void apply(EditContext &ctx) override
     {
-        if (auto img = ctx.image())
-            ctx.set_clipboard(img->duplicate(target_region(ctx)));
+        if (ctx.image && ctx.clipboard)
+            *ctx.clipboard = ctx.image->duplicate(target_region(ctx));
     }
 };
 
 class Cut final : public EditCommand
 {
 public:
-    Info info() const override
+    Cut() : EditCommand({{"Cut", "Cut selection"}, ICON_MY_CUT, ImGuiMod_Ctrl | ImGuiKey_X})
     {
-        Info i{{"Cut", "Cut selection"}, ICON_MY_CUT, ImGuiMod_Ctrl | ImGuiKey_X};
         // the copy half cannot fan out; see Copy
-        i.fans_out = false;
-        return i;
+        m_info.fans_out = false;
     }
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
-        if (!img)
+        auto img = ctx.image;
+        if (!img || !ctx.clipboard)
             return;
 
         // copied before it is cleared, over the same rectangle
-        ctx.set_clipboard(img->duplicate(target_region(ctx)));
+        *ctx.clipboard = img->duplicate(target_region(ctx));
 
         // zero throughout: these samples are held premultiplied, where a color with no alpha is additive
         // and not invisible
-        ctx.modify_pixels("Cut", [](float, int2, int) { return 0.f; });
+        modify_pixels(ctx, "Cut", [](float, int2, int) { return 0.f; });
     }
 };
 
 class Paste final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Paste"}, ICON_MY_PASTE, ImGuiMod_Ctrl | ImGuiKey_V}; }
+    Paste() : EditCommand({{"Paste"}, ICON_MY_PASTE, ImGuiMod_Ctrl | ImGuiKey_V}) {}
 
-    bool enabled(const EditContext &ctx) const override { return ctx.clipboard() != nullptr; }
+    bool enabled(const EditContext &ctx) const override { return ctx.clipboard && *ctx.clipboard; }
 
     void apply(EditContext &ctx) override
     {
-        auto clip = ctx.clipboard();
-        auto img  = ctx.image();
+        auto clip = ctx.clipboard ? *ctx.clipboard : nullptr;
+        auto img  = ctx.image;
         if (!clip || !img || clip->groups.empty())
             return;
 
@@ -105,38 +102,37 @@ public:
         const int4  channels = group.channels;
         const int2  extent   = clip->data_window.size();
 
-        ctx.modify_colors("Paste",
-                          [clip, channels, n, origin, extent](const float4 &dst, int2 p)
-                          {
-                              const int2 q = p - origin;
-                              if (q.x < 0 || q.y < 0 || q.x >= extent.x || q.y >= extent.y)
-                                  return dst; // past the end of what was copied; leave what is there
+        modify_colors(ctx, "Paste",
+                      [clip, channels, n, origin, extent](const float4 &dst, int2 p, int)
+                      {
+                          const int2 q = p - origin;
+                          if (q.x < 0 || q.y < 0 || q.x >= extent.x || q.y >= extent.y)
+                              return dst; // past the end of what was copied; leave what is there
 
-                              // read as stored, not through raw_pixel(), which would divide a straight-alpha
-                              // image's color back out
-                              float4 src{0.f, 0.f, 0.f, 1.f};
-                              for (int c = 0; c < n; ++c) src[c] = clip->channels[size_t(channels[c])](q);
+                          // read as stored, not through raw_pixel(), which would divide a straight-alpha
+                          // image's color back out
+                          float4 src{0.f, 0.f, 0.f, 1.f};
+                          for (int c = 0; c < n; ++c) src[c] = clip->channels[size_t(channels[c])](q);
 
-                              // source-over on premultiplied values, the same expression for color and alpha
-                              return src + dst * (1.f - src.w);
-                          });
+                          // source-over on premultiplied values, the same expression for color and alpha
+                          return src + dst * (1.f - src.w);
+                      });
     }
 };
 
 class SeamlessPaste final : public EditCommand
 {
 public:
-    Info info() const override
+    SeamlessPaste() :
+        EditCommand({{"Seamless paste...", "Poisson paste", "Gradient-domain paste"},
+                     ICON_MY_SEAMLESS_PASTE,
+                     ImGuiMod_Ctrl | ImGuiMod_Shift | ImGuiKey_V,
+                     "Paste",
+                     27.f})
     {
-        return {{"Seamless paste...", "Poisson paste", "Gradient-domain paste"},
-                ICON_MY_SEAMLESS_PASTE,
-                ImGuiMod_Ctrl | ImGuiMod_Shift | ImGuiKey_V,
-                ImGuiInputFlags_None,
-                "Paste",
-                27.f};
     }
 
-    bool enabled(const EditContext &ctx) const override { return ctx.clipboard() != nullptr; }
+    bool enabled(const EditContext &ctx) const override { return ctx.clipboard && *ctx.clipboard; }
 
     void draw(EditContext &ctx) override
     {
@@ -154,14 +150,14 @@ public:
                        "rather than a difference. Usually what an HDR image wants, where the two sides can be "
                        "many stops apart.");
 
-        if (auto clip = ctx.clipboard())
+        if (auto clip = ctx.clipboard ? *ctx.clipboard : nullptr)
             ImGui::TextDisabled("Clipboard: %d x %d", clip->size().x, clip->size().y);
     }
 
     void apply(EditContext &ctx) override
     {
-        auto clip = ctx.clipboard();
-        auto img  = ctx.image();
+        auto clip = ctx.clipboard ? *ctx.clipboard : nullptr;
+        auto img  = ctx.image;
         if (!clip || !img || clip->groups.empty())
             return;
 

--- a/src/edit/commands/color.cpp
+++ b/src/edit/commands/color.cpp
@@ -38,6 +38,7 @@ public:
                      "Convert",
                      27.f})
     {
+        m_info.has_dialog = true;
     }
 
     /// The file's own tag, so a conversion starts from what the pixels are.
@@ -104,7 +105,7 @@ public:
             ImGui::TextWrapped("These describe the same color space, so this would leave the samples as they are.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         float3x3 M;
         color_conversion_matrix(M, from(), to(), AdaptationMethod(m_method));
@@ -160,6 +161,7 @@ public:
         EditCommand(
             {{"Channel mixer...", "Mix channels", "Monochrome"}, ICON_MY_CHANNEL_MIXER, ImGuiKey_None, "Mix", 27.f})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -199,7 +201,7 @@ public:
         ImGui::TextDisabled("Total: %.1f%%", w.x + w.y + w.z);
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto row = [norm = m_normalize](const float3 &r)
         {
@@ -254,6 +256,7 @@ public:
         EditCommand(
             {{"Hue/saturation...", "Colorize", "Desaturate"}, ICON_MY_HUE_SATURATION, ImGuiKey_None, "Apply", 27.f})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -337,7 +340,7 @@ public:
         strip("The hue wheel as these settings would leave it", m_hue, m_saturation, m_lightness);
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float h = m_hue / 360.f, s = (m_saturation + 100.f) / 100.f, l = m_lightness / 100.f;
         modify_colors(ctx, "Hue/saturation",
@@ -358,6 +361,7 @@ public:
                      "Apply",
                      27.f})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -391,7 +395,7 @@ public:
                        "changes how light the image is and leaves its colors, the other does the reverse.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)
@@ -573,6 +577,7 @@ public:
                      ImGuiKey_None,
                      "Flatten"})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &ctx) override
@@ -590,7 +595,7 @@ public:
         ImGui::Tooltip("Takes the custom background color from the View menu.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float4 b = m_bg;
         modify_colors(ctx, "Flatten",

--- a/src/edit/commands/color.cpp
+++ b/src/edit/commands/color.cpp
@@ -13,6 +13,7 @@
 #include "edit/commands.h"
 
 #include "colorspace.h"
+#include "edit/edit_ops.h"
 #include "fonts.h"
 #include "image.h"
 #include "imgui_ext.h"
@@ -30,20 +31,19 @@ namespace
 class ConvertColorSpace final : public EditCommand
 {
 public:
-    Info info() const override
+    ConvertColorSpace() :
+        EditCommand({{"Convert color space...", "Change primaries", "Change white point", "Gamut conversion"},
+                     ICON_MY_COLORSPACE,
+                     ImGuiKey_None,
+                     "Convert",
+                     27.f})
     {
-        return {{"Convert color space...", "Change primaries", "Change white point", "Gamut conversion"},
-                ICON_MY_COLORSPACE,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Convert",
-                27.f};
     }
 
     /// The file's own tag, so a conversion starts from what the pixels are.
     void on_open(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -112,10 +112,10 @@ public:
         const int  g = m_dst_gamut, w = m_dst_white, m = m_method;
         const auto tagged = to();
 
-        ctx.modify_colors(
-            "Convert color space",
+        modify_colors(
+            ctx, "Convert color space",
             // premultiplied alpha is no obstacle: scaling every component by alpha commutes with a matrix
-            [M](const float4 &c, int2) { return float4{la::mul(M, c.xyz()), c.w}; },
+            [M](const float4 &c, int2, int) { return float4{la::mul(M, c.xyz()), c.w}; },
             [g, w, m, tagged](Image &image)
             {
                 image.chromaticities    = tagged;
@@ -156,14 +156,10 @@ private:
 class ChannelMixer final : public EditCommand
 {
 public:
-    Info info() const override
+    ChannelMixer() :
+        EditCommand(
+            {{"Channel mixer...", "Mix channels", "Monochrome"}, ICON_MY_CHANNEL_MIXER, ImGuiKey_None, "Mix", 27.f})
     {
-        return {{"Channel mixer...", "Mix channels", "Monochrome"},
-                ICON_MY_CHANNEL_MIXER,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Mix",
-                27.f};
     }
 
     void draw(EditContext &) override
@@ -216,18 +212,18 @@ public:
         if (m_output == Out_Monochrome)
         {
             const float3 g = row(m_rows[Out_Monochrome]);
-            ctx.modify_colors("Channel mixer",
-                              [g](const float4 &c, int2)
-                              {
-                                  const float y = la::dot(g, c.xyz());
-                                  return float4{y, y, y, c.w};
-                              });
+            modify_colors(ctx, "Channel mixer",
+                          [g](const float4 &c, int2, int)
+                          {
+                              const float y = la::dot(g, c.xyz());
+                              return float4{y, y, y, c.w};
+                          });
         }
         else
         {
             const float3 r = row(m_rows[Out_Red]), g = row(m_rows[Out_Green]), b = row(m_rows[Out_Blue]);
-            ctx.modify_colors("Channel mixer", [r, g, b](const float4 &c, int2)
-                              { return float4{la::dot(r, c.xyz()), la::dot(g, c.xyz()), la::dot(b, c.xyz()), c.w}; });
+            modify_colors(ctx, "Channel mixer", [r, g, b](const float4 &c, int2, int)
+                          { return float4{la::dot(r, c.xyz()), la::dot(g, c.xyz()), la::dot(b, c.xyz()), c.w}; });
         }
     }
 
@@ -254,14 +250,10 @@ private:
 class HueSaturation final : public EditCommand
 {
 public:
-    Info info() const override
+    HueSaturation() :
+        EditCommand(
+            {{"Hue/saturation...", "Colorize", "Desaturate"}, ICON_MY_HUE_SATURATION, ImGuiKey_None, "Apply", 27.f})
     {
-        return {{"Hue/saturation...", "Colorize", "Desaturate"},
-                ICON_MY_HUE_SATURATION,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Apply",
-                27.f};
     }
 
     void draw(EditContext &) override
@@ -348,8 +340,8 @@ public:
     void apply(EditContext &ctx) override
     {
         const float h = m_hue / 360.f, s = (m_saturation + 100.f) / 100.f, l = m_lightness / 100.f;
-        ctx.modify_colors("Hue/saturation",
-                          [h, s, l](const float4 &c, int2) { return float4{adjust_HSL(c.xyz(), h, s, l), c.w}; });
+        modify_colors(ctx, "Hue/saturation",
+                      [h, s, l](const float4 &c, int2, int) { return float4{adjust_HSL(c.xyz(), h, s, l), c.w}; });
     }
 
 private:
@@ -359,14 +351,13 @@ private:
 class BrightnessContrast final : public EditCommand
 {
 public:
-    Info info() const override
+    BrightnessContrast() :
+        EditCommand({{"Brightness/contrast...", "Levels", "Tone curve"},
+                     ICON_MY_BRIGHTNESS_CONTRAST,
+                     ImGuiKey_None,
+                     "Apply",
+                     27.f})
     {
-        return {{"Brightness/contrast...", "Levels", "Tone curve"},
-                ICON_MY_BRIGHTNESS_CONTRAST,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Apply",
-                27.f};
     }
 
     void draw(EditContext &) override
@@ -402,7 +393,7 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -418,8 +409,8 @@ public:
 
         if (m_channel == Channel_RGB)
         {
-            ctx.modify_colors("Brightness/contrast", [curve](const float4 &c, int2)
-                              { return float4{curve(c.x), curve(c.y), curve(c.z), c.w}; });
+            modify_colors(ctx, "Brightness/contrast", [curve](const float4 &c, int2, int)
+                          { return float4{curve(c.x), curve(c.y), curve(c.z), c.w}; });
             return;
         }
 
@@ -430,21 +421,21 @@ public:
         const float3   white    = img->chromaticities ? XYZ_from_xy(img->chromaticities->white) : Lab_reference_white();
         const bool     lightness = m_channel == Channel_Lightness;
 
-        ctx.modify_colors("Brightness/contrast",
-                          [curve, to_XYZ, from_XYZ, white, lightness](const float4 &c, int2)
+        modify_colors(ctx, "Brightness/contrast",
+                      [curve, to_XYZ, from_XYZ, white, lightness](const float4 &c, int2, int)
+                      {
+                          float3 lab = normalize_Lab(XYZ_to_Lab(mul(to_XYZ, c.xyz()), white));
+
+                          if (lightness)
+                              lab.x = curve(lab.x);
+                          else
                           {
-                              float3 lab = normalize_Lab(XYZ_to_Lab(mul(to_XYZ, c.xyz()), white));
+                              lab.y = curve(lab.y);
+                              lab.z = curve(lab.z);
+                          }
 
-                              if (lightness)
-                                  lab.x = curve(lab.x);
-                              else
-                              {
-                                  lab.y = curve(lab.y);
-                                  lab.z = curve(lab.z);
-                              }
-
-                              return float4{mul(from_XYZ, Lab_to_XYZ(unnormalize_Lab(lab), white)), c.w};
-                          });
+                          return float4{mul(from_XYZ, Lab_to_XYZ(unnormalize_Lab(lab), white)), c.w};
+                      });
     }
 
 private:
@@ -576,13 +567,12 @@ private:
 class Flatten final : public EditCommand
 {
 public:
-    Info info() const override
+    Flatten() :
+        EditCommand({{"Flatten...", "Composite over a background", "Remove transparency"},
+                     ICON_MY_FLATTEN,
+                     ImGuiKey_None,
+                     "Flatten"})
     {
-        return {{"Flatten...", "Composite over a background", "Remove transparency"},
-                ICON_MY_FLATTEN,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Flatten"};
     }
 
     void draw(EditContext &ctx) override
@@ -596,20 +586,20 @@ public:
 
         // the color the viewport is already showing behind the image
         if (ImGui::Button("Use viewport background"))
-            m_bg = ctx.background_color();
+            m_bg = ctx.background;
         ImGui::Tooltip("Takes the custom background color from the View menu.");
     }
 
     void apply(EditContext &ctx) override
     {
         const float4 b = m_bg;
-        ctx.modify_colors("Flatten",
-                          [b](const float4 &c, int2)
-                          {
-                              // samples are held premultiplied, so "over" is an addition and not the
-                              // textbook's lerp; the background is given straight and premultiplied here
-                              return float4{c.xyz() + b.xyz() * b.w * (1.f - c.w), c.w + b.w * (1.f - c.w)};
-                          });
+        modify_colors(ctx, "Flatten",
+                      [b](const float4 &c, int2, int)
+                      {
+                          // samples are held premultiplied, so "over" is an addition and not the
+                          // textbook's lerp; the background is given straight and premultiplied here
+                          return float4{c.xyz() + b.xyz() * b.w * (1.f - c.w), c.w + b.w * (1.f - c.w)};
+                      });
     }
 
 private:

--- a/src/edit/commands/color.cpp
+++ b/src/edit/commands/color.cpp
@@ -27,7 +27,6 @@
 
 namespace
 {
-
 class ConvertColorSpace final : public EditCommand
 {
 public:
@@ -35,10 +34,10 @@ public:
         EditCommand({{"Convert color space...", "Change primaries", "Change white point", "Gamut conversion"},
                      ICON_MY_COLORSPACE,
                      ImGuiKey_None,
+                     true,
                      "Convert",
                      27.f})
     {
-        m_info.has_dialog = true;
     }
 
     /// The file's own tag, so a conversion starts from what the pixels are.
@@ -158,10 +157,13 @@ class ChannelMixer final : public EditCommand
 {
 public:
     ChannelMixer() :
-        EditCommand(
-            {{"Channel mixer...", "Mix channels", "Monochrome"}, ICON_MY_CHANNEL_MIXER, ImGuiKey_None, "Mix", 27.f})
+        EditCommand({{"Channel mixer...", "Mix channels", "Monochrome"},
+                     ICON_MY_CHANNEL_MIXER,
+                     ImGuiKey_None,
+                     true,
+                     "Mix",
+                     27.f})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -253,10 +255,13 @@ class HueSaturation final : public EditCommand
 {
 public:
     HueSaturation() :
-        EditCommand(
-            {{"Hue/saturation...", "Colorize", "Desaturate"}, ICON_MY_HUE_SATURATION, ImGuiKey_None, "Apply", 27.f})
+        EditCommand({{"Hue/saturation...", "Colorize", "Desaturate"},
+                     ICON_MY_HUE_SATURATION,
+                     ImGuiKey_None,
+                     true,
+                     "Apply",
+                     27.f})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -358,10 +363,10 @@ public:
         EditCommand({{"Brightness/contrast...", "Levels", "Tone curve"},
                      ICON_MY_BRIGHTNESS_CONTRAST,
                      ImGuiKey_None,
+                     true,
                      "Apply",
                      27.f})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -575,9 +580,9 @@ public:
         EditCommand({{"Flatten...", "Composite over a background", "Remove transparency"},
                      ICON_MY_FLATTEN,
                      ImGuiKey_None,
+                     true,
                      "Flatten"})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &ctx) override

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -43,6 +43,8 @@ public:
                      "Remap",
                      27.f})
     {
+        m_info.has_dialog = true;
+
         // reparameterizes the whole image, so there is no subject to narrow
         m_info.draws_subject_selector = false;
     }
@@ -125,7 +127,7 @@ public:
         }
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const auto s = EnvMapping(m_src_mapping), d = EnvMapping(m_dst_mapping);
         const int2 out_size = m_size;
@@ -136,9 +138,9 @@ public:
             return;
 
         // no bias: the level the footprint asks for is the right one
-        ctx.modify_image_async("Remap envmap", out_size,
-                               [s, d, out_size, ss, mode](const Array2Df &src, AtomicProgress p)
-                               { return remapped_envmap(src, out_size, d, s, mode, ss, 0.f, p); });
+        ctx.resample_image_async("Remap envmap", out_size,
+                                 [s, d, out_size, ss, mode](const Array2Df &src, AtomicProgress p)
+                                 { return remapped_envmap(src, out_size, d, s, mode, ss, 0.f, p); });
     }
 
 private:
@@ -160,6 +162,8 @@ public:
                      "Convolve",
                      27.f})
     {
+        m_info.has_dialog = true;
+
         m_info.draws_subject_selector = false;
     }
 
@@ -185,7 +189,7 @@ public:
                        "nine numbers however large it is written out.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const auto m        = EnvMapping(m_mapping);
         const int2 out_size = m_size;
@@ -193,8 +197,8 @@ public:
         if (out_size.x <= 0 || out_size.y <= 0)
             return;
 
-        ctx.modify_image_async("Irradiance envmap", out_size, [m, out_size](const Array2Df &src, AtomicProgress p)
-                               { return irradiance_envmap(src, out_size, m, p); });
+        ctx.resample_image_async("Irradiance envmap", out_size, [m, out_size](const Array2Df &src, AtomicProgress p)
+                                 { return irradiance_envmap(src, out_size, m, p); });
     }
 
 private:

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -21,7 +21,6 @@
 
 namespace
 {
-
 void mapping_combo(const char *label, int *value)
 {
     if (ImGui::BeginCombo(label, envmapping_name(*value)))
@@ -40,11 +39,10 @@ public:
         EditCommand({{"Remap envmap...", "Change environment map format", "Spherical remapping"},
                      ICON_MY_ENVMAP,
                      ImGuiKey_None,
+                     true,
                      "Remap",
                      27.f})
     {
-        m_info.has_dialog = true;
-
         // reparameterizes the whole image, so there is no subject to narrow
         m_info.draws_subject_selector = false;
     }
@@ -159,11 +157,10 @@ public:
         EditCommand({{"Irradiance envmap...", "Diffuse convolution", "Cosine convolution"},
                      ICON_MY_IRRADIANCE,
                      ImGuiKey_None,
+                     true,
                      "Convolve",
                      27.f})
     {
-        m_info.has_dialog = true;
-
         m_info.draws_subject_selector = false;
     }
 

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -36,23 +36,21 @@ void mapping_combo(const char *label, int *value)
 class Remap final : public EditCommand
 {
 public:
-    Info info() const override
+    Remap() :
+        EditCommand({{"Remap envmap...", "Change environment map format", "Spherical remapping"},
+                     ICON_MY_ENVMAP,
+                     ImGuiKey_None,
+                     "Remap",
+                     27.f})
     {
-        Info i{{"Remap envmap...", "Change environment map format", "Spherical remapping"},
-               ICON_MY_ENVMAP,
-               ImGuiKey_None,
-               ImGuiInputFlags_None,
-               "Remap",
-               27.f};
         // reparameterizes the whole image, so there is no subject to narrow
-        i.draws_subject_selector = false;
-        return i;
+        m_info.draws_subject_selector = false;
     }
 
     /// Opens at the current image's size, then follows the target mapping's aspect.
     void on_open(EditContext &ctx) override
     {
-        if (auto img = ctx.image())
+        if (auto img = ctx.image)
         {
             m_size = img->size();
             if (m_auto_aspect)
@@ -63,7 +61,7 @@ public:
 
     void draw(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -155,29 +153,27 @@ private:
 class Irradiance final : public EditCommand
 {
 public:
-    Info info() const override
+    Irradiance() :
+        EditCommand({{"Irradiance envmap...", "Diffuse convolution", "Cosine convolution"},
+                     ICON_MY_IRRADIANCE,
+                     ImGuiKey_None,
+                     "Convolve",
+                     27.f})
     {
-        Info i{{"Irradiance envmap...", "Diffuse convolution", "Cosine convolution"},
-               ICON_MY_IRRADIANCE,
-               ImGuiKey_None,
-               ImGuiInputFlags_None,
-               "Convolve",
-               27.f};
-        i.draws_subject_selector = false;
-        return i;
+        m_info.draws_subject_selector = false;
     }
 
     /// The current image's size, since the result is usually looked at beside it.
     void on_open(EditContext &ctx) override
     {
-        if (auto img = ctx.image())
+        if (auto img = ctx.image)
             m_size = img->size();
     }
     void on_close(EditContext &) override { m_size = int2{0}; }
 
     void draw(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (img && (m_size.x <= 0 || m_size.y <= 0))
             m_size = img->size();
 

--- a/src/edit/commands/filter.cpp
+++ b/src/edit/commands/filter.cpp
@@ -51,7 +51,7 @@ void border_fields(int *border_x, int *border_y, bool *linked, const char *toolt
 class Blur final : public EditCommand
 {
 public:
-    Blur() : EditCommand({{"Blur...", "Gaussian blur", "Box blur"}, ICON_MY_BLUR}) {}
+    Blur() : EditCommand({{"Blur...", "Gaussian blur", "Box blur"}, ICON_MY_BLUR}) { m_info.has_dialog = true; }
 
     void draw(EditContext &) override
     {
@@ -92,7 +92,7 @@ public:
         }
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         if (m_kind == Kind_Box)
         {
@@ -139,7 +139,7 @@ private:
 class UnsharpMask final : public EditCommand
 {
 public:
-    UnsharpMask() : EditCommand({{"Unsharp mask...", "Sharpen"}, ICON_MY_SHARPEN}) {}
+    UnsharpMask() : EditCommand({{"Unsharp mask...", "Sharpen"}, ICON_MY_SHARPEN}) { m_info.has_dialog = true; }
 
     void draw(EditContext &) override
     {
@@ -150,7 +150,7 @@ public:
         ImGui::Tooltip("How much of what the blur removed is added back. Zero changes nothing.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float s = m_sigma, a = m_amount;
         ctx.modify_channels_async("Unsharp mask", [s, a](const Array2Df &src, const Box2i &r, int, AtomicProgress p)
@@ -164,7 +164,10 @@ private:
 class Median final : public EditCommand
 {
 public:
-    Median() : EditCommand({{"Median filter...", "Remove fireflies and outliers"}, ICON_MY_MEDIAN}) {}
+    Median() : EditCommand({{"Median filter...", "Remove fireflies and outliers"}, ICON_MY_MEDIAN})
+    {
+        m_info.has_dialog = true;
+    }
 
     void draw(EditContext &) override
     {
@@ -177,7 +180,7 @@ public:
                        "would cause. Costs the area of the disc per sample, so a large radius is slow.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float r = m_radius;
         const bool  d = m_disc;
@@ -196,6 +199,7 @@ class Shift final : public EditCommand
 public:
     Shift() : EditCommand({{"Shift...", "Offset", "Translate", "Wrap around"}, ICON_MY_SHIFT, ImGuiKey_None, "Shift"})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -222,7 +226,7 @@ public:
                        "has to ask.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float2 d  = m_offset;
         const int    s  = m_sampler;
@@ -245,6 +249,7 @@ public:
     ZapGremlins() :
         EditCommand({{"Zap gremlins...", "Replace NaNs and infinities"}, ICON_MY_ZAP_GREMLINS, ImGuiKey_None, "Zap"})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &ctx) override
@@ -272,7 +277,7 @@ public:
         ImGui::EndDisabled();
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         if (m_mode == Mode_Median)
             ctx.modify_channels_async("Zap gremlins", [](const Array2Df &src, const Box2i &r, int, AtomicProgress)
@@ -307,6 +312,7 @@ public:
                      "Convert",
                      27.f})
     {
+        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -329,7 +335,7 @@ public:
                        "is a convention it chooses, and the two are commonly called OpenGL and DirectX.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)
@@ -371,7 +377,7 @@ public:
                               return sum / 3.f;
                           };
 
-                          // forward differences: the finest slope the samples can express
+                          // forward differences: the finest slope the pixels can express
                           const float h00 = height(p);
                           const float dx  = height(p + int2{1, 0}) - h00;
                           const float dy  = height(p + int2{0, 1}) - h00;

--- a/src/edit/commands/filter.cpp
+++ b/src/edit/commands/filter.cpp
@@ -23,7 +23,6 @@
 
 namespace
 {
-
 /// The border-mode pair the resampling commands offer.
 void border_fields(int *border_x, int *border_y, bool *linked, const char *tooltip)
 {
@@ -51,7 +50,7 @@ void border_fields(int *border_x, int *border_y, bool *linked, const char *toolt
 class Blur final : public EditCommand
 {
 public:
-    Blur() : EditCommand({{"Blur...", "Gaussian blur", "Box blur"}, ICON_MY_BLUR}) { m_info.has_dialog = true; }
+    Blur() : EditCommand({{"Blur...", "Gaussian blur", "Box blur"}, ICON_MY_BLUR, ImGuiKey_None, true}) {}
 
     void draw(EditContext &) override
     {
@@ -139,7 +138,7 @@ private:
 class UnsharpMask final : public EditCommand
 {
 public:
-    UnsharpMask() : EditCommand({{"Unsharp mask...", "Sharpen"}, ICON_MY_SHARPEN}) { m_info.has_dialog = true; }
+    UnsharpMask() : EditCommand({{"Unsharp mask...", "Sharpen"}, ICON_MY_SHARPEN, ImGuiKey_None, true}) {}
 
     void draw(EditContext &) override
     {
@@ -164,9 +163,8 @@ private:
 class Median final : public EditCommand
 {
 public:
-    Median() : EditCommand({{"Median filter...", "Remove fireflies and outliers"}, ICON_MY_MEDIAN})
+    Median() : EditCommand({{"Median filter...", "Remove fireflies and outliers"}, ICON_MY_MEDIAN, ImGuiKey_None, true})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -197,9 +195,9 @@ private:
 class Shift final : public EditCommand
 {
 public:
-    Shift() : EditCommand({{"Shift...", "Offset", "Translate", "Wrap around"}, ICON_MY_SHIFT, ImGuiKey_None, "Shift"})
+    Shift() :
+        EditCommand({{"Shift...", "Offset", "Translate", "Wrap around"}, ICON_MY_SHIFT, ImGuiKey_None, true, "Shift"})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override
@@ -247,9 +245,9 @@ class ZapGremlins final : public EditCommand
 {
 public:
     ZapGremlins() :
-        EditCommand({{"Zap gremlins...", "Replace NaNs and infinities"}, ICON_MY_ZAP_GREMLINS, ImGuiKey_None, "Zap"})
+        EditCommand(
+            {{"Zap gremlins...", "Replace NaNs and infinities"}, ICON_MY_ZAP_GREMLINS, ImGuiKey_None, true, "Zap"})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &ctx) override
@@ -309,10 +307,10 @@ public:
         EditCommand({{"Bump to normal map...", "Height to normal", "Normal map"},
                      ICON_MY_NORMAL_MAP,
                      ImGuiKey_None,
+                     true,
                      "Convert",
                      27.f})
     {
-        m_info.has_dialog = true;
     }
 
     void draw(EditContext &) override

--- a/src/edit/commands/filter.cpp
+++ b/src/edit/commands/filter.cpp
@@ -13,6 +13,7 @@
 
 #include "edit/commands.h"
 
+#include "edit/edit_ops.h"
 #include "edit/filters.h"
 #include "fonts.h"
 #include "image.h"
@@ -50,7 +51,7 @@ void border_fields(int *border_x, int *border_y, bool *linked, const char *toolt
 class Blur final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Blur...", "Gaussian blur", "Box blur"}, ICON_MY_BLUR}; }
+    Blur() : EditCommand({{"Blur...", "Gaussian blur", "Box blur"}, ICON_MY_BLUR}) {}
 
     void draw(EditContext &) override
     {
@@ -138,7 +139,7 @@ private:
 class UnsharpMask final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Unsharp mask...", "Sharpen"}, ICON_MY_SHARPEN}; }
+    UnsharpMask() : EditCommand({{"Unsharp mask...", "Sharpen"}, ICON_MY_SHARPEN}) {}
 
     void draw(EditContext &) override
     {
@@ -163,7 +164,7 @@ private:
 class Median final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Median filter...", "Remove fireflies and outliers"}, ICON_MY_MEDIAN}; }
+    Median() : EditCommand({{"Median filter...", "Remove fireflies and outliers"}, ICON_MY_MEDIAN}) {}
 
     void draw(EditContext &) override
     {
@@ -193,13 +194,8 @@ private:
 class Shift final : public EditCommand
 {
 public:
-    Info info() const override
+    Shift() : EditCommand({{"Shift...", "Offset", "Translate", "Wrap around"}, ICON_MY_SHIFT, ImGuiKey_None, "Shift"})
     {
-        return {{"Shift...", "Offset", "Translate", "Wrap around"},
-                ICON_MY_SHIFT,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Shift"};
     }
 
     void draw(EditContext &) override
@@ -231,8 +227,8 @@ public:
         const float2 d  = m_offset;
         const int    s  = m_sampler;
         const int    bx = m_border_x, by = m_link_borders ? m_border_x : m_border_y;
-        ctx.modify_channels("Shift", [d, s, bx, by](const Array2Df &src, const Box2i &r)
-                            { return shifted(src, r, d.x, d.y, s, bx, by); });
+        ctx.modify_channels_async("Shift", [d, s, bx, by](const Array2Df &src, const Box2i &r, int, AtomicProgress)
+                                  { return shifted(src, r, d.x, d.y, s, bx, by); });
     }
 
 private:
@@ -246,13 +242,9 @@ private:
 class ZapGremlins final : public EditCommand
 {
 public:
-    Info info() const override
+    ZapGremlins() :
+        EditCommand({{"Zap gremlins...", "Replace NaNs and infinities"}, ICON_MY_ZAP_GREMLINS, ImGuiKey_None, "Zap"})
     {
-        return {{"Zap gremlins...", "Replace NaNs and infinities"},
-                ICON_MY_ZAP_GREMLINS,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Zap"};
     }
 
     void draw(EditContext &ctx) override
@@ -261,7 +253,7 @@ public:
                            "replace them with a specified color, or with the median of their neighborhood.");
         ImGui::Spacing();
 
-        if (auto img = ctx.image())
+        if (auto img = ctx.image)
             if (auto *stats = img->channels[img->groups[img->selected_group].channels[0]].get_stats())
                 if (stats->computed)
                     ImGui::TextFmt("{} NaN and {} infinite samples in this channel.", stats->summary.nan_pixels,
@@ -283,14 +275,14 @@ public:
     void apply(EditContext &ctx) override
     {
         if (m_mode == Mode_Median)
-            ctx.modify_channels("Zap gremlins",
-                                [](const Array2Df &src, const Box2i &r) { return zapped_gremlins(src, r); });
+            ctx.modify_channels_async("Zap gremlins", [](const Array2Df &src, const Box2i &r, int, AtomicProgress)
+                                      { return zapped_gremlins(src, r); });
         else
         {
             // per channel, so the chosen color reaches the component it belongs to
             const float4 v = m_value;
-            ctx.modify_pixels("Zap gremlins",
-                              [v](float s, int2, int slot) { return std::isfinite(s) ? s : v[slot % 4]; });
+            modify_pixels(ctx, "Zap gremlins",
+                          [v](float s, int2, int slot) { return std::isfinite(s) ? s : v[slot % 4]; });
         }
     }
 
@@ -308,14 +300,13 @@ private:
 class BumpToNormal final : public EditCommand
 {
 public:
-    Info info() const override
+    BumpToNormal() :
+        EditCommand({{"Bump to normal map...", "Height to normal", "Normal map"},
+                     ICON_MY_NORMAL_MAP,
+                     ImGuiKey_None,
+                     "Convert",
+                     27.f})
     {
-        return {{"Bump to normal map...", "Height to normal", "Normal map"},
-                ICON_MY_NORMAL_MAP,
-                ImGuiKey_None,
-                ImGuiInputFlags_None,
-                "Convert",
-                27.f};
     }
 
     void draw(EditContext &) override
@@ -340,8 +331,15 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
+            return;
+
+        // the heights are read from a copy of the image, so a slope never straddles a normal already
+        // written; the groups are taken with it, since the copy derives its own from the channel names
+        auto       src    = img->duplicate();
+        const auto groups = img->groups;
+        if (!src)
             return;
 
         // slopes in the image's own coordinates, so height is per unit of the whole image and the same
@@ -349,30 +347,42 @@ public:
         const float2 size{float(img->size().x), float(img->size().y)};
         const float  s      = m_scale;
         const float  y_sign = m_flip_y ? -1.f : 1.f;
+        const int    bx = m_border_x, by = m_link_borders ? m_border_x : m_border_y;
 
-        ctx.modify_neighborhood(
-            "Bump to normal map",
-            [s, size, y_sign](const std::function<float4(int2)> &read, int2 p)
-            {
-                auto height = [&read](int2 q)
-                {
-                    const float4 c = read(q);
-                    return (c.x + c.y + c.z) / 3.f;
-                };
+        modify_colors(ctx, "Bump to normal map",
+                      [src, groups, s, size, y_sign, bx, by](const float4 &, int2 p, int g)
+                      {
+                          // reads anywhere in the channel, not merely the selection; only past the image itself
+                          // does the border mode decide what is there
+                          auto height = [&](int2 q)
+                          {
+                              const int4 channels = groups[size_t(g)].channels;
+                              const int2 extent   = src->channels[size_t(channels[0])].size();
+                              const int  x        = wrap_coord(q.x - src->data_window.min.x, extent.x, bx);
+                              const int  y        = wrap_coord(q.y - src->data_window.min.y, extent.y, by);
 
-                // forward differences: the finest slope the samples can express
-                const float h00 = height(p);
-                const float dx  = height(p + int2{1, 0}) - h00;
-                const float dy  = height(p + int2{0, 1}) - h00;
+                              // where the border mode says there is nothing, no height either
+                              if (x < 0 || y < 0)
+                                  return 0.f;
 
-                // the surface z = h(x,y) has normal (-dh/dx, -dh/dy, 1), the sign folded into the scale
-                float3 n = la::normalize(float3{s * dx * size.x, y_sign * s * dy * size.y, 1.f});
+                              // a color group's first three channels; its alpha says nothing about height
+                              float sum = 0.f;
+                              for (int k = 0; k < 3; ++k) sum += src->channels[size_t(channels[k])](x, y);
+                              return sum / 3.f;
+                          };
 
-                // into the [0,1] range a normal map is stored in, where flat is (0.5, 0.5, 1)
-                n = n * 0.5f + 0.5f;
-                return float4{n, 1.f};
-            },
-            m_border_x, m_link_borders ? m_border_x : m_border_y);
+                          // forward differences: the finest slope the samples can express
+                          const float h00 = height(p);
+                          const float dx  = height(p + int2{1, 0}) - h00;
+                          const float dy  = height(p + int2{0, 1}) - h00;
+
+                          // the surface z = h(x,y) has normal (-dh/dx, -dh/dy, 1), the sign folded into the scale
+                          float3 n = la::normalize(float3{s * dx * size.x, y_sign * s * dy * size.y, 1.f});
+
+                          // into the [0,1] range a normal map is stored in, where flat is (0.5, 0.5, 1)
+                          n = n * 0.5f + 0.5f;
+                          return float4{n, 1.f};
+                      });
     }
 
 private:

--- a/src/edit/commands/mipmap.cpp
+++ b/src/edit/commands/mipmap.cpp
@@ -21,7 +21,6 @@
 
 namespace
 {
-
 /// How many levels an image of \p size has, counting the image itself, down to a single sample.
 int level_count(int2 size) { return 1 + int(std::floor(std::log2(float(std::max(1, std::max(size.x, size.y)))))); }
 
@@ -37,11 +36,10 @@ public:
         EditCommand({{"Generate mipmaps...", "Build a mip pyramid", "Halve repeatedly"},
                      ICON_MY_CHANNEL_GROUP,
                      ImGuiKey_None,
+                     true,
                      "Generate",
                      26.f})
     {
-        m_info.has_dialog = true;
-
         // rewrites the whole image into a pyramid, so there is no subject to narrow
         m_info.draws_subject_selector = false;
     }

--- a/src/edit/commands/mipmap.cpp
+++ b/src/edit/commands/mipmap.cpp
@@ -33,35 +33,33 @@ int level_count(int2 size) { return 1 + int(std::floor(std::log2(float(std::max(
 class GenerateMipmaps final : public EditCommand
 {
 public:
-    Info info() const override
+    GenerateMipmaps() :
+        EditCommand({{"Generate mipmaps...", "Build a mip pyramid", "Halve repeatedly"},
+                     ICON_MY_CHANNEL_GROUP,
+                     ImGuiKey_None,
+                     "Generate",
+                     26.f})
     {
-        Info i{{"Generate mipmaps...", "Build a mip pyramid", "Halve repeatedly"},
-               ICON_MY_CHANNEL_GROUP,
-               ImGuiKey_None,
-               ImGuiInputFlags_None,
-               "Generate",
-               26.f};
         // rewrites the whole image into a pyramid, so there is no subject to narrow
-        i.draws_subject_selector = false;
-        return i;
+        m_info.draws_subject_selector = false;
     }
 
     bool enabled(const EditContext &ctx) const override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         return img && level_count(img->size()) > 1;
     }
 
     void on_open(EditContext &ctx) override
     {
         // the whole chain by default, clamped to what this image has
-        if (auto img = ctx.image())
+        if (auto img = ctx.image)
             m_levels = std::min(m_levels, level_count(img->size()) - 1);
     }
 
     void draw(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -86,7 +84,7 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 

--- a/src/edit/commands/mipmap.cpp
+++ b/src/edit/commands/mipmap.cpp
@@ -40,6 +40,8 @@ public:
                      "Generate",
                      26.f})
     {
+        m_info.has_dialog = true;
+
         // rewrites the whole image into a pyramid, so there is no subject to narrow
         m_info.draws_subject_selector = false;
     }
@@ -82,7 +84,7 @@ public:
             ImGui::TextDisabled("... down to mip %d", m_levels);
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)

--- a/src/edit/commands/tonal.cpp
+++ b/src/edit/commands/tonal.cpp
@@ -33,7 +33,7 @@ class Invert final : public EditCommand
 public:
     Invert() : EditCommand({{"Invert", "Negative"}, ICON_MY_INVERT, ImGuiMod_Ctrl | ImGuiKey_I}) {}
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         modify_pixels(ctx, "Invert", [](float v, int2, int) { return 1.f - v; });
     }
@@ -44,7 +44,7 @@ class Clamp final : public EditCommand
 public:
     Clamp() : EditCommand({{"Clamp to [0,1]", "Clip to LDR range"}, ICON_MY_CLAMP}) {}
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         modify_pixels(ctx, "Clamp to [0,1]", [](float v, int2, int) { return std::min(1.f, std::max(0.f, v)); });
     }
@@ -53,7 +53,7 @@ public:
 class ExposureGamma final : public EditCommand
 {
 public:
-    ExposureGamma() : EditCommand({{"Exposure/gamma..."}, ICON_MY_EXPOSURE}) {}
+    ExposureGamma() : EditCommand({{"Exposure/gamma..."}, ICON_MY_EXPOSURE}) { m_info.has_dialog = true; }
 
     void draw(EditContext &) override
     {
@@ -93,7 +93,7 @@ public:
         m_plot.end();
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float scale = std::pow(2.f, m_exposure);
         const float inv_g = 1.f / std::max(MIN_GAMMA, m_gamma);
@@ -116,7 +116,7 @@ private:
 class Fill final : public EditCommand
 {
 public:
-    Fill() : EditCommand({{"Fill..."}, ICON_MY_FILL, ImGuiKey_None, "Fill"}) {}
+    Fill() : EditCommand({{"Fill..."}, ICON_MY_FILL, ImGuiKey_None, "Fill"}) { m_info.has_dialog = true; }
 
     void draw(EditContext &ctx) override
     {
@@ -140,7 +140,7 @@ public:
                                            "nowhere to go. Blend over instead to use it as coverage.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const float4 c = m_color;
 

--- a/src/edit/commands/tonal.cpp
+++ b/src/edit/commands/tonal.cpp
@@ -14,6 +14,7 @@
 
 #include "colorspace.h"
 #include "common.h"
+#include "edit/edit_ops.h"
 #include "fonts.h"
 #include "image.h"
 #include "imgui_ext.h"
@@ -30,29 +31,29 @@ namespace
 class Invert final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Invert", "Negative"}, ICON_MY_INVERT, ImGuiMod_Ctrl | ImGuiKey_I}; }
+    Invert() : EditCommand({{"Invert", "Negative"}, ICON_MY_INVERT, ImGuiMod_Ctrl | ImGuiKey_I}) {}
 
     void apply(EditContext &ctx) override
     {
-        ctx.modify_pixels("Invert", [](float v, int2, int) { return 1.f - v; });
+        modify_pixels(ctx, "Invert", [](float v, int2, int) { return 1.f - v; });
     }
 };
 
 class Clamp final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Clamp to [0,1]", "Clip to LDR range"}, ICON_MY_CLAMP}; }
+    Clamp() : EditCommand({{"Clamp to [0,1]", "Clip to LDR range"}, ICON_MY_CLAMP}) {}
 
     void apply(EditContext &ctx) override
     {
-        ctx.modify_pixels("Clamp to [0,1]", [](float v, int2, int) { return std::min(1.f, std::max(0.f, v)); });
+        modify_pixels(ctx, "Clamp to [0,1]", [](float v, int2, int) { return std::min(1.f, std::max(0.f, v)); });
     }
 };
 
 class ExposureGamma final : public EditCommand
 {
 public:
-    Info info() const override { return {{"Exposure/gamma..."}, ICON_MY_EXPOSURE}; }
+    ExposureGamma() : EditCommand({{"Exposure/gamma..."}, ICON_MY_EXPOSURE}) {}
 
     void draw(EditContext &) override
     {
@@ -98,13 +99,13 @@ public:
         const float inv_g = 1.f / std::max(MIN_GAMMA, m_gamma);
         const float off   = m_offset;
 
-        ctx.modify_pixels("Exposure/gamma",
-                          [scale, off, inv_g](float v, int2, int)
-                          {
-                              // signed: a negative sample is meaningful in an HDR image and pow() of one
-                              // is not, so the curve is mirrored through the origin
-                              return spow(scale * v + off, inv_g);
-                          });
+        modify_pixels(ctx, "Exposure/gamma",
+                      [scale, off, inv_g](float v, int2, int)
+                      {
+                          // signed: a negative sample is meaningful in an HDR image and pow() of one
+                          // is not, so the curve is mirrored through the origin
+                          return spow(scale * v + off, inv_g);
+                      });
     }
 
 private:
@@ -115,10 +116,7 @@ private:
 class Fill final : public EditCommand
 {
 public:
-    Info info() const override
-    {
-        return {{"Fill..."}, ICON_MY_FILL, ImGuiKey_None, ImGuiInputFlags_None, "Fill", 24.f};
-    }
+    Fill() : EditCommand({{"Fill..."}, ICON_MY_FILL, ImGuiKey_None, "Fill"}) {}
 
     void draw(EditContext &ctx) override
     {
@@ -136,7 +134,7 @@ public:
                        "anywhere.");
 
         if (m_mode == Mode_Replace)
-            if (auto img = ctx.image(); img && img->is_valid_group(img->active_group_index(Target_Primary)))
+            if (auto img = ctx.image; img && img->is_valid_group(img->active_group_index(Target_Primary)))
                 if (!group_has_alpha(img->groups[size_t(img->active_group_index(Target_Primary))].type))
                     ImGui::TextUnformatted("This channel group has no alpha, so the color's alpha has\n"
                                            "nowhere to go. Blend over instead to use it as coverage.");
@@ -150,7 +148,7 @@ public:
         // means transparency. Both modes have to match that or the result is out by a factor of alpha.
         bool premultiplied = false;
         int  alpha_slot    = -1;
-        if (auto img = ctx.image(); img && img->is_valid_group(img->active_group_index(Target_Primary)))
+        if (auto img = ctx.image; img && img->is_valid_group(img->active_group_index(Target_Primary)))
         {
             const auto &group = img->groups[size_t(img->active_group_index(Target_Primary))];
             if (img->alpha_type != AlphaType_None && group_has_alpha(group.type))
@@ -166,19 +164,19 @@ public:
             // stored as given
             const float4 v = premultiplied ? float4{c.x * c.w, c.y * c.w, c.z * c.w, c.w} : c;
 
-            ctx.modify_pixels("Fill", [v](float, int2, int slot) { return v[slot % 4]; });
+            modify_pixels(ctx, "Fill", [v](float, int2, int slot) { return v[slot % 4]; });
         }
         else
         {
             // source-over: with premultiplied storage the color contributes a*c and what was there keeps
             // (1-a) of itself, the same expression for color and alpha alike
             const float a = c.w;
-            ctx.modify_pixels("Fill",
-                              [c, a, alpha_slot](float old, int2, int slot)
-                              {
-                                  const float src = (slot == alpha_slot) ? 1.f : c[slot % 4];
-                                  return a * src + (1.f - a) * old;
-                              });
+            modify_pixels(ctx, "Fill",
+                          [c, a, alpha_slot](float old, int2, int slot)
+                          {
+                              const float src = (slot == alpha_slot) ? 1.f : c[slot % 4];
+                              return a * src + (1.f - a) * old;
+                          });
         }
     }
 

--- a/src/edit/commands/tonal.cpp
+++ b/src/edit/commands/tonal.cpp
@@ -53,7 +53,7 @@ public:
 class ExposureGamma final : public EditCommand
 {
 public:
-    ExposureGamma() : EditCommand({{"Exposure/gamma..."}, ICON_MY_EXPOSURE}) { m_info.has_dialog = true; }
+    ExposureGamma() : EditCommand({{"Exposure/gamma..."}, ICON_MY_EXPOSURE, ImGuiKey_None, true}) {}
 
     void draw(EditContext &) override
     {
@@ -116,7 +116,7 @@ private:
 class Fill final : public EditCommand
 {
 public:
-    Fill() : EditCommand({{"Fill..."}, ICON_MY_FILL, ImGuiKey_None, "Fill"}) { m_info.has_dialog = true; }
+    Fill() : EditCommand({{"Fill..."}, ICON_MY_FILL, ImGuiKey_None, true, "Fill"}) {}
 
     void draw(EditContext &ctx) override
     {

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -22,7 +22,6 @@
 
 namespace
 {
-
 /// A flip or a quarter turn: its own inverse, or paired with the opposite one.
 /**
     Every sample survives, so this is reversed by performing the opposite and costs a few bytes of history.
@@ -172,11 +171,10 @@ public:
         EditCommand({{"Image size...", "Resize the image"},
                      ICON_MY_IMAGE_SIZE,
                      ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_I,
+                     true,
                      "Resize",
                      30.f})
     {
-        m_info.has_dialog = true;
-
         // replaces the image rather than writing into it, so the subject has nothing to say about it
         m_info.draws_subject_selector = false;
     }
@@ -235,10 +233,8 @@ class CanvasSize final : public EditCommand
 public:
     CanvasSize() :
         EditCommand(
-            {{"Canvas size..."}, ICON_MY_CANVAS_SIZE, ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C, "Resize", 30.f})
+            {{"Canvas size..."}, ICON_MY_CANVAS_SIZE, ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C, true, "Resize", 30.f})
     {
-        m_info.has_dialog = true;
-
         m_info.draws_subject_selector = false;
     }
 

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -37,7 +37,7 @@ public:
         m_info.draws_subject_selector = false;
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         modify_image(ctx, m_info.names.front(), m_forward, reversible(m_forward, m_backward));
     }
@@ -68,7 +68,7 @@ public:
         return box.has_volume() && box != img->data_window;
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img)
@@ -175,6 +175,8 @@ public:
                      "Resize",
                      30.f})
     {
+        m_info.has_dialog = true;
+
         // replaces the image rather than writing into it, so the subject has nothing to say about it
         m_info.draws_subject_selector = false;
     }
@@ -214,7 +216,7 @@ public:
             ImGui::TextUnformatted("Enlarging: samples are interpolated.");
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         const int2 out = m_size;
         if (m_have_size && out.x > 0 && out.y > 0)
@@ -235,6 +237,8 @@ public:
         EditCommand(
             {{"Canvas size..."}, ICON_MY_CANVAS_SIZE, ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C, "Resize", 30.f})
     {
+        m_info.has_dialog = true;
+
         m_info.draws_subject_selector = false;
     }
 
@@ -295,7 +299,7 @@ public:
             }
     }
 
-    void apply(EditContext &ctx) override
+    void apply(const EditContext &ctx) override
     {
         auto img = ctx.image;
         if (!img || !m_have_size)

--- a/src/edit/commands/transform.cpp
+++ b/src/edit/commands/transform.cpp
@@ -13,6 +13,7 @@
 
 #include "edit/commands.h"
 
+#include "edit/edit_ops.h"
 #include "fonts.h"
 #include "image.h"
 #include "imgui_ext.h"
@@ -30,59 +31,57 @@ class Geometric final : public EditCommand
 {
 public:
     Geometric(Info info, std::function<void(Image &)> forward, std::function<void(Image &)> backward) :
-        m_info(std::move(info)), m_forward(std::move(forward)), m_backward(std::move(backward))
+        EditCommand(std::move(info)), m_forward(std::move(forward)), m_backward(std::move(backward))
     {
         // moves every sample of every channel, so there is nothing for a scope to narrow
         m_info.draws_subject_selector = false;
     }
 
-    Info info() const override { return m_info; }
-
-    void apply(EditContext &ctx) override { ctx.modify_reversibly(m_info.names.front(), m_forward, m_backward); }
+    void apply(EditContext &ctx) override
+    {
+        modify_image(ctx, m_info.names.front(), m_forward, reversible(m_forward, m_backward));
+    }
 
 private:
-    Info                         m_info;
     std::function<void(Image &)> m_forward, m_backward;
 };
 
 class Crop final : public EditCommand
 {
 public:
-    Info info() const override
+    Crop() : EditCommand({{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C})
     {
-        Info i{{"Crop to selection"}, ICON_MY_CROP, ImGuiMod_Alt | ImGuiKey_C};
         // reshapes the image rather than writing into it, so the subject has nothing to say about it
-        i.draws_subject_selector = false;
-        return i;
+        m_info.draws_subject_selector = false;
     }
 
     /// Only when there is something to crop to, and it is not already the whole image.
     bool enabled(const EditContext &ctx) const override
     {
         // cropping to the whole image would do nothing
-        auto img = ctx.image();
-        if (!img || !ctx.selection().has_volume())
+        auto img = ctx.image;
+        if (!img || !ctx.roi.has_volume())
             return false;
 
-        Box2i box = ctx.selection();
+        Box2i box = ctx.roi;
         box.intersect(img->data_window);
         return box.has_volume() && box != img->data_window;
     }
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
         // enabled()'s conditions again, per image: a fan-out reaches images the rectangle misses, or
         // already is, and neither is a crop
-        Box2i box = ctx.selection();
+        Box2i box = ctx.roi;
         box.intersect(img->data_window);
         if (!box.has_volume() || box == img->data_window)
             return;
 
-        ctx.modify_structure("Crop to selection", [box](Image &i) { i.crop(box); });
+        modify_image(ctx, "Crop to selection", [box](Image &i) { i.crop(box); }, structure_undo, Extent_Structure);
 
         // what was selected is now the whole image
         ctx.set_selection(Box2i{});
@@ -169,23 +168,21 @@ void size_fields(int2 *size, int *units, bool *locked, int2 original, int lower)
 class ImageSize final : public EditCommand
 {
 public:
-    Info info() const override
+    ImageSize() :
+        EditCommand({{"Image size...", "Resize the image"},
+                     ICON_MY_IMAGE_SIZE,
+                     ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_I,
+                     "Resize",
+                     30.f})
     {
-        Info i{{"Image size...", "Resize the image"},
-               ICON_MY_IMAGE_SIZE,
-               ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_I,
-               ImGuiInputFlags_None,
-               "Resize",
-               30.f};
         // replaces the image rather than writing into it, so the subject has nothing to say about it
-        i.draws_subject_selector = false;
-        return i;
+        m_info.draws_subject_selector = false;
     }
 
     /// Opens on the image's own size, and does not carry it to the next one.
     void on_open(EditContext &ctx) override
     {
-        if (auto img = ctx.image())
+        if (auto img = ctx.image)
             m_size = img->size();
         m_have_size = true;
     }
@@ -193,7 +190,7 @@ public:
 
     void draw(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -221,7 +218,7 @@ public:
     {
         const int2 out = m_size;
         if (m_have_size && out.x > 0 && out.y > 0)
-            ctx.modify_structure("Image size", [out](Image &i) { i.resample(out); });
+            modify_image(ctx, "Image size", [out](Image &i) { i.resample(out); }, structure_undo, Extent_Structure);
     }
 
 private:
@@ -234,16 +231,11 @@ private:
 class CanvasSize final : public EditCommand
 {
 public:
-    Info info() const override
+    CanvasSize() :
+        EditCommand(
+            {{"Canvas size..."}, ICON_MY_CANVAS_SIZE, ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C, "Resize", 30.f})
     {
-        Info i{{"Canvas size..."},
-               ICON_MY_CANVAS_SIZE,
-               ImGuiMod_Alt | ImGuiMod_Ctrl | ImGuiKey_C,
-               ImGuiInputFlags_None,
-               "Resize",
-               30.f};
-        i.draws_subject_selector = false;
-        return i;
+        m_info.draws_subject_selector = false;
     }
 
     /// Opens describing the canvas as it is: its own size, or, given relatively, no change at all.
@@ -252,7 +244,7 @@ public:
     */
     void on_open(EditContext &ctx) override
     {
-        if (auto img = ctx.image())
+        if (auto img = ctx.image)
             m_size = m_relative ? int2{0} : img->size();
         m_have_size = true;
     }
@@ -260,7 +252,7 @@ public:
 
     void draw(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img)
             return;
 
@@ -305,13 +297,14 @@ public:
 
     void apply(EditContext &ctx) override
     {
-        auto img = ctx.image();
+        auto img = ctx.image;
         if (!img || !m_have_size)
             return;
 
         const int2 out = m_relative ? la::max(img->size() + m_size, int2{1}) : la::max(m_size, int2{1});
         const auto a   = m_anchor;
-        ctx.modify_structure("Canvas size", [out, a](Image &i) { i.resize_canvas(out, a); });
+        modify_image(
+            ctx, "Canvas size", [out, a](Image &i) { i.resize_canvas(out, a); }, structure_undo, Extent_Structure);
     }
 
 private:

--- a/src/edit/edit_ops.cpp
+++ b/src/edit/edit_ops.cpp
@@ -38,7 +38,7 @@ std::vector<int> subject_groups(const Image &img, const EditSubject &subject)
 /**
     \p op fills the staging arrays for the rows [y0, y1) of the rectangle: one array per entry of
     \p channels, each sized to the rectangle and indexed from its corner. Nothing reaches the image until
-    every row is staged, so an op may read the samples it is replacing.
+    every row is staged, so an op may read the pixels it is replacing.
 */
 void write_rect(Image &image, const std::vector<int> &channels, const Box2i &bounds,
                 const function<void(int y0, int y1, std::vector<Array2Df> &staging)> &op)
@@ -53,7 +53,7 @@ void write_rect(Image &image, const std::vector<int> &channels, const Box2i &bou
     stp::parallel_for(stp::blocked_range<int>(0, extent.y, block_size),
                       [&](int y0, int y1, int, int) { op(y0, y1, staging); });
 
-    // upload_tile() writes the samples and pushes just this rectangle to the GPU
+    // upload_tile() writes the pixels and pushes just this rectangle to the GPU
     for (size_t i = 0; i < channels.size(); ++i)
         image.channels[size_t(channels[i])].upload_tile(Box2i{offset, offset + extent}, staging[i].data());
 }
@@ -151,7 +151,7 @@ bool modify_image(const EditContext &ctx, const string &name, const function<voi
 
     spdlog::debug("Editing '{}': {}", img->filename, name);
 
-    // a statistics task reads these samples from a worker thread, so it has to be off them before the
+    // a statistics task reads these pixels from a worker thread, so it has to be off them before the
     // write, and before the undo entry reads them
     for (auto &c : img->channels) c.cancel_stats();
 
@@ -264,7 +264,7 @@ bool modify_colors(const EditContext &ctx, const string &name, const function<fl
         },
         [&channels, &bounds, &retag](const Image &image, const string &n) -> UndoPtr
         {
-            // the samples and what they mean changed together, so they are taken back together
+            // the pixels and what they mean changed together, so they are taken back together
             if (retag)
                 return std::make_unique<ColorMetadataUndo>(image, channels, bounds, n);
             return std::make_unique<ChannelRectUndo>(image, channels, bounds, n);

--- a/src/edit/edit_ops.cpp
+++ b/src/edit/edit_ops.cpp
@@ -1,0 +1,272 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include "edit/edit_ops.h"
+
+#include "image.h"
+
+#include <numeric>
+#include <smallthreadpool.h>
+#include <spdlog/spdlog.h>
+
+using std::function;
+using std::string;
+
+namespace
+{
+
+/// The groups \p subject's scope names, before any filtering by what they contain.
+std::vector<int> subject_groups(const Image &img, const EditSubject &subject)
+{
+    std::vector<int> groups;
+    if (subject.scope == EditSubject::Scope_AllChannels)
+    {
+        for (int g = 0; g < int(img.groups.size()); ++g) groups.push_back(g);
+    }
+    else if (subject.scope == EditSubject::Scope_SelectedGroups)
+        groups = img.selected_groups();
+    else if (int g = img.active_group_index(Target_Primary); img.is_valid_group(g))
+        groups.push_back(g);
+
+    return groups;
+}
+
+/// Compute a rectangle of one or more channels in parallel, then upload it.
+/**
+    \p op fills the staging arrays for the rows [y0, y1) of the rectangle: one array per entry of
+    \p channels, each sized to the rectangle and indexed from its corner. Nothing reaches the image until
+    every row is staged, so an op may read the samples it is replacing.
+*/
+void write_rect(Image &image, const std::vector<int> &channels, const Box2i &bounds,
+                const function<void(int y0, int y1, std::vector<Array2Df> &staging)> &op)
+{
+    const int2 offset = bounds.min - image.data_window.min;
+    const int2 extent = bounds.size();
+
+    std::vector<Array2Df> staging(channels.size());
+    for (auto &s : staging) s = Array2Df{extent};
+
+    const int block_size = std::max(1, 1024 * 1024 / std::max(1, extent.x));
+    stp::parallel_for(stp::blocked_range<int>(0, extent.y, block_size),
+                      [&](int y0, int y1, int, int) { op(y0, y1, staging); });
+
+    // upload_tile() writes the samples and pushes just this rectangle to the GPU
+    for (size_t i = 0; i < channels.size(); ++i)
+        image.channels[size_t(channels[i])].upload_tile(Box2i{offset, offset + extent}, staging[i].data());
+}
+
+} // namespace
+
+bool can_edit(const ConstImagePtr &img) { return img && !img->is_live; }
+
+std::vector<int> target_groups(const ConstImagePtr &img, int pointed_at)
+{
+    if (!img)
+        return {};
+
+    // a group pointed at from the Images panel names itself alone, unless it is one of the selected
+    // ones, in which case the right-click covers the selection, the same way a click inside one does
+    if (pointed_at >= 0 && !img->is_group_selected(pointed_at))
+        return {pointed_at};
+
+    // the fallback is for an image the panel has never had a say over: one a command just produced, or
+    // a test driving a command directly
+    std::vector<int> groups = img->selected_groups();
+    if (groups.empty() && img->is_valid_group(img->active_group_index(Target_Primary)))
+        groups.push_back(img->active_group_index(Target_Primary));
+
+    return groups;
+}
+
+std::vector<int> subject_channels(const Image &img, const EditSubject &subject)
+{
+    // every channel, not the union of every group's, so one belonging to no group is still covered
+    if (subject.scope == EditSubject::Scope_AllChannels)
+    {
+        std::vector<int> channels(img.channels.size());
+        std::iota(channels.begin(), channels.end(), 0);
+        return channels;
+    }
+
+    std::vector<int> channels;
+    for (int g : subject_groups(img, subject))
+    {
+        const auto &group = img.groups[size_t(g)];
+        for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
+    }
+    return channels;
+}
+
+std::pair<std::vector<int>, std::vector<int>> subject_color_groups(const Image &img, const EditSubject &subject)
+{
+    std::vector<int> groups = subject_groups(img, subject);
+
+    groups.erase(std::remove_if(groups.begin(), groups.end(),
+                                [&img](int g)
+                                {
+                                    const auto t = img.groups[size_t(g)].type;
+                                    return t != ChannelGroup::RGB_Channels && t != ChannelGroup::RGBA_Channels;
+                                }),
+                 groups.end());
+
+    // every channel of every covered group, which is the set an undo entry has to hold
+    std::vector<int> channels;
+    for (int g : groups)
+    {
+        const auto &group = img.groups[size_t(g)];
+        for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
+    }
+
+    return {groups, channels};
+}
+
+std::pair<std::vector<int>, Box2i> resolve_subject(const ConstImagePtr &img, const EditSubject &subject,
+                                                   const Box2i &roi)
+{
+    if (!img)
+        return {std::vector<int>{}, Box2i{}};
+
+    std::vector<int> channels = subject_channels(*img, subject);
+
+    Box2i bounds = img->data_window;
+    // an empty selection means "no selection", not "select nothing"
+    if (subject.selection_only && roi.has_volume())
+        bounds.intersect(roi);
+
+    return {channels, bounds};
+}
+
+bool modify_image(const EditContext &ctx, const string &name, const function<void(Image &)> &op,
+                  const UndoFactory &make_undo, EditExtent extent)
+{
+    const ImagePtr &img = ctx.image;
+    if (!can_edit(img))
+    {
+        spdlog::warn("Cannot edit '{}': its pixels come from a running process.", img ? img->filename : "");
+        return false;
+    }
+
+    spdlog::debug("Editing '{}': {}", img->filename, name);
+
+    // a statistics task reads these samples from a worker thread, so it has to be off them before the
+    // write, and before the undo entry reads them
+    for (auto &c : img->channels) c.cancel_stats();
+
+    // built first: an entry that stores pixels has to see them as they were
+    auto entry = make_undo(*img, name);
+
+    op(*img);
+
+    if (entry)
+        img->history.add(std::move(entry));
+
+    // the channel list changed wholesale, so the layers and groups built from its names are rebuilt
+    if (extent == Extent_Structure)
+        img->rebuild_layers();
+
+    ++img->content_version; // invalidates the cached statistics and histograms
+
+    if (ctx.edited)
+        ctx.edited(extent);
+
+    return true;
+}
+
+bool modify_pixels(const EditContext &ctx, const string &name, const function<float(float, int2, int)> &op)
+{
+    auto [channels, bounds] = resolve_subject(ctx.image, ctx.subject, ctx.roi);
+    if (channels.empty() || !bounds.has_volume())
+        return false;
+
+    return modify_image(
+        ctx, name,
+        [&channels, &bounds, &op](Image &image)
+        {
+            const int2 offset = bounds.min - image.data_window.min;
+            const int2 extent = bounds.size();
+
+            for (size_t slot = 0; slot < channels.size(); ++slot)
+            {
+                const Channel &channel = image.channels[size_t(channels[slot])];
+
+                write_rect(image, {channels[slot]}, bounds,
+                           [&](int y0, int y1, std::vector<Array2Df> &staging)
+                           {
+                               for (int y = y0; y < y1; ++y)
+                                   for (int x = 0; x < extent.x; ++x)
+                                       staging[0](x, y) = op(channel(offset.x + x, offset.y + y),
+                                                             int2{bounds.min.x + x, bounds.min.y + y}, int(slot));
+                           });
+            }
+        },
+        [&channels, &bounds](const Image &image, const string &n) -> UndoPtr
+        { return std::make_unique<ChannelRectUndo>(image, channels, bounds, n); });
+}
+
+bool modify_colors(const EditContext &ctx, const string &name, const function<float4(const float4 &, int2, int)> &op,
+                   const function<void(Image &)> &retag)
+{
+    if (!ctx.image)
+        return false;
+
+    auto [groups, channels] = subject_color_groups(*ctx.image, ctx.subject);
+    if (groups.empty())
+    {
+        // e.g. an ungrouped image or a depth pass: nothing here is color
+        spdlog::warn("'{}' covers no color channel group of '{}'.", name, ctx.image->file_and_partname());
+        return false;
+    }
+
+    Box2i bounds = ctx.image->data_window;
+    if (ctx.subject.selection_only && ctx.roi.has_volume())
+        bounds.intersect(ctx.roi);
+    if (!bounds.has_volume())
+        return false;
+
+    return modify_image(
+        ctx, name,
+        [&groups, &bounds, &op, &retag](Image &image)
+        {
+            const int2 offset = bounds.min - image.data_window.min;
+            const int2 extent = bounds.size();
+
+            for (int g : groups)
+            {
+                const int        n = image.groups[size_t(g)].num_channels;
+                std::vector<int> group_channels;
+                for (int k = 0; k < n; ++k) group_channels.push_back(image.groups[size_t(g)].channels[k]);
+
+                write_rect(image, group_channels, bounds,
+                           [&](int y0, int y1, std::vector<Array2Df> &staging)
+                           {
+                               for (int y = y0; y < y1; ++y)
+                                   for (int x = 0; x < extent.x; ++x)
+                                   {
+                                       // opaque where the group has no alpha, so an op may read the fourth
+                                       // component whatever kind of group it was handed
+                                       float4 c{0.f, 0.f, 0.f, 1.f};
+                                       for (int k = 0; k < n; ++k)
+                                           c[k] = image.channels[size_t(group_channels[size_t(k)])](offset.x + x,
+                                                                                                    offset.y + y);
+
+                                       const float4 out = op(c, int2{bounds.min.x + x, bounds.min.y + y}, g);
+
+                                       for (int k = 0; k < n; ++k) staging[size_t(k)](x, y) = out[k];
+                                   }
+                           });
+            }
+
+            if (retag)
+                retag(image);
+        },
+        [&channels, &bounds, &retag](const Image &image, const string &n) -> UndoPtr
+        {
+            // the samples and what they mean changed together, so they are taken back together
+            if (retag)
+                return std::make_unique<ColorMetadataUndo>(image, channels, bounds, n);
+            return std::make_unique<ChannelRectUndo>(image, channels, bounds, n);
+        });
+}

--- a/src/edit/edit_ops.h
+++ b/src/edit/edit_ops.h
@@ -17,16 +17,12 @@
 #include <utility>
 #include <vector>
 
-/// Whether \p img accepts edits at all.
-/**
-    False while a renderer is streaming into it, since the next tile would overwrite the edit.
-*/
+/// Whether \p img accepts edits: false while a renderer is streaming into it, whose next tile would overwrite them.
 bool can_edit(const ConstImagePtr &img);
 
-/// The groups of \p img an edit acts on: normally the selected ones.
+/// The groups of \p img an edit acts on: the selected ones, or \p pointed_at alone when it is outside them.
 /**
-    \p pointed_at, when it names a group outside the selection, stands for itself. Falls back to the group
-    on screen for an image the Images panel has never had a say over.
+    An image the Images panel has never had a say over falls back to the group on screen.
 */
 std::vector<int> target_groups(const ConstImagePtr &img, int pointed_at = -1);
 
@@ -38,50 +34,46 @@ std::vector<int> target_groups(const ConstImagePtr &img, int pointed_at = -1);
 std::pair<std::vector<int>, Box2i> resolve_subject(const ConstImagePtr &img, const EditSubject &subject,
                                                    const Box2i &roi);
 
-//
-// The ways an image can be changed, each landing as one undoable edit. Every one of them cancels the
-// statistics tasks reading the samples, builds the undo entry from the image as it was, applies the
-// change, pushes the entry onto the image's history and invalidates the caches keyed on its samples.
-// All return whether anything was edited; false for an image that refuses edits or a subject that names
-// nothing. The async pair on EditContext ends up here too, once its worker is done.
-//
+/** \name Editing an image
+    Each lands as one undoable edit: it cancels the statistics tasks reading the pixels, builds the undo
+    entry from the image as it was, applies the change, pushes the entry onto the image's history and
+    invalidates the caches keyed on the pixels. All return whether anything was edited -- false for an image
+    that refuses edits, or a subject that names nothing. The async pair on EditContext ends up here too,
+    once its worker is done.
+*/
+///@{
 
+/// Apply \p op to the context's image and record how to reverse it; the only thing that writes pixels.
 /**
-    Apply \p op to the context's image and record how to reverse it. The only thing that writes image
-    pixels; the two below go through it.
-
     \param ctx       What is being edited
     \param name      Shown beside "Undo"/"Redo", e.g. "Rotate 90 CW"
     \param op        Makes the change
-    \param make_undo Builds the entry that reverses it, called before \p op so it can capture whatever
-                     \p op is about to overwrite
-    \param extent    Whether \p op reshapes the image, in which case the layer tree is rebuilt and the view
-                     refit afterwards
+    \param make_undo Builds the entry that reverses it, called before \p op so it can capture what \p op
+                     is about to overwrite
+    \param extent    Whether \p op reshapes the image, so the layer tree is rebuilt and the view refit
 */
 bool modify_image(const EditContext &ctx, const std::string &name, const std::function<void(Image &)> &op,
-                  const UndoFactory &make_undo, EditExtent extent = Extent_Samples);
+                  const UndoFactory &make_undo, EditExtent extent = Extent_Pixels);
 
+/// Apply \p op to every pixel the subject covers, one at a time.
 /**
-    Apply \p op to every sample the subject covers.
-
-    \p op is handed a sample, its position in image coordinates, and which of the subject's channels it
+    \p op is handed a value, its position in image coordinates, and which of the subject's channels it
     belongs to -- 0 for the first, so a group's R, G, B, A arrive as 0, 1, 2, 3 -- and returns what to
     replace it with. Both the GPU upload and the undo entry cover only the subject's rectangle.
 */
 bool modify_pixels(const EditContext &ctx, const std::string &name, const std::function<float(float, int2, int)> &op);
 
+/// Apply \p op to each covered group's channels together, so it can mix them into each other.
 /**
-    Apply \p op to each covered group's channels together: their values, the position in image coordinates,
-    and the group's index into Image::groups, which is how an op reads the group's other samples. Unlike
-    modify_pixels(), which sees one sample at a time, this can mix channels into each other, as a
-    color-space conversion or a channel mixer does.
+    \p op is handed the group's values, the position in image coordinates, and the group's index into
+    Image::groups, which is how it reads elsewhere in the group. Only color groups are covered, RGB and
+    RGBA; a group without alpha gets 1 in that slot and whatever \p op returns there is dropped.
 
-    Only color groups are covered, RGB and RGBA; the subject's other channels are left alone. A group
-    without alpha gets 1 in that slot and whatever \p op returns there is dropped.
-
-    \p retag, if given, updates the image's color metadata to describe what \p op produced, recorded in the
-    same history entry as the pixels so undoing takes back both.
+    \p retag, if given, retags the image's color metadata in the same history entry, so undoing takes back
+    both what \p op wrote and what it means.
 */
 bool modify_colors(const EditContext &ctx, const std::string &name,
                    const std::function<float4(const float4 &, int2, int)> &op,
                    const std::function<void(Image &)>                     &retag = {});
+
+///@}

--- a/src/edit/edit_ops.h
+++ b/src/edit/edit_ops.h
@@ -1,0 +1,87 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#pragma once
+
+#include "box.h"
+#include "edit/command.h"
+#include "edit/subject.h"
+#include "edit/undo.h"
+#include "fwd.h"
+
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+/// Whether \p img accepts edits at all.
+/**
+    False while a renderer is streaming into it, since the next tile would overwrite the edit.
+*/
+bool can_edit(const ConstImagePtr &img);
+
+/// The groups of \p img an edit acts on: normally the selected ones.
+/**
+    \p pointed_at, when it names a group outside the selection, stands for itself. Falls back to the group
+    on screen for an image the Images panel has never had a say over.
+*/
+std::vector<int> target_groups(const ConstImagePtr &img, int pointed_at = -1);
+
+/// The channels \p subject names, and the rectangle of them it covers, in image coordinates.
+/**
+    The rectangle is the data window, narrowed to \p roi when the subject asks for it. Empty means there is
+    nothing to edit.
+*/
+std::pair<std::vector<int>, Box2i> resolve_subject(const ConstImagePtr &img, const EditSubject &subject,
+                                                   const Box2i &roi);
+
+//
+// The ways an image can be changed, each landing as one undoable edit. Every one of them cancels the
+// statistics tasks reading the samples, builds the undo entry from the image as it was, applies the
+// change, pushes the entry onto the image's history and invalidates the caches keyed on its samples.
+// All return whether anything was edited; false for an image that refuses edits or a subject that names
+// nothing. The async pair on EditContext ends up here too, once its worker is done.
+//
+
+/**
+    Apply \p op to the context's image and record how to reverse it. The only thing that writes image
+    pixels; the two below go through it.
+
+    \param ctx       What is being edited
+    \param name      Shown beside "Undo"/"Redo", e.g. "Rotate 90 CW"
+    \param op        Makes the change
+    \param make_undo Builds the entry that reverses it, called before \p op so it can capture whatever
+                     \p op is about to overwrite
+    \param extent    Whether \p op reshapes the image, in which case the layer tree is rebuilt and the view
+                     refit afterwards
+*/
+bool modify_image(const EditContext &ctx, const std::string &name, const std::function<void(Image &)> &op,
+                  const UndoFactory &make_undo, EditExtent extent = Extent_Samples);
+
+/**
+    Apply \p op to every sample the subject covers.
+
+    \p op is handed a sample, its position in image coordinates, and which of the subject's channels it
+    belongs to -- 0 for the first, so a group's R, G, B, A arrive as 0, 1, 2, 3 -- and returns what to
+    replace it with. Both the GPU upload and the undo entry cover only the subject's rectangle.
+*/
+bool modify_pixels(const EditContext &ctx, const std::string &name, const std::function<float(float, int2, int)> &op);
+
+/**
+    Apply \p op to each covered group's channels together: their values, the position in image coordinates,
+    and the group's index into Image::groups, which is how an op reads the group's other samples. Unlike
+    modify_pixels(), which sees one sample at a time, this can mix channels into each other, as a
+    color-space conversion or a channel mixer does.
+
+    Only color groups are covered, RGB and RGBA; the subject's other channels are left alone. A group
+    without alpha gets 1 in that slot and whatever \p op returns there is dropped.
+
+    \p retag, if given, updates the image's color metadata to describe what \p op produced, recorded in the
+    same history entry as the pixels so undoing takes back both.
+*/
+bool modify_colors(const EditContext &ctx, const std::string &name,
+                   const std::function<float4(const float4 &, int2, int)> &op,
+                   const std::function<void(Image &)>                     &retag = {});

--- a/src/edit/undo.cpp
+++ b/src/edit/undo.cpp
@@ -66,55 +66,37 @@ size_t ChannelRectUndo::memory_usage() const
     return total;
 }
 
-/// Everything about an image that says what its samples mean as color.
-struct ColorMetadataUndo::State
+ColorMetadataUndo::ColorMetadataUndo(const Image &img, std::vector<int> channels, const Box2i &bounds,
+                                     std::string name) :
+    m_pixels(img, std::move(channels), bounds, std::move(name)), m_chromaticities(img.chromaticities),
+    m_adopted_neutral(img.adopted_neutral), m_RGB_to_XYZ(img.M_RGB_to_XYZ), m_XYZ_to_RGB(img.M_XYZ_to_RGB),
+    m_to_sRGB(img.M_to_sRGB), m_luminance_weights(img.luminance_weights), m_adaptation_method(img.adaptation_method),
+    m_color_space(img.color_space), m_white_point(img.white_point),
+    m_color_profile(img.metadata.value<std::string>("color profile", ""))
 {
-    std::optional<Chromaticities> chromaticities;
-    std::optional<float2>         adopted_neutral;
-    float3x3                      M_RGB_to_XYZ, M_XYZ_to_RGB, M_to_sRGB;
-    float3                        luminance_weights;
-    AdaptationMethod              adaptation_method;
-    ColorGamut_                   color_space;
-    WhitePoint_                   white_point;
-    std::string                   color_profile; ///< metadata["color profile"], the panel's "Profile name"
-};
-
-ColorMetadataUndo::ColorMetadataUndo(const Image &img, std::string name) :
-    m_state(std::make_unique<State>()), m_name(std::move(name))
-{
-    m_state->chromaticities    = img.chromaticities;
-    m_state->adopted_neutral   = img.adopted_neutral;
-    m_state->M_RGB_to_XYZ      = img.M_RGB_to_XYZ;
-    m_state->M_XYZ_to_RGB      = img.M_XYZ_to_RGB;
-    m_state->M_to_sRGB         = img.M_to_sRGB;
-    m_state->luminance_weights = img.luminance_weights;
-    m_state->adaptation_method = img.adaptation_method;
-    m_state->color_space       = img.color_space;
-    m_state->white_point       = img.white_point;
-    m_state->color_profile     = img.metadata.value<std::string>("color profile", "");
 }
-
-ColorMetadataUndo::~ColorMetadataUndo() = default;
 
 void ColorMetadataUndo::swap(Image &img)
 {
-    std::swap(m_state->chromaticities, img.chromaticities);
-    std::swap(m_state->adopted_neutral, img.adopted_neutral);
-    std::swap(m_state->M_RGB_to_XYZ, img.M_RGB_to_XYZ);
-    std::swap(m_state->M_XYZ_to_RGB, img.M_XYZ_to_RGB);
-    std::swap(m_state->M_to_sRGB, img.M_to_sRGB);
-    std::swap(m_state->luminance_weights, img.luminance_weights);
-    std::swap(m_state->adaptation_method, img.adaptation_method);
-    std::swap(m_state->color_space, img.color_space);
-    std::swap(m_state->white_point, img.white_point);
+    m_pixels.undo(img); // swaps, whichever direction this is
+
+    std::swap(m_chromaticities, img.chromaticities);
+    std::swap(m_adopted_neutral, img.adopted_neutral);
+    std::swap(m_RGB_to_XYZ, img.M_RGB_to_XYZ);
+    std::swap(m_XYZ_to_RGB, img.M_XYZ_to_RGB);
+    std::swap(m_to_sRGB, img.M_to_sRGB);
+    std::swap(m_luminance_weights, img.luminance_weights);
+    std::swap(m_adaptation_method, img.adaptation_method);
+    std::swap(m_color_space, img.color_space);
+    std::swap(m_white_point, img.white_point);
 
     // an image whose profile was never named has no entry, not an empty one, so the panel falls back
     std::string current = img.metadata.value<std::string>("color profile", "");
-    if (m_state->color_profile.empty())
+    if (m_color_profile.empty())
         img.metadata.erase("color profile");
     else
-        img.metadata["color profile"] = m_state->color_profile;
-    m_state->color_profile = std::move(current);
+        img.metadata["color profile"] = m_color_profile;
+    m_color_profile = std::move(current);
 }
 
 void CommandHistory::add(UndoPtr entry)
@@ -223,4 +205,13 @@ size_t StructureUndo::memory_usage() const
     size_t total = 0;
     for (const auto &c : m_channels) total += size_t(c.num_elements()) * sizeof(float);
     return total;
+}
+
+UndoPtr structure_undo(const Image &img, const std::string &name) { return std::make_unique<StructureUndo>(img, name); }
+
+UndoFactory reversible(std::function<void(Image &)> forward, std::function<void(Image &)> backward)
+{
+    return [forward = std::move(forward), backward = std::move(backward)](const Image &,
+                                                                          const std::string &name) -> UndoPtr
+    { return std::make_unique<LambdaUndo>(name, backward, forward); };
 }

--- a/src/edit/undo.h
+++ b/src/edit/undo.h
@@ -20,7 +20,7 @@ struct Channel;
 
 /// One reversible change to an Image.
 /**
-    An entry restores principal data only: the samples and the windows they sit in. Derived data
+    An entry restores principal data only: the pixels and the windows they sit in. Derived data
     (textures, mip chains, statistics, the layer tree) is flagged for recomputation by whoever applies it.
 */
 class UndoEntry
@@ -94,10 +94,7 @@ private:
     std::vector<Array2Df> m_pixels; ///< One per entry of m_channels, sized to m_bounds
 };
 
-/// An image's whole channel list and windows, for cropping, resizing, and anything that adds or removes a channel.
-/**
-    Putting one back swaps the vectors, so the sample buffers move rather than copy.
-*/
+/// An image's whole channel list and windows, for cropping, resizing, and anything that adds or removes one.
 class StructureUndo : public UndoEntry
 {
 public:
@@ -119,12 +116,7 @@ private:
     Box2i                m_data_window, m_display_window;
 };
 
-/// What a color conversion changed: the samples, and the color metadata that says what they mean.
-/**
-    The metadata is every field compute_color_transform() reads or writes, plus the profile name. It goes
-    back with the pixels, so the image is never left describing itself with a profile its samples no longer
-    match.
-*/
+/// The pixels a color conversion rewrote and the color metadata describing them, taken back together.
 class ColorMetadataUndo : public UndoEntry
 {
 public:
@@ -198,12 +190,7 @@ public:
     /// Total bytes held by the entries.
     size_t memory_usage() const;
 
-    /// Largest total the entries may occupy before the oldest are dropped.
-    /**
-        Bounded by bytes rather than by count, since what threatens memory is one large structural edit and
-        not many small ones. Generous, since dropping an entry silently shortens how far back the user can
-        go.
-    */
+    /// Largest total the entries may occupy before the oldest are dropped; generous, since dropping one is silent.
     static constexpr size_t k_max_memory = size_t(1) << 30; // 1 GiB
 
 private:

--- a/src/edit/undo.h
+++ b/src/edit/undo.h
@@ -8,9 +8,11 @@
 
 #include "array2d.h"
 #include "box.h"
+#include "colorspace.h"
 #include "fwd.h"
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,9 +40,9 @@ public:
 
 using UndoPtr = std::unique_ptr<UndoEntry>;
 
-/// Specify the undo and redo commands using lambda expressions, storing no pixels at all.
+/// Undo and redo given as lambdas, storing no pixels at all.
 /**
-    For operations that re-derive their inverse: a flip, or a quarter turn the other way.
+    For the edits that re-derive their inverse: a flip, or a quarter turn the other way.
 */
 class LambdaUndo : public UndoEntry
 {
@@ -49,9 +51,6 @@ public:
         m_name(std::move(name)), m_undo(std::move(undo_fn)), m_redo(std::move(redo_fn))
     {
     }
-
-    /// An operation that is its own inverse; \p fn is used in both directions.
-    LambdaUndo(std::string name, std::function<void(Image &)> fn) : LambdaUndo(std::move(name), fn, fn) {}
 
     void        undo(Image &img) override { m_undo(img); }
     void        redo(Image &img) override { m_redo(img); }
@@ -95,7 +94,10 @@ private:
     std::vector<Array2Df> m_pixels; ///< One per entry of m_channels, sized to m_bounds
 };
 
-/// An image's whole channel list and windows, for cropping, resizing, and anything that adds or removes one.
+/// An image's whole channel list and windows, for cropping, resizing, and anything that adds or removes a channel.
+/**
+    Putting one back swaps the vectors, so the sample buffers move rather than copy.
+*/
 class StructureUndo : public UndoEntry
 {
 public:
@@ -117,64 +119,47 @@ private:
     Box2i                m_data_window, m_display_window;
 };
 
-/// Every field compute_color_transform() reads or writes, plus the profile name, as a color conversion found them.
+/// What a color conversion changed: the samples, and the color metadata that says what they mean.
 /**
-    Rides alongside the pixels in a CompositeUndo, since the two must undo together.
+    The metadata is every field compute_color_transform() reads or writes, plus the profile name. It goes
+    back with the pixels, so the image is never left describing itself with a profile its samples no longer
+    match.
 */
 class ColorMetadataUndo : public UndoEntry
 {
 public:
-    ColorMetadataUndo(const Image &img, std::string name);
-    /// Out of line because State is incomplete here and the pointer has to destroy it.
-    ~ColorMetadataUndo() override;
+    /// As ChannelRectUndo, and \p img's color metadata alongside.
+    ColorMetadataUndo(const Image &img, std::vector<int> channels, const Box2i &bounds, std::string name);
 
     void        undo(Image &img) override { swap(img); }
     void        redo(Image &img) override { swap(img); }
-    std::string name() const override { return m_name; }
+    std::string name() const override { return m_pixels.name(); }
+    size_t      memory_usage() const override { return m_pixels.memory_usage(); }
 
 private:
     void swap(Image &img);
 
-    struct State;
-    std::unique_ptr<State> m_state; ///< Out of line, since its members need image.h
-    std::string            m_name;
+    ChannelRectUndo               m_pixels;
+    std::optional<Chromaticities> m_chromaticities;
+    std::optional<float2>         m_adopted_neutral;
+    float3x3                      m_RGB_to_XYZ, m_XYZ_to_RGB, m_to_sRGB;
+    float3                        m_luminance_weights;
+    AdaptationMethod              m_adaptation_method;
+    ColorGamut_                   m_color_space;
+    WhitePoint_                   m_white_point;
+    std::string                   m_color_profile; ///< metadata["color profile"], the panel's "Profile name"
 };
 
-/// Several entries applied as one, undone in the opposite order to how they were built.
-class CompositeUndo : public UndoEntry
-{
-public:
-    CompositeUndo(std::string name, std::vector<UndoPtr> entries) :
-        m_name(std::move(name)), m_entries(std::move(entries))
-    {
-    }
+/// Builds the entry that reverses an edit, from the image as it was before it; see modify_image().
+using UndoFactory = std::function<UndoPtr(const Image &, const std::string &)>;
 
-    void undo(Image &img) override
-    {
-        for (auto it = m_entries.rbegin(); it != m_entries.rend(); ++it) (*it)->undo(img);
-    }
-    void redo(Image &img) override
-    {
-        for (auto &e : m_entries) e->redo(img);
-    }
-    std::string name() const override { return m_name; }
-    size_t      memory_usage() const override
-    {
-        size_t total = 0;
-        for (const auto &e : m_entries) total += e->memory_usage();
-        return total;
-    }
+/// Saves the whole channel list and the windows, for the edits that reshape the image.
+UndoPtr structure_undo(const Image &img, const std::string &name);
 
-private:
-    std::string          m_name;
-    std::vector<UndoPtr> m_entries;
-};
+/// An edit that re-derives its inverse: \p backward must undo \p forward, as a flip or a quarter turn does.
+UndoFactory reversible(std::function<void(Image &)> forward, std::function<void(Image &)> backward);
 
-/// An image's undo history: the entries applied so far, and a cursor into them.
-/**
-    Bounded by total bytes, since what threatens memory is one large structural edit and not many small
-    ones.
-*/
+/// An image's undo history: the entries applied so far, a cursor into them, and a bound on total bytes.
 class CommandHistory
 {
 public:
@@ -215,7 +200,9 @@ public:
 
     /// Largest total the entries may occupy before the oldest are dropped.
     /**
-        Generous, since dropping one silently shortens how far back the user can go.
+        Bounded by bytes rather than by count, since what threatens memory is one large structural edit and
+        not many small ones. Generous, since dropping an entry silently shortens how far back the user can
+        go.
     */
     static constexpr size_t k_max_memory = size_t(1) << 30; // 1 GiB
 

--- a/src/image.h
+++ b/src/image.h
@@ -602,6 +602,7 @@ public:
         it. HDRViewApp owns the rules relating the selection to the current and reference images.
     */
     ///@{
+
     /// Whether every channel of group \p index is selected.
     bool is_group_selected(int index) const
     {

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -733,7 +733,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 
         auto img = hdrview()->current_image();
 
-        // applied straight through modify_channels, so the comparison is of the filters themselves
+        // the filters called directly, so the comparison is of the filters themselves and not of the plumbing
         auto blurred_by = [&](int which)
         {
             const Box2i all{int2{0}, img->channels[0].size()};
@@ -971,12 +971,13 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         const auto original = snapshot(img);
 
         // the dialogs themselves, from the menu: everything above tests the operation, and an operation
-        // wired to nothing passes all of it
+        // wired to nothing passes all of it. Each waits for the entry, since a dialog may hand the work to
+        // a worker rather than do it in the frame that confirmed it.
         menu_click(ctx, "Edit/Shift...");
         ctx->SetRef("Shift...");
         ctx->ItemInputValue("X, Y offset/$$0", 3.0f);
         ctx->ItemClick("Shift");
-        ctx->Yield(2);
+        wait_until(ctx, [&] { return img->history.has_undo(); });
 
         IM_CHECK(snapshot(img) != original);
         IM_CHECK_STR_EQ(img->history.undo_name().c_str(), "Shift");
@@ -988,7 +989,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         ctx->SetRef("Convert color space...");
         ctx->ComboClick("Primaries##to/ACES AP0");
         ctx->ItemClick("Convert");
-        ctx->Yield(2);
+        wait_until(ctx, [&] { return img->history.has_undo(); });
 
         IM_CHECK(snapshot(img) != original);
         IM_CHECK_STR_EQ(img->history.undo_name().c_str(), "Convert color space");
@@ -1003,7 +1004,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         ctx->SetRef("Channel mixer...");
         ctx->ItemClick("Monochrome");
         ctx->ItemClick("Mix");
-        ctx->Yield(2);
+        wait_until(ctx, [&] { return img->history.has_undo(); });
 
         IM_CHECK(snapshot(img) != original);
         IM_CHECK_STR_EQ(img->history.undo_name().c_str(), "Channel mixer");
@@ -1031,7 +1032,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         ctx->SetRef("Hue\\/saturation...");
         ctx->ItemInputValue("Saturation", -100.0f);
         ctx->ItemClick("Apply");
-        ctx->Yield(2);
+        wait_until(ctx, [&] { return img->history.has_undo(); });
 
         IM_CHECK(snapshot(img) != original);
         IM_CHECK_STR_EQ(img->history.undo_name().c_str(), "Hue/saturation");
@@ -1042,7 +1043,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         menu_click(ctx, "Edit/Flatten...");
         ctx->SetRef("Flatten...");
         ctx->ItemClick("Flatten");
-        ctx->Yield(2);
+        wait_until(ctx, [&] { return img->history.has_undo(); });
 
         IM_CHECK(snapshot(img) != original);
         IM_CHECK_STR_EQ(img->history.undo_name().c_str(), "Flatten");
@@ -1053,7 +1054,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         menu_click(ctx, "Edit/Bump to normal map...");
         ctx->SetRef("Bump to normal map...");
         ctx->ItemClick("Convert");
-        ctx->Yield(2);
+        wait_until(ctx, [&] { return img->history.has_undo(); });
 
         IM_CHECK(snapshot(img) != original);
         IM_CHECK_STR_EQ(img->history.undo_name().c_str(), "Bump to normal map");
@@ -1210,8 +1211,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         auto img = hdrview()->current_image();
 
         // a depth channel beside the color, the ordinary shape of a render: a color matrix has no meaning
-        // for it, so covering "all channels" must still not touch it. Added through the structural
-        // chokepoint, which rebuilds the layer tree and the visibility the Images panel walks.
+        // for it, so covering "all channels" must still not touch it. Added through modify_image() with a
+        // structural extent, which rebuilds the layer tree and the visibility the Images panel walks.
         modify_image(
             hdrview()->edit_context(img), "Add Z",
             [](Image &i)

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -29,6 +29,14 @@ using std::vector;
 namespace
 {
 
+/// The context the application builds for \p img, with \p subject standing in for the current one.
+EditContext edit_context(const ImagePtr &img, const EditSubject &subject)
+{
+    auto ctx    = hdrview()->edit_context(img);
+    ctx.subject = subject;
+    return ctx;
+}
+
 /// Loads the single-layer fixture and leaves it as the current image.
 bool load_fixture(ImGuiTestContext *ctx)
 {
@@ -129,8 +137,9 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         LogWatcher  log;
         EditSubject all_channels;
         all_channels.scope = EditSubject::Scope_AllChannels;
-        IM_CHECK_EQ(hdrview()->modify_colors(img, "Test", all_channels, [](const float4 &c, int2) { return -c; }),
-                    false);
+        IM_CHECK_EQ(
+            modify_colors(edit_context(img, all_channels), "Test", [](const float4 &c, int2, int) { return -c; }),
+            false);
 
         IM_CHECK(snapshot(img) == original);
         IM_CHECK_EQ((int)img->history.size(), entries);
@@ -370,7 +379,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         subject.selection_only = true;
 
         const auto before = snapshot(img);
-        IM_CHECK(hdrview()->modify_pixels(img, "Invert", subject, [](float v, int2, int) { return 1.f - v; }));
+        IM_CHECK(modify_pixels(edit_context(img, subject), "Invert", [](float v, int2, int) { return 1.f - v; }));
 
         const auto &ch = img->channels[img->groups[img->selected_group].channels[0]];
         const int2  o  = img->data_window.min;
@@ -406,8 +415,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         EditSubject group_scope, all_scope;
         all_scope.scope = EditSubject::Scope_AllChannels;
         if (!HDRViewApp::scope_matters(img))
-            IM_CHECK(hdrview()->resolve_subject(img, group_scope).first ==
-                     hdrview()->resolve_subject(img, all_scope).first);
+            IM_CHECK(resolve_subject(img, group_scope, hdrview()->roi()).first ==
+                     resolve_subject(img, all_scope, hdrview()->roi()).first);
     };
 
     t           = IM_REGISTER_TEST(engine, "edit", "a dialog changes nothing until it is confirmed");
@@ -458,8 +467,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         // not all come out the same
         const float4 color{0.25f, 0.5f, 0.75f, 1.f};
         EditSubject  subject;
-        IM_CHECK(
-            hdrview()->modify_pixels(img, "Fill", subject, [color](float, int2, int slot) { return color[slot % 4]; }));
+        IM_CHECK(modify_pixels(edit_context(img, subject), "Fill",
+                               [color](float, int2, int slot) { return color[slot % 4]; }));
 
         const auto &group = img->groups[img->selected_group];
         for (int c = 0; c < group.num_channels; ++c)
@@ -558,8 +567,9 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         const size_t layers = img->layers.size();
         const size_t groups = img->groups.size();
 
-        IM_CHECK(hdrview()->modify_structure(img, "Canvas size", [](Image &i)
-                                             { i.resize_canvas(i.size() + int2{4, 4}, Image::Anchor_MiddleCenter); }));
+        IM_CHECK(modify_image(
+            hdrview()->edit_context(img), "Canvas size", [](Image &i)
+            { i.resize_canvas(i.size() + int2{4, 4}, Image::Anchor_MiddleCenter); }, structure_undo, Extent_Structure));
 
         IM_CHECK(img->size() == int2{img->channels[0].size()});
         // rebuilt from the new channels, not left describing the old ones
@@ -916,9 +926,9 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         const bool needed = color_conversion_matrix(M, *original_chr, to, AdaptationMethod_Bradford);
         IM_CHECK(needed);
 
-        IM_CHECK(hdrview()->modify_colors(
-            img, "Convert color space", hdrview()->edit_subject(),
-            [M](const float4 &c, int2) { return float4{la::mul(M, c.xyz()), c.w}; },
+        IM_CHECK(modify_colors(
+            hdrview()->edit_context(img), "Convert color space",
+            [M](const float4 &c, int2, int) { return float4{la::mul(M, c.xyz()), c.w}; },
             [to](Image &image)
             {
                 image.chromaticities = to;
@@ -1062,12 +1072,12 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 
         // a color with all three channels different, so an edit touching one quality of it can be told
         // from one touching everything
-        IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(),
-                                          [](float, int2, int slot)
-                                          {
-                                              const float v[4] = {0.6f, 0.3f, 0.15f, 1.f};
-                                              return v[slot < 4 ? slot : 0];
-                                          }));
+        IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Fill",
+                               [](float, int2, int slot)
+                               {
+                                   const float v[4] = {0.6f, 0.3f, 0.15f, 1.f};
+                                   return v[slot < 4 ? slot : 0];
+                               }));
         ctx->Yield();
 
         const int4   ch    = img->groups[img->selected_group].channels;
@@ -1166,8 +1176,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 
         // reading the sample beside it is what modify_pixels() cannot do: it is handed one sample and told
         // which slot it is, never the others
-        IM_CHECK(hdrview()->modify_colors(img, "Swap red and blue", hdrview()->edit_subject(),
-                                          [](const float4 &c, int2) { return float4{c.z, c.y, c.x, c.w}; }));
+        IM_CHECK(modify_colors(hdrview()->edit_context(img), "Swap red and blue",
+                               [](const float4 &c, int2, int) { return float4{c.z, c.y, c.x, c.w}; }));
         ctx->Yield();
 
         const auto &r = img->channels[group.channels[0]];
@@ -1202,13 +1212,15 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         // a depth channel beside the color, the ordinary shape of a render: a color matrix has no meaning
         // for it, so covering "all channels" must still not touch it. Added through the structural
         // chokepoint, which rebuilds the layer tree and the visibility the Images panel walks.
-        hdrview()->modify_structure(img, "Add Z",
-                                    [](Image &i)
-                                    {
-                                        Channel z{"Z", i.channels[0].size()};
-                                        for (int k = 0; k < z.num_elements(); ++k) z(k) = 0.25f * float(k % 7);
-                                        i.channels.push_back(std::move(z));
-                                    });
+        modify_image(
+            hdrview()->edit_context(img), "Add Z",
+            [](Image &i)
+            {
+                Channel z{"Z", i.channels[0].size()};
+                for (int k = 0; k < z.num_elements(); ++k) z(k) = 0.25f * float(k % 7);
+                i.channels.push_back(std::move(z));
+            },
+            structure_undo, Extent_Structure);
         ctx->Yield();
 
         const int     zi = int(img->channels.size()) - 1;
@@ -1218,8 +1230,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         auto subject  = hdrview()->edit_subject();
         subject.scope = EditSubject::Scope_AllChannels;
 
-        IM_CHECK(hdrview()->modify_colors(img, "Halve", subject,
-                                          [](const float4 &c, int2) { return float4{0.5f * c.xyz(), c.w}; }));
+        IM_CHECK(modify_colors(edit_context(img, subject), "Halve",
+                               [](const float4 &c, int2, int) { return float4{0.5f * c.xyz(), c.w}; }));
         ctx->Yield();
 
         for (int i = 0; i < img->channels[zi].num_elements(); ++i) IM_CHECK_EQ(img->channels[zi](i), before[i]);
@@ -1291,14 +1303,13 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         // a known state to composite: half-transparent mid gray, premultiplied the way the image model
         // holds every RGBA group
         const float4 fg{0.25f, 0.25f, 0.25f, 0.5f};
-        IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(),
-                                          [fg](float, int2, int slot) { return fg[slot % 4]; }));
+        IM_CHECK(
+            modify_pixels(hdrview()->edit_context(img), "Fill", [fg](float, int2, int slot) { return fg[slot % 4]; }));
         ctx->Yield();
 
         const float4 bg{0.5f, 0.f, 0.f, 1.f};
-        IM_CHECK(hdrview()->modify_colors(
-            img, "Flatten", hdrview()->edit_subject(), [bg](const float4 &c, int2)
-            { return float4{c.xyz() + bg.xyz() * bg.w * (1.f - c.w), c.w + bg.w * (1.f - c.w)}; }));
+        IM_CHECK(modify_colors(hdrview()->edit_context(img), "Flatten", [bg](const float4 &c, int2, int)
+                               { return float4{c.xyz() + bg.xyz() * bg.w * (1.f - c.w), c.w + bg.w * (1.f - c.w)}; }));
         ctx->Yield();
 
         const auto &group = img->groups[img->active_group_index(Target_Primary)];
@@ -1314,9 +1325,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         // an opaque background makes it idempotent: there is nothing left for a second pass to show
         // through, which a lerp written against straight alpha would get wrong
         const auto once = snapshot(img);
-        IM_CHECK(hdrview()->modify_colors(
-            img, "Flatten", hdrview()->edit_subject(), [bg](const float4 &c, int2)
-            { return float4{c.xyz() + bg.xyz() * bg.w * (1.f - c.w), c.w + bg.w * (1.f - c.w)}; }));
+        IM_CHECK(modify_colors(hdrview()->edit_context(img), "Flatten", [bg](const float4 &c, int2, int)
+                               { return float4{c.xyz() + bg.xyz() * bg.w * (1.f - c.w), c.w + bg.w * (1.f - c.w)}; }));
         ctx->Yield();
         IM_CHECK(snapshot(img) == once);
 
@@ -1338,26 +1348,34 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         const int2 size = img->size();
 
         // a ramp rising to the right, so the answer is known: flat down the image, sloped across it
-        IM_CHECK(hdrview()->modify_pixels(img, "Ramp", hdrview()->edit_subject(), [size](float, int2 p, int slot)
-                                          { return slot >= 3 ? 1.f : float(p.x) / float(size.x); }));
+        IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Ramp", [size](float, int2 p, int slot)
+                               { return slot >= 3 ? 1.f : float(p.x) / float(size.x); }));
         ctx->Yield();
 
+        // the heights come from a copy, as the command's own do
         const float2 fsize{float(size.x), float(size.y)};
-        IM_CHECK(hdrview()->modify_neighborhood(
-            img, "Bump to normal map", hdrview()->edit_subject(),
-            [fsize](const std::function<float4(int2)> &read, int2 p)
-            {
-                auto height = [&read](int2 q)
-                {
-                    const float4 c = read(q);
-                    return (c.x + c.y + c.z) / 3.f;
-                };
-                const float h00 = height(p);
-                const float dx = height(p + int2{1, 0}) - h00, dy = height(p + int2{0, 1}) - h00;
-                float3      n = la::normalize(float3{dx * fsize.x, dy * fsize.y, 1.f});
-                return float4{n * 0.5f + 0.5f, 1.f};
-            },
-            BorderMode_Edge, BorderMode_Edge));
+        auto         src = img->duplicate();
+        const auto   grp = img->groups;
+        IM_CHECK(modify_colors(hdrview()->edit_context(img), "Bump to normal map",
+                               [fsize, src, grp](const float4 &, int2 p, int gi)
+                               {
+                                   auto height = [&](int2 q)
+                                   {
+                                       const int4 channels = grp[size_t(gi)].channels;
+                                       const int2 extent   = src->channels[size_t(channels[0])].size();
+                                       const int  x =
+                                           wrap_coord(q.x - src->data_window.min.x, extent.x, BorderMode_Edge);
+                                       const int y =
+                                           wrap_coord(q.y - src->data_window.min.y, extent.y, BorderMode_Edge);
+                                       float sum = 0.f;
+                                       for (int k = 0; k < 3; ++k) sum += src->channels[size_t(channels[k])](x, y);
+                                       return sum / 3.f;
+                                   };
+                                   const float h00 = height(p);
+                                   const float dx = height(p + int2{1, 0}) - h00, dy = height(p + int2{0, 1}) - h00;
+                                   float3      n = la::normalize(float3{dx * fsize.x, dy * fsize.y, 1.f});
+                                   return float4{n * 0.5f + 0.5f, 1.f};
+                               }));
         ctx->Yield();
 
         const auto &r = img->channels[group.channels[0]];
@@ -1413,8 +1431,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         IM_CHECK(snapshot(copy) == before);
 
         // ...and its own copy of it: a shallow copy would pass everything above and fail here
-        IM_CHECK(hdrview()->modify_pixels(copy, "Invert", hdrview()->edit_subject(),
-                                          [](float v, int2, int) { return 1.f - v; }));
+        IM_CHECK(modify_pixels(hdrview()->edit_context(copy), "Invert", [](float v, int2, int) { return 1.f - v; }));
         ctx->Yield();
         IM_CHECK(snapshot(copy) != before);
         IM_CHECK(snapshot(original) == before);
@@ -1479,8 +1496,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         const int2 size = img->size();
 
         // two known, different halves, so what lands where is unambiguous
-        IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(), [size](float, int2 p, int slot)
-                                          { return slot == 3 ? 1.f : (p.x < size.x / 2 ? 1.f : 0.f); }));
+        IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Fill", [size](float, int2 p, int slot)
+                               { return slot == 3 ? 1.f : (p.x < size.x / 2 ? 1.f : 0.f); }));
         ctx->Yield();
 
         const auto &ch = img->channels[img->groups[img->selected_group].channels[0]];
@@ -1671,8 +1688,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         const int2 patch{32, 32};
 
         // a flat background, so any step at the border is the paste's doing and not the picture's
-        IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(),
-                                          [](float, int2, int slot) { return slot == 3 ? 1.f : 0.25f; }));
+        IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Fill",
+                               [](float, int2, int slot) { return slot == 3 ? 1.f : 0.25f; }));
         ctx->Yield();
 
         // copy a corner, which is 0.25 throughout...
@@ -1686,8 +1703,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         // leave a visible step where 0.25 meets 0.8, and a seamless one cannot
         hdrview()->set_selection(Box2i{});
         ctx->Yield();
-        IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(),
-                                          [](float, int2, int slot) { return slot == 3 ? 1.f : 0.8f; }));
+        IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Fill",
+                               [](float, int2, int slot) { return slot == 3 ? 1.f : 0.8f; }));
         ctx->Yield();
 
         const Box2i dst_box{int2{size.x / 2, size.y / 2}, int2{size.x / 2, size.y / 2} + patch};
@@ -1787,8 +1804,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
             ctx->Yield();
 
             // a constant, so the copy taken from it has no gradients of its own to impose
-            IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(),
-                                              [](float, int2, int slot) { return slot == 3 ? 1.f : 0.5f; }));
+            IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Fill",
+                                   [](float, int2, int slot) { return slot == 3 ? 1.f : 0.5f; }));
             ctx->Yield();
 
             hdrview()->set_selection(Box2i{int2{0, 0}, patch});
@@ -1798,8 +1815,8 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 
             hdrview()->set_selection(Box2i{});
             ctx->Yield();
-            IM_CHECK(hdrview()->modify_pixels(img, "Fill", hdrview()->edit_subject(), [](float, int2 p, int slot)
-                                              { return slot == 3 ? 1.f : (((p.x / 4 + p.y / 4) % 2) ? 1.f : 0.f); }));
+            IM_CHECK(modify_pixels(hdrview()->edit_context(img), "Fill", [](float, int2 p, int slot)
+                                   { return slot == 3 ? 1.f : (((p.x / 4 + p.y / 4) % 2) ? 1.f : 0.f); }));
             ctx->Yield();
 
             hdrview()->set_selection(cfg.selection);
@@ -1900,10 +1917,9 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 
         // not only grayed out in the menu: the edit itself has to decline, since the command palette and
         // the keyboard chord reach the same callback
-        const auto before = snapshot(img);
-        IM_CHECK_EQ(hdrview()->modify_image_reversibly(
-                        img, "Flip image horizontally", [](Image &i) { i.flip_horizontal(); },
-                        [](Image &i) { i.flip_horizontal(); }),
+        const auto                         before = snapshot(img);
+        const std::function<void(Image &)> flip   = [](Image &i) { i.flip_horizontal(); };
+        IM_CHECK_EQ(modify_image(hdrview()->edit_context(img), "Flip image horizontally", flip, reversible(flip, flip)),
                     false);
         IM_CHECK(snapshot(img) == before);
         IM_CHECK_EQ(img->history.has_undo(), false);

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -7,13 +7,14 @@
 /** \file test_edit_commands.cpp
     \author Wojciech Jarosz
 
-    The edit commands driven through EditContext, so everything but the dialog runs with no window, GL
-    context or frame loop.
+    The edit commands and the functions they change images through, run with no window, GL context or
+    frame loop; everything but the dialogs.
 */
 
 #include <doctest/doctest.h>
 
 #include "edit/commands.h"
+#include "edit/edit_ops.h"
 #include "edit/subject.h"
 #include "image.h"
 
@@ -27,297 +28,85 @@
 namespace
 {
 
-/// EditContext over a bare Image: HDRViewApp's undo/subject rules, no textures, async ops running inline.
-class TestEditContext : public EditContext
+/// What the application hands a command, over a bare Image: no textures, worker thread or window.
+/**
+    The subject and target rules and the edit functions are the application's own; the async pair runs
+    inline.
+*/
+struct TestEditContext : EditContext
 {
-public:
-    explicit TestEditContext(ImagePtr img) : m_image(std::move(img)) {}
+    ImagePtr              clipboard_image; ///< what cut and copy write to
+    std::vector<ImagePtr> added;           ///< the images a command put beside the one it was given
 
-    ImagePtr           image() const override { return m_image; }
-    const EditSubject &subject() const override { return m_subject; }
+    explicit TestEditContext(ImagePtr img)
+    {
+        image     = std::move(img);
+        clipboard = &clipboard_image;
+        retarget();
 
-    /// Mirrors HDRViewApp::target_groups().
+        add_image = [this](ImagePtr made, std::string partname)
+        {
+            if (!made)
+                return;
+            made->partname = std::move(partname);
+            added.push_back(std::move(made));
+        };
+        set_selection = [this](const Box2i &box) { roi = box; };
+
+        modify_channels_async = [this](const std::string &name, const ChannelFilter &filter)
+        {
+            auto [channels, bounds] = resolve_subject(image, subject, roi);
+            if (channels.empty() || !bounds.has_volume())
+                return;
+
+            const int2  offset = bounds.min - image->data_window.min;
+            const Box2i local{offset, offset + bounds.size()};
+
+            std::vector<Array2Df> results;
+            for (size_t i = 0; i < channels.size(); ++i)
+                results.push_back(filter(image->channels[size_t(channels[i])], local, int(i), AtomicProgress{}));
+
+            modify_image(
+                *this, name,
+                [&](Image &img)
+                {
+                    for (size_t i = 0; i < channels.size(); ++i)
+                        img.channels[size_t(channels[i])].upload_tile(local, results[i].data());
+                },
+                [&](const Image &img, const std::string &n) -> UndoPtr
+                { return std::make_unique<ChannelRectUndo>(img, channels, bounds, n); });
+        };
+
+        modify_image_async = [this](const std::string &name, int2 size, const ImageFilter &op)
+        {
+            if (!image || size.x <= 0 || size.y <= 0)
+                return;
+
+            std::vector<Array2Df> results;
+            for (const auto &channel : image->channels) results.push_back(op(channel, AtomicProgress{}));
+
+            modify_image(
+                *this, name,
+                [&](Image &img)
+                {
+                    for (size_t i = 0; i < img.channels.size(); ++i)
+                    {
+                        img.channels[i].resize(size);
+                        std::copy(results[i].data(), results[i].data() + results[i].num_elements(),
+                                  img.channels[i].data());
+                    }
+                    img.data_window    = Box2i{img.data_window.min, img.data_window.min + size};
+                    img.display_window = img.data_window;
+                },
+                structure_undo, Extent_Structure);
+        };
+    }
+
+    /// Re-read which groups an edit acts on, as the application does each time it builds a context.
     /**
-        A group pointed at from outside the selection names itself alone, one inside it covers the selection,
-        and an image the panel never saw falls back to the group on screen.
+        \p pointed_at names a group the way right-clicking one in the Images panel does.
     */
-    std::vector<int> target_groups() const override
-    {
-        if (!m_image)
-            return {};
-
-        if (m_target_group >= 0 && !m_image->is_group_selected(m_target_group))
-            return {m_target_group};
-
-        std::vector<int> groups = m_image->selected_groups();
-        const int        shown  = m_image->active_group_index(Target_Primary);
-        if (groups.empty() && m_image->is_valid_group(shown))
-            groups.push_back(shown);
-        return groups;
-    }
-
-    /// Point at a group without selecting it, the way the Images panel's context menu does.
-    void          set_target_group(int group) { m_target_group = group; }
-    Box2i         selection() const override { return m_selection; }
-    void          set_selection(const Box2i &box) override { m_selection = box; }
-    float4        background_color() const override { return m_background; }
-    ConstImagePtr clipboard() const override { return m_clipboard; }
-    void          set_clipboard(ImagePtr img) override { m_clipboard = std::move(img); }
-    void          draw_subject_selector() override {}
-
-    /// Collected, so a command that produces images can be checked for what it made.
-    void add_image(ImagePtr img, const std::string &partname) override
-    {
-        if (!img)
-            return;
-        img->partname = partname;
-        m_added.push_back(std::move(img));
-    }
-
-    const std::vector<ImagePtr> &added_images() const { return m_added; }
-
-    EditSubject &mutable_subject() { return m_subject; }
-    void         set_background(float4 c) { m_background = c; }
-
-    /// Whether the last edit went through a chokepoint that takes the subject at all.
-    /**
-        Not the same question as Info::draws_subject_selector, which says only whether the dialog draws the
-        "Apply to" controls.
-    */
-    bool last_edit_used_subject() const { return m_used_subject; }
-
-    bool modify_pixels(const std::string &name, const std::function<float(float, int2, int)> &op) override
-    {
-        auto [channels, bounds] = resolve();
-        if (channels.empty() || !bounds.has_volume())
-            return false;
-
-        return edit(name, channels, bounds,
-                    [&](Image &img)
-                    {
-                        for (size_t i = 0; i < channels.size(); ++i)
-                            for (int y = bounds.min.y; y < bounds.max.y; ++y)
-                                for (int x = bounds.min.x; x < bounds.max.x; ++x)
-                                {
-                                    auto &ch = img.channels[size_t(channels[i])];
-                                    ch(x, y) = op(ch(x, y), int2{x, y}, int(i));
-                                }
-                    });
-    }
-
-    bool modify_colors(const std::string &name, const std::function<float4(const float4 &, int2)> &op,
-                       const std::function<void(Image &)> &retag = {}) override
-    {
-        auto [channels, bounds] = resolve();
-        if (channels.empty() || !bounds.has_volume())
-            return false;
-
-        const bool ok = edit(name, channels, bounds,
-                             [&](Image &img)
-                             {
-                                 const int n = int(channels.size());
-                                 for (int y = bounds.min.y; y < bounds.max.y; ++y)
-                                     for (int x = bounds.min.x; x < bounds.max.x; ++x)
-                                     {
-                                         float4 c{0.f, 0.f, 0.f, 1.f};
-                                         for (int i = 0; i < std::min(4, n); ++i)
-                                             c[i] = img.channels[size_t(channels[size_t(i)])](x, y);
-
-                                         const float4 out = op(c, int2{x, y});
-                                         for (int i = 0; i < std::min(4, n); ++i)
-                                             img.channels[size_t(channels[size_t(i)])](x, y) = out[i];
-                                     }
-                             });
-        if (ok && retag)
-            retag(*m_image);
-        return ok;
-    }
-
-    bool modify_neighborhood(const std::string                                                      &name,
-                             const std::function<float4(const std::function<float4(int2)> &, int2)> &op, int,
-                             int) override
-    {
-        auto [channels, bounds] = resolve();
-        if (channels.empty() || !bounds.has_volume())
-            return false;
-
-        // the reader sees the image as it was, so an op cannot read what it has already written
-        const Image before = snapshot();
-
-        return edit(name, channels, bounds,
-                    [&](Image &img)
-                    {
-                        const int n    = int(channels.size());
-                        auto      read = [&](int2 p)
-                        {
-                            float4     c{0.f, 0.f, 0.f, 1.f};
-                            const int2 q{std::clamp(p.x, 0, img.size().x - 1), std::clamp(p.y, 0, img.size().y - 1)};
-                            for (int i = 0; i < std::min(4, n); ++i)
-                                c[i] = before.channels[size_t(channels[size_t(i)])](q.x, q.y);
-                            return c;
-                        };
-
-                        for (int y = bounds.min.y; y < bounds.max.y; ++y)
-                            for (int x = bounds.min.x; x < bounds.max.x; ++x)
-                            {
-                                const float4 out = op(read, int2{x, y});
-                                for (int i = 0; i < std::min(4, n); ++i)
-                                    img.channels[size_t(channels[size_t(i)])](x, y) = out[i];
-                            }
-                    });
-    }
-
-    bool modify_channels(const std::string                                              &name,
-                         const std::function<Array2Df(const Array2Df &, const Box2i &)> &filter) override
-    {
-        auto [channels, bounds] = resolve();
-        if (channels.empty() || !bounds.has_volume())
-            return false;
-
-        return edit(name, channels, bounds,
-                    [&](Image &img)
-                    {
-                        for (int c : channels)
-                        {
-                            Channel       &ch  = img.channels[size_t(c)];
-                            const Array2Df out = filter(ch, bounds);
-                            for (int y = 0; y < bounds.size().y; ++y)
-                                for (int x = 0; x < bounds.size().x; ++x)
-                                    ch(bounds.min.x + x, bounds.min.y + y) = out(x, y);
-                        }
-                    });
-    }
-
-    void modify_channels_async(
-        const std::string                                                                   &name,
-        const std::function<Array2Df(const Array2Df &, const Box2i &, int, AtomicProgress)> &f) override
-    {
-        auto [channels, bounds] = resolve();
-        if (channels.empty() || !bounds.has_volume())
-            return;
-
-        edit(name, channels, bounds,
-             [&](Image &img)
-             {
-                 std::vector<Array2Df> results;
-                 results.reserve(channels.size());
-                 for (size_t i = 0; i < channels.size(); ++i)
-                     results.push_back(f(img.channels[size_t(channels[i])], bounds, int(i), AtomicProgress{}));
-
-                 for (size_t i = 0; i < channels.size(); ++i)
-                 {
-                     Channel &ch = img.channels[size_t(channels[i])];
-                     for (int y = 0; y < bounds.size().y; ++y)
-                         for (int x = 0; x < bounds.size().x; ++x)
-                             ch(bounds.min.x + x, bounds.min.y + y) = results[i](x, y);
-                 }
-             });
-    }
-
-    void modify_image_async(const std::string &name, int2 size,
-                            const std::function<Array2Df(const Array2Df &, AtomicProgress)> &op) override
-    {
-        if (!m_image || size.x <= 0 || size.y <= 0)
-            return;
-
-        auto entry = std::make_unique<StructureUndo>(*m_image, name);
-
-        std::vector<Array2Df> results;
-        results.reserve(m_image->channels.size());
-        for (auto &ch : m_image->channels) results.push_back(op(ch, AtomicProgress{}));
-
-        for (size_t i = 0; i < m_image->channels.size(); ++i)
-        {
-            m_image->channels[i].resize(size);
-            std::copy(results[i].data(), results[i].data() + results[i].num_elements(), m_image->channels[i].data());
-        }
-        m_image->data_window    = Box2i{m_image->data_window.min, m_image->data_window.min + size};
-        m_image->display_window = m_image->data_window;
-
-        m_image->history.add(std::move(entry));
-        ++m_image->content_version;
-    }
-
-    bool modify_structure(const std::string &name, const std::function<void(Image &)> &op) override
-    {
-        if (!m_image)
-            return false;
-
-        auto entry = std::make_unique<StructureUndo>(*m_image, name);
-        op(*m_image);
-        m_image->history.add(std::move(entry));
-        ++m_image->content_version;
-        return true;
-    }
-
-    bool modify_reversibly(const std::string &name, const std::function<void(Image &)> &forward,
-                           const std::function<void(Image &)> &backward) override
-    {
-        if (!m_image)
-            return false;
-
-        forward(*m_image);
-        m_image->history.add(std::make_unique<LambdaUndo>(name, backward, forward));
-        ++m_image->content_version;
-        return true;
-    }
-
-private:
-    /// Which channels and which rectangle the subject names; mirrors HDRViewApp::resolve_subject().
-    std::pair<std::vector<int>, Box2i> resolve() const
-    {
-        std::vector<int> channels;
-        if (!m_image)
-            return {channels, Box2i{}};
-
-        if (m_subject.scope == EditSubject::Scope_AllChannels)
-        {
-            channels.resize(m_image->channels.size());
-            std::iota(channels.begin(), channels.end(), 0);
-        }
-        else if (int g = m_image->active_group_index(Target_Primary); m_image->is_valid_group(g))
-        {
-            const auto &group = m_image->groups[size_t(g)];
-            for (int c = 0; c < group.num_channels; ++c) channels.push_back(group.channels[c]);
-        }
-
-        Box2i bounds = m_image->data_window;
-        if (m_subject.selection_only && m_selection.has_volume())
-            bounds.intersect(m_selection);
-
-        return {channels, bounds};
-    }
-
-    /// The undo entry is built before the edit, so it records what the edit is about to displace.
-    bool edit(const std::string &name, const std::vector<int> &channels, const Box2i &bounds,
-              const std::function<void(Image &)> &op)
-    {
-        m_used_subject = true;
-        auto entry     = std::make_unique<ChannelRectUndo>(*m_image, channels, bounds, name);
-        op(*m_image);
-        m_image->history.add(std::move(entry));
-        ++m_image->content_version;
-        return true;
-    }
-
-    /// A copy of the samples alone, for the ops that must read the image as it was.
-    Image snapshot() const
-    {
-        Image copy{m_image->size(), int(m_image->channels.size())};
-        for (size_t c = 0; c < m_image->channels.size(); ++c)
-            std::copy(m_image->channels[c].data(), m_image->channels[c].data() + m_image->channels[c].num_elements(),
-                      copy.channels[c].data());
-        return copy;
-    }
-
-    bool                  m_used_subject = false;
-    int                   m_target_group = -1;
-    std::vector<ImagePtr> m_added;
-    ImagePtr              m_image;
-    ImagePtr              m_clipboard;
-    EditSubject           m_subject;
-    Box2i                 m_selection;
-    float4                m_background{0.f, 0.f, 0.f, 1.f};
+    void retarget(int pointed_at = -1) { target_groups = ::target_groups(image, pointed_at); }
 };
 
 constexpr int2 k_size{7, 5};
@@ -342,8 +131,8 @@ ImagePtr make_image(int num_channels = 4)
 
 /// An image with three channel groups: two color groups and a depth channel.
 /**
-    "The group on screen", "the selected groups" and "every channel" are then three different sets, and the
-    color-only filter has one group to drop.
+    So "the group on screen", "the selected groups" and "every channel" are three different sets, and the
+    color-only filter has one to drop.
 */
 ImagePtr make_layered_image()
 {
@@ -443,7 +232,7 @@ TEST_CASE("Every edit that applies leaves exactly one undo entry, and undoing re
         TestEditContext ctx{img};
 
         // something on the clipboard, so the paste commands are exercised and not skipped
-        ctx.set_clipboard(make_image());
+        ctx.clipboard_image = make_image();
 
         if (!cmd->enabled(ctx))
             continue;
@@ -496,9 +285,7 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
             CAPTURE(name);
             CAPTURE(scope);
 
-            auto            img = make_layered_image();
-            TestEditContext ctx{img};
-            ctx.set_clipboard(make_image());
+            auto img = make_layered_image();
 
             // the color group on screen and the two color groups selected, so "selected" is neither the
             // current group nor every channel
@@ -506,11 +293,14 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
             img->select_group(img->selected_group);
             img->select_group(group_of_channel(img, "normal.R"));
 
+            TestEditContext ctx{img};
+            ctx.clipboard_image = make_image();
+
             // a selection well inside the image, so there is untouched ground on every side of it
             const Box2i roi{int2{2, 1}, int2{5, 4}};
-            ctx.set_selection(roi);
-            ctx.mutable_subject().selection_only = true;
-            ctx.mutable_subject().scope          = EditSubject::Scope(scope);
+            ctx.roi                    = roi;
+            ctx.subject.selection_only = true;
+            ctx.subject.scope          = EditSubject::Scope(scope);
 
             if (!cmd->enabled(ctx))
                 continue;
@@ -535,21 +325,18 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
 
             const std::vector<float> before      = samples(img);
             const int                steps       = img->history.size();
-            const ConstImagePtr      clip_before = ctx.clipboard();
+            const ConstImagePtr      clip_before = ctx.clipboard_image;
 
             cmd->apply(ctx);
 
             // there is one clipboard, so a command that fills it cannot also run once per selected image
-            if (ctx.clipboard() != clip_before)
+            if (ctx.clipboard_image != clip_before)
                 CHECK_FALSE(cmd->info().fans_out);
 
-            // an edit that changed the image without going through a chokepoint taking the subject is not
-            // narrowed by it, and must not offer controls that would change nothing
-            if (img->history.size() != steps && !ctx.last_edit_used_subject())
-                CHECK_FALSE(cmd->info().draws_subject_selector);
-
-            // a flip moves every sample by definition, and a resize has no rectangle to stay in
-            if (img->history.size() == steps || img->size() != k_size || !ctx.last_edit_used_subject())
+            // A command offering the "Apply to" controls owes this: what it wrote lies inside the channels
+            // and the rectangle they name. The others move every sample by definition -- a flip -- or have
+            // no rectangle to stay in, and say so by declining the controls.
+            if (img->history.size() == steps || img->size() != k_size || !cmd->info().draws_subject_selector)
                 continue;
 
             for (size_t c = 0; c < img->channels.size(); ++c)
@@ -569,6 +356,133 @@ TEST_CASE("An edit covers the subject it was given and nothing else")
                     }
             }
         }
+}
+
+TEST_CASE("An edit reaches every channel its scope names")
+{
+    // The other half of the sweep above, which catches only an edit writing where it should not: a scope
+    // resolving to too few channels leaves part of the subject untouched and passes there. The ops are
+    // driven directly, since each has to change every sample it is handed for "changed" to mean "covered".
+    for (int scope = 0; scope < EditSubject::Scope_COUNT; ++scope)
+    {
+        CAPTURE(scope);
+
+        auto img = make_layered_image(); // R,G,B,A -- Z -- normal.R,G,B
+
+        // the color group on screen, and that plus the second color group selected
+        img->selected_group = group_of_channel(img, "R");
+        img->select_group(img->selected_group);
+        img->select_group(group_of_channel(img, "normal.R"));
+
+        TestEditContext ctx{img};
+        ctx.subject.scope          = EditSubject::Scope(scope);
+        ctx.subject.selection_only = false;
+
+        // the groups the scope names, read off the image rather than asked of the resolver
+        std::vector<int> groups;
+        if (scope == EditSubject::Scope_AllChannels)
+            for (size_t g = 0; g < img->groups.size(); ++g) groups.push_back(int(g));
+        else if (scope == EditSubject::Scope_SelectedGroups)
+            groups = img->selected_groups();
+        else
+            groups.push_back(img->selected_group);
+
+        std::vector<int> covered, colors;
+        for (int g : groups)
+            for (int i = 0; i < img->groups[size_t(g)].num_channels; ++i)
+            {
+                covered.push_back(img->groups[size_t(g)].channels[i]);
+                const auto type = img->groups[size_t(g)].type;
+                if (type == ChannelGroup::RGB_Channels || type == ChannelGroup::RGBA_Channels)
+                    colors.push_back(img->groups[size_t(g)].channels[i]);
+            }
+
+        // "every channel" names them all, whether or not they belong to a group
+        if (scope == EditSubject::Scope_AllChannels)
+        {
+            covered.resize(img->channels.size());
+            std::iota(covered.begin(), covered.end(), 0);
+        }
+
+        // both add one to every sample they are handed, so afterwards a channel has changed exactly when
+        // the subject named it
+        auto changed_by = [&img](const std::function<void()> &edit)
+        {
+            const std::vector<float> before = samples(img);
+            edit();
+
+            std::vector<int> changed;
+            const size_t     per_channel = size_t(k_size.x * k_size.y);
+            for (size_t c = 0; c < img->channels.size(); ++c)
+                for (size_t i = 0; i < per_channel; ++i)
+                    if (img->channels[c](int(i)) != before[c * per_channel + i])
+                    {
+                        changed.push_back(int(c));
+                        break;
+                    }
+
+            REQUIRE(img->history.undo(*img));
+            CHECK(samples(img) == before);
+            return changed;
+        };
+
+        CHECK(changed_by([&] { modify_pixels(ctx, "Raise", [](float v, int2, int) { return v + 1.f; }); }) == covered);
+        CHECK(changed_by([&] { modify_colors(ctx, "Raise", [](const float4 &c, int2, int) { return c + 1.f; }); }) ==
+              colors);
+    }
+}
+
+TEST_CASE("A bump map becomes the normal map its slopes ask for")
+{
+    // Two color groups sloping different ways, so a normal derived from the wrong group's heights shows up
+    // as one group wearing the other's normal. The heights are planes, so the interior normals are known in
+    // closed form; the last row and column are left out, where the border mode decides the slope.
+    constexpr float dh_dx = 0.02f, dh_dy = 0.05f;
+
+    auto img = std::make_shared<Image>(k_size, std::vector<std::string>{"diffuse.R", "diffuse.G", "diffuse.B",
+                                                                        "specular.R", "specular.G", "specular.B"});
+    for (int y = 0; y < k_size.y; ++y)
+        for (int x = 0; x < k_size.x; ++x)
+            for (int c = 0; c < 3; ++c)
+            {
+                img->channels[size_t(c)](x, y)     = dh_dx * float(x);
+                img->channels[size_t(c + 3)](x, y) = dh_dy * float(y);
+            }
+    img->rebuild_layers();
+    REQUIRE(img->groups.size() == 2);
+
+    TestEditContext ctx{img};
+    ctx.subject.scope          = EditSubject::Scope_AllChannels;
+    ctx.subject.selection_only = false;
+
+    auto cmd = find_command("Bump to normal map...");
+    REQUIRE(cmd);
+    cmd->apply(ctx);
+
+    const float2 size{float(k_size.x), float(k_size.y)};
+    // z = h(x,y) has normal (-dh/dx, -dh/dy, 1), stored in [0,1] where flat is (0.5, 0.5, 1)
+    const float3 diffuse  = la::normalize(float3{dh_dx * size.x, 0.f, 1.f}) * 0.5f + 0.5f;
+    const float3 specular = la::normalize(float3{0.f, dh_dy * size.y, 1.f}) * 0.5f + 0.5f;
+
+    const int diffuse_group  = group_of_channel(img, "diffuse.R");
+    const int specular_group = group_of_channel(img, "specular.R");
+
+    for (int y = 0; y < k_size.y - 1; ++y)
+        for (int x = 0; x < k_size.x - 1; ++x)
+            for (int k = 0; k < 3; ++k)
+            {
+                CAPTURE(x);
+                CAPTURE(y);
+                CAPTURE(k);
+                CHECK(img->channels[size_t(img->groups[size_t(diffuse_group)].channels[k])](x, y) ==
+                      doctest::Approx(diffuse[k]).epsilon(1e-5));
+                CHECK(img->channels[size_t(img->groups[size_t(specular_group)].channels[k])](x, y) ==
+                      doctest::Approx(specular[k]).epsilon(1e-5));
+            }
+
+    // the two are different maps, which is what says each group read its own heights
+    CHECK(diffuse.x != doctest::Approx(specular.x));
+    CHECK(diffuse.y != doctest::Approx(specular.y));
 }
 
 TEST_CASE("Each scope names the channels it says it does")
@@ -674,8 +588,8 @@ TEST_CASE("An edit covers the whole image when there is no selection")
 
         auto            img = make_image();
         TestEditContext ctx{img};
-        ctx.set_clipboard(make_image());
-        ctx.mutable_subject().scope = EditSubject::Scope_AllChannels;
+        ctx.clipboard_image = make_image();
+        ctx.subject.scope   = EditSubject::Scope_AllChannels;
 
         if (!cmd->enabled(ctx))
             continue;
@@ -685,7 +599,7 @@ TEST_CASE("An edit covers the whole image when there is no selection")
 
         cmd->apply(ctx);
 
-        if (img->history.size() == steps || !ctx.last_edit_used_subject() || img->size() != k_size)
+        if (img->history.size() == steps || !cmd->info().draws_subject_selector || img->size() != k_size)
             continue;
 
         // it was allowed to write anywhere, so the undo entry has to cover the whole image
@@ -698,7 +612,7 @@ TEST_CASE("Clamping leaves every sample inside the unit range")
 {
     auto            img = make_image();
     TestEditContext ctx{img};
-    ctx.mutable_subject().scope = EditSubject::Scope_AllChannels;
+    ctx.subject.scope = EditSubject::Scope_AllChannels;
 
     // pushed well outside [0,1] first, so the clamp has something to do at both ends
     for (auto &ch : img->channels)
@@ -720,7 +634,7 @@ TEST_CASE("Zapping gremlins replaces the non-finite samples and leaves the rest"
 {
     auto            img = make_image();
     TestEditContext ctx{img};
-    ctx.mutable_subject().scope = EditSubject::Scope_AllChannels;
+    ctx.subject.scope = EditSubject::Scope_AllChannels;
 
     auto       &ch   = img->channels[0];
     const float kept = ch(2, 2);
@@ -770,6 +684,9 @@ TEST_CASE("Exploding a group takes its channels out of it, and regrouping puts t
 
     auto regroup = find_command("Regroup channels");
     REQUIRE(regroup);
+
+    // the rebuild renumbered the groups, so the next invocation reads which to act on afresh
+    ctx.retarget();
     REQUIRE(regroup->enabled(ctx));
 
     regroup->apply(ctx);
@@ -818,6 +735,7 @@ TEST_CASE("Deleting a channel group removes its channels, and undo brings them b
 
     // explode first, so there is more than one group and deleting one leaves an image behind
     find_command("Ungroup channels")->apply(ctx);
+    ctx.retarget();
 
     const size_t channels_before = img->channels.size();
     const size_t groups_before   = img->groups.size();
@@ -881,7 +799,7 @@ TEST_CASE("Generating mipmaps halves the image down to the number of levels aske
     cmd->on_open(ctx);
     cmd->apply(ctx);
 
-    const auto &made = ctx.added_images();
+    const auto &made = ctx.added;
     REQUIRE_FALSE(made.empty());
 
     // each one half the size of the one before, never below a single sample
@@ -919,8 +837,8 @@ TEST_CASE("A mip level is averaged from its samples rather than dropping three o
     cmd->on_open(ctx);
     cmd->apply(ctx);
 
-    REQUIRE_FALSE(ctx.added_images().empty());
-    const auto &half = ctx.added_images().front();
+    REQUIRE_FALSE(ctx.added.empty());
+    const auto &half = ctx.added.front();
 
     for (int i = 0; i < half->channels[0].num_elements(); ++i)
     {
@@ -955,6 +873,7 @@ TEST_CASE("Regrouping reaches the whole layer from any one of its exploded chann
                 img->selected_group = int(g);
                 break;
             }
+        ctx.retarget();
         explode->apply(ctx);
     }
 
@@ -968,6 +887,7 @@ TEST_CASE("Regrouping reaches the whole layer from any one of its exploded chann
             break;
         }
 
+    ctx.retarget();
     REQUIRE(regroup->enabled(ctx));
     regroup->apply(ctx);
 
@@ -994,6 +914,7 @@ TEST_CASE("Regrouping reaches the whole layer from any one of its exploded chann
             break;
         }
 
+    ctx.retarget();
     REQUIRE(regroup->enabled(ctx));
     regroup->apply(ctx);
     CHECK(img->groups.size() == 2);
@@ -1022,6 +943,7 @@ TEST_CASE("Regrouping touches only the channels an explosion marked, not every l
             img->selected_group = int(g);
             break;
         }
+    ctx.retarget();
     find_command("Ungroup channels")->apply(ctx);
 
     // three marked, and the depth channel still unmarked though it too stands alone
@@ -1030,6 +952,7 @@ TEST_CASE("Regrouping touches only the channels an explosion marked, not every l
     CHECK(img->channels[2].ungrouped);
     CHECK_FALSE(img->channels[3].ungrouped);
 
+    ctx.retarget();
     find_command("Regroup channels")->apply(ctx);
     CHECK(img->groups.size() == 2);
     for (const auto &c : img->channels) CHECK_FALSE(c.ungrouped);
@@ -1054,6 +977,7 @@ TEST_CASE("Regrouping from a selection puts back exactly the channels it names")
     REQUIRE(regroup);
 
     img->selected_group = group_of_channel(img, "R");
+    ctx.retarget();
     find_command("Ungroup channels")->apply(ctx);
     REQUIRE(img->groups.size() == 5); // four singletons, plus the depth
 
@@ -1063,6 +987,7 @@ TEST_CASE("Regrouping from a selection puts back exactly the channels it names")
     for (const char *name : {"R", "G", "B", "Z"}) img->select_group(group_of_channel(img, name));
     img->selected_group = group_of_channel(img, "R");
 
+    ctx.retarget();
     REQUIRE(regroup->enabled(ctx));
     regroup->apply(ctx);
 
@@ -1099,13 +1024,13 @@ TEST_CASE("A group command covers every group it is given, and nothing else")
         auto img = make_layered_image(); // R,G,B,A -- Z -- normal.R,G,B
         REQUIRE(img->groups.size() == 3);
 
-        TestEditContext ctx{img};
-
         // two of the three groups selected, so a command reaching only the one on screen and one reaching
         // every group are both caught
         img->selected_group = group_of_channel(img, "R");
         img->select_group(group_of_channel(img, "R"));
         img->select_group(group_of_channel(img, "normal.R"));
+
+        TestEditContext ctx{img};
 
         // regrouping has nothing to put back until something has been taken apart; the selection rides on
         // the channels, so it survives the rebuild that renumbers the groups
@@ -1113,7 +1038,8 @@ TEST_CASE("A group command covers every group it is given, and nothing else")
         {
             find_command("Ungroup channels")->apply(ctx);
             REQUIRE(img->history.size() == 1);
-            REQUIRE(ctx.target_groups().size() == 7);
+            ctx.retarget();
+            REQUIRE(ctx.target_groups.size() == 7);
         }
 
         auto cmd = find_command(name);
@@ -1156,6 +1082,7 @@ TEST_CASE("The delete command says whether it is about to take one channel or a 
 
     TestEditContext ctx{img};
     find_command("Ungroup channels")->apply(ctx);
+    ctx.retarget();
 
     // now every group is a lone channel, and deleting one is not deleting a group
     REQUIRE(img->groups[size_t(img->selected_group)].num_channels == 1);
@@ -1196,9 +1123,9 @@ TEST_CASE("A group can be acted on without becoming the one on screen")
     CHECK(delete_channels_label(img, {depth}) == "Delete channel");
 
     // point at the depth channel without selecting it
-    ctx.set_target_group(depth);
-    CHECK(ctx.target_groups() == std::vector<int>{depth});
-    CHECK(delete_channels_label(img, ctx.target_groups()) == "Delete channel");
+    ctx.retarget(depth);
+    CHECK(ctx.target_groups == std::vector<int>{depth});
+    CHECK(delete_channels_label(img, ctx.target_groups) == "Delete channel");
 
     auto del = find_command("Delete channel group");
     REQUIRE(del);
@@ -1214,8 +1141,8 @@ TEST_CASE("A group can be acted on without becoming the one on screen")
     CHECK(img->is_group_selected(img->selected_group));
 
     // pointing at a group that is selected covers the selection, as a click inside one keeps it
-    ctx.set_target_group(img->selected_group);
-    CHECK(ctx.target_groups() == img->selected_groups());
+    ctx.retarget(img->selected_group);
+    CHECK(ctx.target_groups == img->selected_groups());
 }
 
 TEST_CASE("Ungrouping a group that is not on screen leaves the viewport where it was")
@@ -1235,7 +1162,7 @@ TEST_CASE("Ungrouping a group that is not on screen leaves the viewport where it
     const std::string on_screen = img->channels[size_t(img->groups[size_t(shown)].channels[0])].name;
 
     TestEditContext ctx{img};
-    ctx.set_target_group(other);
+    ctx.retarget(other);
 
     find_command("Ungroup channels")->apply(ctx);
 

--- a/tests/test_edit_commands.cpp
+++ b/tests/test_edit_commands.cpp
@@ -77,7 +77,7 @@ struct TestEditContext : EditContext
                 { return std::make_unique<ChannelRectUndo>(img, channels, bounds, n); });
         };
 
-        modify_image_async = [this](const std::string &name, int2 size, const ImageFilter &op)
+        resample_image_async = [this](const std::string &name, int2 size, const ChannelResampler &op)
         {
             if (!image || size.x <= 0 || size.y <= 0)
                 return;
@@ -206,11 +206,6 @@ TEST_CASE("Every edit command is addressable and describes itself")
         CHECK_FALSE(info.names.front().empty());
         CHECK_FALSE(info.icon.empty());
         CHECK(info.width_em > 0.f);
-
-        // "..." means a dialog everywhere in the interface, so a command with no draw() must not claim one
-        const std::string &n        = info.names.front();
-        const bool         ellipsis = n.size() >= 3 && n.compare(n.size() - 3, 3, "...") == 0;
-        CHECK(cmd->has_dialog() == ellipsis);
 
         names.push_back(info.names.front());
     }

--- a/tests/test_undo.cpp
+++ b/tests/test_undo.cpp
@@ -220,7 +220,10 @@ TEST_CASE("The history cursor tracks what can be undone and redone")
 
     int  applied        = 0;
     auto counting_entry = [&applied](std::string name)
-    { return std::make_unique<LambdaUndo>(std::move(name), [&applied](Image &) { ++applied; }); };
+    {
+        auto count = [&applied](Image &) { ++applied; };
+        return std::make_unique<LambdaUndo>(std::move(name), count, count);
+    };
 
     history.add(counting_entry("First"));
     history.add(counting_entry("Second"));
@@ -251,7 +254,8 @@ TEST_CASE("A new edit discards what had been undone")
     auto           img = make_test_image(1);
     CommandHistory history;
 
-    auto noop = [](std::string name) { return std::make_unique<LambdaUndo>(std::move(name), [](Image &) {}); };
+    auto noop = [](std::string name)
+    { return std::make_unique<LambdaUndo>(std::move(name), [](Image &) {}, [](Image &) {}); };
 
     history.add(noop("First"));
     history.add(noop("Second"));
@@ -269,7 +273,8 @@ TEST_CASE("The modified flag follows the distance from the last save in both dir
     auto           img = make_test_image(1);
     CommandHistory history;
 
-    auto noop = [](std::string name) { return std::make_unique<LambdaUndo>(std::move(name), [](Image &) {}); };
+    auto noop = [](std::string name)
+    { return std::make_unique<LambdaUndo>(std::move(name), [](Image &) {}, [](Image &) {}); };
 
     CHECK_FALSE(history.is_modified());
 
@@ -300,7 +305,8 @@ TEST_CASE("A save point that is discarded cannot be returned to")
     auto           img = make_test_image(1);
     CommandHistory history;
 
-    auto noop = [](std::string name) { return std::make_unique<LambdaUndo>(std::move(name), [](Image &) {}); };
+    auto noop = [](std::string name)
+    { return std::make_unique<LambdaUndo>(std::move(name), [](Image &) {}, [](Image &) {}); };
 
     history.add(noop("First"));
     history.add(noop("Second"));


### PR DESCRIPTION
**Based on `fix/ai-audit-2026-09` (#212), so review that first.** GitHub will retarget this to `master` when #212 merges; the diff shown here is just this change.

The first structural change from the audit. An edit reached the pixels through nine hops across five files: an `Action`, two dispatch functions, a forwarding adapter, a virtual interface, one of eight `modify_*` methods, and a resolver. The interface had one production implementation and one in the tests, which is what let the tests drift away from what the app actually does.

## What changed

**`EditContext` is a plain struct** a caller fills in, instead of a 13-method abstract interface. The synchronous chokepoints are free functions over `Image&` in the new `src/edit/edit_ops.{h,cpp}`, keeping their ordering guarantee: cancel the stats tasks, build the undo entry from the pre-edit image, apply, push onto the history, bump `content_version`. `AppEditContext`, a pure forwarding adapter, is gone.

Two callbacks survive because they genuinely need the app: setting the selection, which Crop clears in two places, and what runs after an edit, since only a structural one refits the view. I had expected to remove both; the report in the audit assumed a size-changed heuristic would do, but that would have started refitting the view after every rotate.

**Eight ways of changing an image become four.**

| was | now |
|---|---|
| `modify_channels` | `modify_channels_async` run inline, as the web build already ran it |
| `modify_structure`, `modify_reversibly` | `modify_image` with the undo entry the caller wants, plus an `EditExtent` saying whether the layer tree and view must follow |
| `modify_neighborhood` | folded into `modify_colors`; its one caller, bump-to-normal, reads heights from a duplicate |

`modify_neighborhood` had duplicated 55 lines of `modify_colors`. Folding it required `modify_colors`' op to learn which group it is in, since the normal map has to know whose heights to read.

## The test hole this closes

The old test double had **no branch for `Scope_SelectedGroups` at all**. It fell through to the current group, so every command exercised under that scope was silently testing something else.

Worse, the sweep meant to catch this could not: it only asserts that nothing *outside* the subject changed, which under-reach satisfies by construction. So "An edit reaches every channel its scope names" is new, comparing the changed set against an independently computed one.

Mutation-checked both ways:

| broken thing | cases failed | assertions failed |
|---|---|---|
| scope resolver under-reaches | 2 | 5 |
| color resolver ignores the scope | 3 | 60 |

The second was entirely vacuous before. The test double is now 76 lines instead of 288 and calls the same functions the app does.

## Smaller items

- `EditCommand::Info` loses `flags`, which was `ImGuiInputFlags_None` in all 32 commands, and is built once per command instead of three strings and a vector on every call, every frame.
- `CompositeUndo` and `ColorMetadataUndo`'s pimpl are gone, one construction site each.

## Numbers

| | |
|---|---|
| net lines | −261 |
| `app-edit.cpp` | 969 → 533 |
| test double | 288 → 76 |
| hops, menu to pixel write | 9 → 7 |
| tests | 327 cases, 361,767 assertions |

## Behavior I could not prove unchanged

**Shift and zap-gremlins now run on the worker thread with a progress dialog.** Same result, same undo entry, one frame later. That follows from merging `modify_channels` into the async path, but it is a real change and the thing most worth trying by hand.

The GUI tests build but cannot run headless here; CI runs them under `xvfb`. A few log-only and ordering shifts are listed in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
