### PR TITLE
Keep app.h to what the rest of the app calls

### DIFF
--- a/src/app-edit.cpp
+++ b/src/app-edit.cpp
@@ -313,6 +313,36 @@ void HDRViewApp::draw_edit_subject_selector()
         ImGui::Tooltip("There is no selection, so edits cover the whole image.");
 }
 
+/// A filter running off the main thread, with what is needed to finish or abandon it.
+/**
+    The worker writes only `results` and `progress`; the main thread reads `done` once a frame and applies
+    the results.
+*/
+struct HDRViewApp::RunningFilter
+{
+    ImagePtr         image;
+    std::string      name;
+    std::vector<int> channels;
+    Box2i            bounds;
+
+    /// Filters one of `channels`, given its index among them and a share of the progress bar.
+    std::function<Array2Df(const Array2Df &, int, AtomicProgress)> filter;
+
+    int2                  new_size{0}; ///< The size of the results; zero keeps the image's shape.
+    std::vector<Array2Df> results;
+    AtomicProgress        progress{true};
+    std::atomic<bool>     done{false};
+    std::thread           worker;
+
+    /// Cancel and join the worker, which reads this object and the thread pool.
+    ~RunningFilter()
+    {
+        progress.cancel();
+        if (worker.joinable())
+            worker.join();
+    }
+};
+
 void HDRViewApp::modify_channels_async(const ImagePtr &img, const string &name, const EditSubject &subject,
                                        const ChannelFilter &filter)
 {
@@ -330,7 +360,7 @@ void HDRViewApp::modify_channels_async(const ImagePtr &img, const string &name, 
     if (channels.empty() || !bounds.has_volume())
         return;
 
-    auto running      = std::make_unique<RunningFilter>();
+    auto running      = std::make_shared<RunningFilter>();
     running->image    = img;
     running->name     = name;
     running->channels = channels;
@@ -357,7 +387,7 @@ void HDRViewApp::resample_image_async(const ImagePtr &img, const string &name, i
         return;
     }
 
-    auto running      = std::make_unique<RunningFilter>();
+    auto running      = std::make_shared<RunningFilter>();
     running->image    = img;
     running->name     = name;
     running->bounds   = img->data_window;
@@ -369,7 +399,7 @@ void HDRViewApp::resample_image_async(const ImagePtr &img, const string &name, i
     start_filter(std::move(running));
 }
 
-void HDRViewApp::start_filter(std::unique_ptr<RunningFilter> running)
+void HDRViewApp::start_filter(std::shared_ptr<RunningFilter> running)
 {
     // the statistics tasks read the very pixels the filter is about to
     for (auto &c : running->image->channels) c.cancel_stats();

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -46,6 +46,11 @@ const char *const g_blend_mode_ids[BlendMode_COUNT] = {
 const char *const g_tonemap_ids[Tonemap_COUNT]  = {"gamma", "false_color", "positive_negative"};
 const char *const g_channel_ids[Channels_COUNT] = {"rgba", "rgb", "red", "green", "blue", "alpha", "y"};
 const char *const g_bg_mode_ids[BGMode_COUNT]   = {"black", "white", "dark_checker", "light_checker", "custom_color"};
+// A session records the alpha override the user chose, not the interpretation it produced: with no override
+// the file is read afresh, so a corrected loader or an edited file is picked up. The trailing entry is that
+// "no override" case, which is why this table is one longer than the enum.
+const char *const g_alpha_type_ids[AlphaType_Count + 1] = {"none", "premultiplied-linear", "premultiplied-nonlinear",
+                                                           "straight", ""};
 
 template <typename Enum, size_t N>
 string enum_to_id(Enum value, const char *const (&ids)[N])
@@ -67,36 +72,11 @@ Enum id_to_enum(const json &j, const char *key, const char *const (&ids)[N], Enu
     return default_value;
 }
 
-// A session records the alpha override the user chose, not the interpretation it produced: with no override
-// the file is read afresh, so a corrected loader or an edited file is picked up. Spelled out, not stored as
-// the enum's ordinal, which would reinterpret every session if a value were ever inserted.
-static const char *alpha_override_token(AlphaType_ at)
+// The alpha override an image entry asks for, empty when it uses the file's own interpretation.
+optional<AlphaType_> alpha_override_from_id(const json &j)
 {
-    switch (at)
-    {
-    case AlphaType_None: return "none";
-    case AlphaType_PremultipliedLinear: return "premultiplied-linear";
-    case AlphaType_PremultipliedNonLinear: return "premultiplied-nonlinear";
-    default: return "straight";
-    }
-}
-
-static optional<AlphaType_> alpha_override_from_token(const json &j)
-{
-    auto token = j.value<string>("alpha_override", "");
-    if (token.empty())
-        return nullopt;
-    if (token == "none")
-        return AlphaType_None;
-    if (token == "premultiplied-linear")
-        return AlphaType_PremultipliedLinear;
-    if (token == "premultiplied-nonlinear")
-        return AlphaType_PremultipliedNonLinear;
-    if (token == "straight")
-        return AlphaType_Straight;
-
-    spdlog::warn("Unrecognized alpha override '{}'; reading the file's own interpretation instead.", token);
-    return nullopt;
+    auto at = id_to_enum(j, "alpha_override", g_alpha_type_ids, (AlphaType_)AlphaType_Count);
+    return at == AlphaType_Count ? optional<AlphaType_>{} : at;
 }
 
 // Checks "type"/"version" on a parsed session manifest (`source_name` is a filename or zip archive name,
@@ -916,7 +896,7 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
         entry["path"]             = path_of(img);
         entry["channel_selector"] = img->channel_selector;
         if (img->alpha_override)
-            entry["alpha_override"] = alpha_override_token(*img->alpha_override);
+            entry["alpha_override"] = enum_to_id(*img->alpha_override, g_alpha_type_ids);
         entry["selected_group"]  = img->selected_group;
         entry["reference_group"] = img->reference_group;
 
@@ -1081,6 +1061,47 @@ void HDRViewApp::export_session_bundle()
 #endif
 }
 
+/// A parsed session file waiting on the user to confirm closing the currently-open images.
+/**
+    A bundled session carries the zip's bytes along, since begin_session_load() needs them again once the
+    user confirms; an empty `zip_bytes` is a plain .hsess, whose entries name files under `dir`.
+*/
+struct HDRViewApp::PendingSessionLoad
+{
+    json     j;
+    fs::path dir;
+    string   zip_bytes;
+    string   zip_name;
+};
+
+/// A session whose images have been issued to the loader and are loading asynchronously.
+/**
+    The rest of it (selection, blend mode, view settings) is applied by finish_pending_session() once every
+    entry here has been resolved, successfully or not.
+*/
+struct HDRViewApp::PendingSession
+{
+    struct Entry
+    {
+        fs::path             path;
+        string               channel_selector;
+        optional<AlphaType_> alpha_override; ///< Empty when the file's own interpretation was used
+        int                  selected_group = 0, reference_group = 0;
+        vector<string>       selected_channels; ///< The multi-selection, by channel name; see Channel::selected
+        ImagePtr             loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
+    };
+    vector<Entry> entries;                                  ///< One per saved "images" entry, in file order
+    int           current_index = -1, reference_index = -1; ///< Index into entries, or -1 if unset
+    BlendMode_    blend_mode;
+    json          view; ///< The session file's "view" sub-object, applied verbatim once loading completes
+
+    // An arriving image is matched to the earliest not-yet-filled entry sharing its load options. Entries
+    // sharing that key are content-identical, so any one-to-one assignment among them is correct however the
+    // async loads finish, which is what makes it safe to load the same file twice in one session.
+    using Key = std::tuple<fs::path, string, optional<AlphaType_>>; ///< path, channel_selector, alpha_override
+    map<Key, deque<int>> unresolved;
+};
+
 void HDRViewApp::load_session()
 {
 #if !defined(__EMSCRIPTEN__)
@@ -1130,14 +1151,16 @@ void HDRViewApp::load_session(const string &filename)
 
     fs::path dir = fs::path(filename).parent_path();
 
+    PendingSessionLoad load{j, dir, {}, {}};
+
     if (!m_images.empty())
     {
-        m_pending_session_load          = PendingSessionLoad{j, dir};
+        m_pending_session_load          = std::make_shared<PendingSessionLoad>(std::move(load));
         dialog("Replace session?").open = true;
         return;
     }
 
-    begin_session_load(j, dir);
+    begin_session_load(load);
 #endif
 }
 
@@ -1174,30 +1197,35 @@ bool HDRViewApp::try_load_zip_as_session(string_view zip_bytes, const string &zi
                  zip_name, candidates.front().first);
     m_image_loader.add_recent_file(zip_name);
 
+    PendingSessionLoad load{j, {}, string(zip_bytes), zip_name};
+
     if (!m_images.empty())
     {
-        m_pending_zip_session_load      = PendingZipSessionLoad{string(zip_bytes), zip_name, j};
+        m_pending_session_load          = std::make_shared<PendingSessionLoad>(std::move(load));
         dialog("Replace session?").open = true;
         return true;
     }
 
-    begin_bundle_session_load(zip_bytes, zip_name, j);
+    begin_session_load(load);
     return true;
 }
 
-void HDRViewApp::begin_session_load(const json &j, const fs::path &dir)
+void HDRViewApp::begin_session_load(const PendingSessionLoad &load)
 {
     // Loading a session was already confirmed, by the prompt that warned it would replace what is
     // open; asking a second time here would stall a load that is already underway.
     close_all_images_immediately();
 
-    auto resolve = [&dir](const string &rel) -> fs::path
+    const json &j        = load.j;
+    const bool  from_zip = !load.zip_bytes.empty();
+
+    auto resolve = [&load](const string &rel) -> fs::path
     {
         if (rel.empty())
             return {};
         std::error_code ec;
-        fs::path        abs = fs::weakly_canonical(dir / fs::u8path(rel), ec);
-        return ec ? (dir / fs::u8path(rel)) : abs;
+        fs::path        abs = fs::weakly_canonical(load.dir / fs::u8path(rel), ec);
+        return ec ? (load.dir / fs::u8path(rel)) : abs;
     };
 
     PendingSession pending;
@@ -1210,57 +1238,13 @@ void HDRViewApp::begin_session_load(const json &j, const fs::path &dir)
         if (rel.empty())
             continue;
 
+        // A bundled entry takes the same "zip_name/entry_path" synthetic identity regular zip-loaded images
+        // get (see extract_and_schedule() in image_loader.cpp), so "reveal in file manager" and
+        // reload_image() need no session-specific handling.
         PendingSession::Entry e;
-        e.path              = resolve(rel);
+        e.path              = from_zip ? fs::path(load.zip_name) / fs::u8path(rel) : resolve(rel);
         e.channel_selector  = entry.value<string>("channel_selector", "");
-        e.alpha_override    = alpha_override_from_token(entry);
-        e.selected_group    = entry.value<int>("selected_group", 0);
-        e.reference_group   = entry.value<int>("reference_group", 0);
-        e.selected_channels = entry.value<vector<string>>("selected_channels", {});
-
-        int idx = (int)pending.entries.size();
-        pending.entries.push_back(e);
-        pending.unresolved[{e.path, e.channel_selector, e.alpha_override}].push_back(idx);
-
-        ImageLoadOptions opts;
-        opts.channel_selector = e.channel_selector;
-        opts.override_alpha   = e.alpha_override.has_value();
-        if (e.alpha_override)
-            opts.alpha_override = *e.alpha_override;
-        load_image(e.path.string(), {}, false, opts);
-    }
-
-    int n                   = (int)pending.entries.size();
-    pending.current_index   = clamp(j.value<int>("current", -1), -1, n - 1);
-    pending.reference_index = clamp(j.value<int>("reference", -1), -1, n - 1);
-
-    m_pending_session                 = std::move(pending);
-    dialog("Loading session...").open = true;
-}
-
-void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &zip_name, const json &j)
-{
-    // Loading a session was already confirmed, by the prompt that warned it would replace what is
-    // open; asking a second time here would stall a load that is already underway.
-    close_all_images_immediately();
-
-    PendingSession pending;
-    pending.blend_mode = id_to_enum(j, "blend_mode", g_blend_mode_ids, BlendMode_Normal);
-    pending.view       = j.value("view", json::object());
-
-    for (auto &entry : j.value("images", json::array()))
-    {
-        string rel = entry.value<string>("path", "");
-        if (rel.empty())
-            continue;
-
-        // The same "zip_name/entry_path" synthetic identity regular zip-loaded images get (see
-        // extract_and_schedule() in image_loader.cpp), so "reveal in file manager" and reload_image() need
-        // no session-specific handling.
-        PendingSession::Entry e;
-        e.path              = fs::path(zip_name) / fs::u8path(rel);
-        e.channel_selector  = entry.value<string>("channel_selector", "");
-        e.alpha_override    = alpha_override_from_token(entry);
+        e.alpha_override    = alpha_override_from_id(entry);
         e.selected_group    = entry.value<int>("selected_group", 0);
         e.reference_group   = entry.value<int>("reference_group", 0);
         e.selected_channels = entry.value<vector<string>>("selected_channels", {});
@@ -1268,13 +1252,18 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
 
-        auto bytes = zip_extract_entry(zip_bytes, rel);
-        if (!bytes)
+        optional<string> bytes;
+        if (from_zip)
         {
-            // Never issued to the loader, so it stays unresolved and finish_pending_session() reports it
-            // as a load failure, as it does a missing file on disk.
-            spdlog::warn("Session bundle '{}' references '{}', but it isn't present in the zip.", zip_name, rel);
-            continue;
+            bytes = zip_extract_entry(load.zip_bytes, rel);
+            if (!bytes)
+            {
+                // Never issued to the loader, so it stays unresolved and finish_pending_session() reports it
+                // as a load failure, as it does a missing file on disk.
+                spdlog::warn("Session bundle '{}' references '{}', but it isn't present in the zip.", load.zip_name,
+                             rel);
+                continue;
+            }
         }
 
         pending.unresolved[{e.path, e.channel_selector, e.alpha_override}].push_back(idx);
@@ -1284,15 +1273,40 @@ void HDRViewApp::begin_bundle_session_load(string_view zip_bytes, const string &
         opts.override_alpha   = e.alpha_override.has_value();
         if (e.alpha_override)
             opts.alpha_override = *e.alpha_override;
-        m_image_loader.background_load(e.path.string(), *bytes, false, nullptr, opts);
+        if (from_zip)
+            m_image_loader.background_load(e.path.string(), *bytes, false, nullptr, opts);
+        else
+            load_image(e.path.string(), {}, false, opts);
     }
 
     int n                   = (int)pending.entries.size();
     pending.current_index   = clamp(j.value<int>("current", -1), -1, n - 1);
     pending.reference_index = clamp(j.value<int>("reference", -1), -1, n - 1);
 
-    m_pending_session                 = std::move(pending);
+    m_pending_session                 = std::make_shared<PendingSession>(std::move(pending));
     dialog("Loading session...").open = true;
+}
+
+void HDRViewApp::resolve_pending_session_image(const ImagePtr &new_image)
+{
+    if (!m_pending_session)
+        return;
+
+    // Resolve this arrival to the earliest not-yet-filled entry sharing its load options; see PendingSession
+    // for why that key is the right one to match on.
+    auto key = PendingSession::Key{new_image->path, new_image->channel_selector, new_image->alpha_override};
+    auto it  = m_pending_session->unresolved.find(key);
+    if (it == m_pending_session->unresolved.end())
+        return;
+
+    if (!it->second.empty())
+    {
+        int entry_idx = it->second.front();
+        it->second.pop_front();
+        m_pending_session->entries[entry_idx].loaded = new_image;
+    }
+    if (it->second.empty())
+        m_pending_session->unresolved.erase(it);
 }
 
 void HDRViewApp::finish_pending_session()
@@ -1390,19 +1404,12 @@ void HDRViewApp::draw_confirm_load_session_dialog(bool &open)
     auto result = ImGui::ConfirmDialog("Replace session?", open,
                                        "Loading this session will close all currently open images.", "Replace");
     if (result == ImGui::DialogResult::Cancel)
-    {
         m_pending_session_load.reset();
-        m_pending_zip_session_load.reset();
-    }
     else if (result == ImGui::DialogResult::Confirm)
     {
         if (m_pending_session_load)
-            begin_session_load(m_pending_session_load->j, m_pending_session_load->dir);
-        else
-            begin_bundle_session_load(m_pending_zip_session_load->zip_bytes, m_pending_zip_session_load->zip_name,
-                                      m_pending_zip_session_load->j);
+            begin_session_load(*m_pending_session_load);
         m_pending_session_load.reset();
-        m_pending_zip_session_load.reset();
     }
 }
 

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -1062,7 +1062,7 @@ void HDRViewApp::export_session_bundle()
 }
 
 /// A parsed session file waiting on the user to confirm closing the currently-open images.
-struct HDRViewApp::PendingSessionLoad
+struct HDRViewApp::UnconfirmedSession
 {
     json     j;
     fs::path dir;       ///< Where a plain .hsess's entries are relative to
@@ -1071,7 +1071,7 @@ struct HDRViewApp::PendingSessionLoad
 };
 
 /// A session whose images have been issued to the loader and are loading asynchronously.
-struct HDRViewApp::PendingSession
+struct HDRViewApp::LoadingSession
 {
     struct Entry
     {
@@ -1142,11 +1142,11 @@ void HDRViewApp::load_session(const string &filename)
 
     fs::path dir = fs::path(filename).parent_path();
 
-    PendingSessionLoad load{j, dir, {}, {}};
+    UnconfirmedSession load{j, dir, {}, {}};
 
     if (!m_images.empty())
     {
-        m_pending_session_load          = std::make_shared<PendingSessionLoad>(std::move(load));
+        m_unconfirmed_session           = std::make_shared<UnconfirmedSession>(std::move(load));
         dialog("Replace session?").open = true;
         return;
     }
@@ -1188,11 +1188,11 @@ bool HDRViewApp::try_load_zip_as_session(string_view zip_bytes, const string &zi
                  zip_name, candidates.front().first);
     m_image_loader.add_recent_file(zip_name);
 
-    PendingSessionLoad load{j, {}, string(zip_bytes), zip_name};
+    UnconfirmedSession load{j, {}, string(zip_bytes), zip_name};
 
     if (!m_images.empty())
     {
-        m_pending_session_load          = std::make_shared<PendingSessionLoad>(std::move(load));
+        m_unconfirmed_session           = std::make_shared<UnconfirmedSession>(std::move(load));
         dialog("Replace session?").open = true;
         return true;
     }
@@ -1201,7 +1201,7 @@ bool HDRViewApp::try_load_zip_as_session(string_view zip_bytes, const string &zi
     return true;
 }
 
-void HDRViewApp::begin_session_load(const PendingSessionLoad &load)
+void HDRViewApp::begin_session_load(const UnconfirmedSession &load)
 {
     // Loading a session was already confirmed, by the prompt that warned it would replace what is
     // open; asking a second time here would stall a load that is already underway.
@@ -1219,7 +1219,7 @@ void HDRViewApp::begin_session_load(const PendingSessionLoad &load)
         return ec ? (load.dir / fs::u8path(rel)) : abs;
     };
 
-    PendingSession pending;
+    LoadingSession pending;
     pending.blend_mode = id_to_enum(j, "blend_mode", g_blend_mode_ids, BlendMode_Normal);
     pending.view       = j.value("view", json::object());
 
@@ -1232,7 +1232,7 @@ void HDRViewApp::begin_session_load(const PendingSessionLoad &load)
         // A bundled entry takes the same "zip_name/entry_path" synthetic identity regular zip-loaded images
         // get (see extract_and_schedule() in image_loader.cpp), so "reveal in file manager" and
         // reload_image() need no session-specific handling.
-        PendingSession::Entry e;
+        LoadingSession::Entry e;
         e.path              = from_zip ? fs::path(load.zip_name) / fs::u8path(rel) : resolve(rel);
         e.channel_selector  = entry.value<string>("channel_selector", "");
         e.alpha_override    = alpha_override_from_id(entry);
@@ -1249,7 +1249,7 @@ void HDRViewApp::begin_session_load(const PendingSessionLoad &load)
             bytes = zip_extract_entry(load.zip_bytes, rel);
             if (!bytes)
             {
-                // Never issued to the loader, so it stays unresolved and finish_pending_session() reports it
+                // Never issued to the loader, so it stays unresolved and finish_loading_session() reports it
                 // as a load failure, as it does a missing file on disk.
                 spdlog::warn("Session bundle '{}' references '{}', but it isn't present in the zip.", load.zip_name,
                              rel);
@@ -1274,38 +1274,38 @@ void HDRViewApp::begin_session_load(const PendingSessionLoad &load)
     pending.current_index   = clamp(j.value<int>("current", -1), -1, n - 1);
     pending.reference_index = clamp(j.value<int>("reference", -1), -1, n - 1);
 
-    m_pending_session                 = std::make_shared<PendingSession>(std::move(pending));
+    m_loading_session                 = std::make_shared<LoadingSession>(std::move(pending));
     dialog("Loading session...").open = true;
 }
 
-void HDRViewApp::resolve_pending_session_image(const ImagePtr &new_image)
+void HDRViewApp::resolve_loading_session_image(const ImagePtr &new_image)
 {
-    if (!m_pending_session)
+    if (!m_loading_session)
         return;
 
-    // Resolve this arrival to the earliest not-yet-filled entry sharing its load options; see PendingSession
+    // Resolve this arrival to the earliest not-yet-filled entry sharing its load options; see LoadingSession
     // for why that key is the right one to match on.
-    auto key = PendingSession::Key{new_image->path, new_image->channel_selector, new_image->alpha_override};
-    auto it  = m_pending_session->unresolved.find(key);
-    if (it == m_pending_session->unresolved.end())
+    auto key = LoadingSession::Key{new_image->path, new_image->channel_selector, new_image->alpha_override};
+    auto it  = m_loading_session->unresolved.find(key);
+    if (it == m_loading_session->unresolved.end())
         return;
 
     if (!it->second.empty())
     {
         int entry_idx = it->second.front();
         it->second.pop_front();
-        m_pending_session->entries[entry_idx].loaded = new_image;
+        m_loading_session->entries[entry_idx].loaded = new_image;
     }
     if (it->second.empty())
-        m_pending_session->unresolved.erase(it);
+        m_loading_session->unresolved.erase(it);
 }
 
-void HDRViewApp::finish_pending_session()
+void HDRViewApp::finish_loading_session()
 {
-    if (!m_pending_session)
+    if (!m_loading_session)
         return;
 
-    auto &entries = m_pending_session->entries;
+    auto &entries = m_loading_session->entries;
 
     for (auto &e : entries)
         if (!e.loaded)
@@ -1339,14 +1339,14 @@ void HDRViewApp::finish_pending_session()
     { return (idx >= 0 && idx < (int)entries.size()) ? entries[idx].loaded : nullptr; };
 
     m_current = m_reference = -1;
-    if (auto img = entry_loaded(m_pending_session->current_index))
+    if (auto img = entry_loaded(m_loading_session->current_index))
         m_current = image_index(img);
-    if (auto img = entry_loaded(m_pending_session->reference_index))
+    if (auto img = entry_loaded(m_loading_session->reference_index))
         m_reference = image_index(img);
 
-    m_blend_mode = m_pending_session->blend_mode;
+    m_blend_mode = m_loading_session->blend_mode;
 
-    const json &view = m_pending_session->view;
+    const json &view = m_loading_session->view;
     m_exposure_live = m_exposure = view.value<float>("exposure", m_exposure);
     // Only the floor; see MIN_GAMMA. Exposure and offset have no unsafe values, and a session has to carry
     // back whatever Ctrl+click entry and the keyboard shortcuts can set.
@@ -1383,7 +1383,7 @@ void HDRViewApp::finish_pending_session()
     m_roi_live = m_roi;
 
     m_request_sort = true;
-    m_pending_session.reset();
+    m_loading_session.reset();
 
     // m_images was rebuilt above and m_visible_images indexes into it, so leaving the old indices in place
     // would walk off the end of the new vector.
@@ -1395,12 +1395,12 @@ void HDRViewApp::draw_confirm_load_session_dialog(bool &open)
     auto result = ImGui::ConfirmDialog("Replace session?", open,
                                        "Loading this session will close all currently open images.", "Replace");
     if (result == ImGui::DialogResult::Cancel)
-        m_pending_session_load.reset();
+        m_unconfirmed_session.reset();
     else if (result == ImGui::DialogResult::Confirm)
     {
-        if (m_pending_session_load)
-            begin_session_load(*m_pending_session_load);
-        m_pending_session_load.reset();
+        if (m_unconfirmed_session)
+            begin_session_load(*m_unconfirmed_session);
+        m_unconfirmed_session.reset();
     }
 }
 
@@ -1409,11 +1409,11 @@ void HDRViewApp::draw_loading_session_dialog(bool &open)
     if (ImGui::BeginModalDialog("Loading session...", open, ImGui::DialogPosition::Center,
                                 ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar))
     {
-        if (m_pending_session)
+        if (m_loading_session)
         {
-            int total = (int)m_pending_session->entries.size();
+            int total = (int)m_loading_session->entries.size();
             int done  = 0;
-            for (auto &e : m_pending_session->entries)
+            for (auto &e : m_loading_session->entries)
                 if (e.loaded)
                     ++done;
             ImGui::Text("Loading session... (%d/%d)", done, total);

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -1062,23 +1062,15 @@ void HDRViewApp::export_session_bundle()
 }
 
 /// A parsed session file waiting on the user to confirm closing the currently-open images.
-/**
-    A bundled session carries the zip's bytes along, since begin_session_load() needs them again once the
-    user confirms; an empty `zip_bytes` is a plain .hsess, whose entries name files under `dir`.
-*/
 struct HDRViewApp::PendingSessionLoad
 {
     json     j;
-    fs::path dir;
-    string   zip_bytes;
+    fs::path dir;       ///< Where a plain .hsess's entries are relative to
+    string   zip_bytes; ///< Empty for a plain .hsess; begin_session_load() needs these again after the confirm
     string   zip_name;
 };
 
 /// A session whose images have been issued to the loader and are loading asynchronously.
-/**
-    The rest of it (selection, blend mode, view settings) is applied by finish_pending_session() once every
-    entry here has been resolved, successfully or not.
-*/
 struct HDRViewApp::PendingSession
 {
     struct Entry
@@ -1095,9 +1087,8 @@ struct HDRViewApp::PendingSession
     BlendMode_    blend_mode;
     json          view; ///< The session file's "view" sub-object, applied verbatim once loading completes
 
-    // An arriving image is matched to the earliest not-yet-filled entry sharing its load options. Entries
-    // sharing that key are content-identical, so any one-to-one assignment among them is correct however the
-    // async loads finish, which is what makes it safe to load the same file twice in one session.
+    // An arrival fills the earliest entry sharing its load options. Entries sharing a key ask for identical
+    // content, so any one-to-one assignment is right whatever order the loads finish in.
     using Key = std::tuple<fs::path, string, optional<AlphaType_>>; ///< path, channel_selector, alpha_override
     map<Key, deque<int>> unresolved;
 };

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -111,6 +111,21 @@ void HDRViewApp::set_ipc_port(uint16_t port)
         set_ipc_listening(true);
 }
 
+/// Turns the listener's running totals into the rates the activity readout shows.
+/**
+    Sampled over a window rather than per frame: at 60 fps the per-frame deltas are one or two packets.
+*/
+struct HDRViewApp::IpcRates
+{
+    double   sampled_at    = 0.0; ///< ImGui::GetTime() of the last sample
+    uint64_t last_packets  = 0;
+    uint64_t last_bytes    = 0;
+    double   packets_per_s = 0.0;
+    double   bytes_per_s   = 0.0;
+
+    void update(const IpcActivity &now, double time);
+};
+
 void HDRViewApp::IpcRates::update(const IpcActivity &now, double time)
 {
     // long enough that the numbers hold still, short enough to follow a renderer starting and stopping
@@ -167,7 +182,9 @@ void HDRViewApp::draw_ipc_gui()
                            clients == 1 ? "1 client" : fmt::format("{} clients", clients).c_str());
 
         const auto activity = m_ipc_server.activity();
-        m_ipc_rates.update(activity, ImGui::GetTime());
+        if (!m_ipc_rates)
+            m_ipc_rates = std::make_shared<IpcRates>();
+        m_ipc_rates->update(activity, ImGui::GetTime());
 
         // well above the quarter-second pbrt leaves between updates, so a renderer pausing between passes
         // does not make the readout flicker
@@ -180,7 +197,7 @@ void HDRViewApp::draw_ipc_gui()
             ImGui::ProgressBar(-1.f * float(ImGui::GetTime()), ImVec2(-FLT_MIN, ImGui::GetFrameHeight() * 0.35f), "");
             ImGui::TextWrapped("%s",
                                fmt::format("Receiving {:.1h}/s over {:.0f} updates/s.",
-                                           human_readible{size_t(m_ipc_rates.bytes_per_s)}, m_ipc_rates.packets_per_s)
+                                           human_readible{size_t(m_ipc_rates->bytes_per_s)}, m_ipc_rates->packets_per_s)
                                    .c_str());
         }
         else if (clients)

--- a/src/app-ipc.cpp
+++ b/src/app-ipc.cpp
@@ -112,12 +112,9 @@ void HDRViewApp::set_ipc_port(uint16_t port)
 }
 
 /// Turns the listener's running totals into the rates the activity readout shows.
-/**
-    Sampled over a window rather than per frame: at 60 fps the per-frame deltas are one or two packets.
-*/
 struct HDRViewApp::IpcRates
 {
-    double   sampled_at    = 0.0; ///< ImGui::GetTime() of the last sample
+    double   sampled_at    = 0.0; ///< ImGui::GetTime() of the last sample; see k_window for why not per frame
     uint64_t last_packets  = 0;
     uint64_t last_bytes    = 0;
     double   packets_per_s = 0.0;

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -686,14 +686,14 @@ void HDRViewApp::setup_frame_callbacks()
                 if (should_select)
                     m_current = is_valid(idx) ? idx : int(m_images.size() - 1);
 
-                resolve_pending_session_image(new_image);
+                resolve_loading_session_image(new_image);
 
                 update_visibility(); // this also calls set_image_textures();
                 m_request_sort = true;
             });
 
-        if (m_pending_session && m_image_loader.num_pending_images() == 0)
-            finish_pending_session();
+        if (m_loading_session && m_image_loader.num_pending_images() == 0)
+            finish_loading_session();
 
         draw_tool_palette();
         draw_tweak_window();

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -686,24 +686,7 @@ void HDRViewApp::setup_frame_callbacks()
                 if (should_select)
                     m_current = is_valid(idx) ? idx : int(m_images.size() - 1);
 
-                if (m_pending_session)
-                {
-                    // Resolve this arrival to the earliest not-yet-filled entry sharing its load options;
-                    // see PendingSession in app.h for why that key is the right one to match on.
-                    auto key =
-                        PendingSession::Key{new_image->path, new_image->channel_selector, new_image->alpha_override};
-                    if (auto it = m_pending_session->unresolved.find(key); it != m_pending_session->unresolved.end())
-                    {
-                        if (!it->second.empty())
-                        {
-                            int entry_idx = it->second.front();
-                            it->second.pop_front();
-                            m_pending_session->entries[entry_idx].loaded = new_image;
-                        }
-                        if (it->second.empty())
-                            m_pending_session->unresolved.erase(it);
-                    }
-                }
+                resolve_pending_session_image(new_image);
 
                 update_visibility(); // this also calls set_image_textures();
                 m_request_sort = true;

--- a/src/app.h
+++ b/src/app.h
@@ -509,15 +509,23 @@ public:
     float display_headroom() const;
 
 private:
+    //-----------------------------------------------------------------------------
+    // Subsystem state, defined in the .cpp file that owns it
+    //-----------------------------------------------------------------------------
+    struct PendingSessionLoad; // app-file-io.cpp
+    struct PendingSession;     // app-file-io.cpp
+    struct RunningFilter;      // app-edit.cpp
+#if HDRVIEW_ENABLE_IPC
+    struct IpcRates; // app-ipc.cpp
+#endif
+
     void load_fonts();
 
-    // Begins asynchronously loading the images listed in a parsed session file `j` (paths resolved relative
-    // to `dir`), populating m_pending_session; the rest of the session is applied by finish_pending_session()
-    // once every image has arrived.
-    void begin_session_load(const json &j, const fs::path &dir);
-    // Same as begin_session_load(), but for a session bundled inside a zip: each image entry's "path" names
-    // an entry of `zip_bytes`, extracted into memory and fed to the loader as a buffer.
-    void begin_bundle_session_load(string_view zip_bytes, const string &zip_name, const json &j);
+    // Begins asynchronously loading the images `load` lists, populating m_pending_session; the rest of the
+    // session is applied by finish_pending_session() once every image has arrived.
+    void begin_session_load(const PendingSessionLoad &load);
+    // Matches an image that has just finished loading to the session entry that asked for it.
+    void resolve_pending_session_image(const ImagePtr &new_image);
     // Called once every image in m_pending_session has been resolved (successfully or not); rebuilds m_images
     // in the saved order, then applies current/reference selection, blend mode, and view settings.
     void finish_pending_session();
@@ -624,40 +632,8 @@ private:
     /// Do the thing the prompt was asking about, now that it has been confirmed.
     void apply_pending_discard();
 
-    /// A filter running off the main thread, with what is needed to finish or abandon it.
-    /**
-        The worker writes only `results` and `progress`; the main thread reads `done` once a frame and
-        applies the results.
-    */
-    struct RunningFilter
-    {
-        ImagePtr         image;
-        std::string      name;
-        std::vector<int> channels;
-        Box2i            bounds;
-
-        /// Filters one of `channels`, given its index among them and a share of the progress bar.
-        std::function<Array2Df(const Array2Df &, int, AtomicProgress)> filter;
-
-        int2                  new_size{0}; ///< The size of the results; zero keeps the image's shape.
-        std::vector<Array2Df> results;
-        AtomicProgress        progress{true};
-        std::atomic<bool>     done{false};
-        std::thread           worker;
-
-        /// Cancel and join the worker.
-        /**
-            It reads this object and the thread pool, and both go away with the application.
-        */
-        ~RunningFilter()
-        {
-            progress.cancel();
-            if (worker.joinable())
-                worker.join();
-        }
-    };
-
-    std::unique_ptr<RunningFilter> m_running_filter;
+    /// The filter running off the main thread, if any; see start_filter().
+    std::shared_ptr<RunningFilter> m_running_filter;
 
     /// Filters waiting for the one in flight; only one runs at a time (one progress dialog, one Cancel).
     /**
@@ -669,7 +645,7 @@ private:
     /**
         On a worker with a progress dialog, or inline where there are no threads.
     */
-    void start_filter(std::unique_ptr<RunningFilter> running);
+    void start_filter(std::shared_ptr<RunningFilter> running);
     /// Applies a finished filter's results, or clears an abandoned one. Called once a frame.
     void drain_running_filter();
     /// Starts the next queued filter, if a fan-out left any waiting.
@@ -715,21 +691,8 @@ private:
     */
     bool m_ipc_listen_requested = false;
 
-    /// Turns the listener's running totals into the rates the activity readout shows.
-    /**
-        Sampled over a window rather than per frame: at 60 fps the per-frame deltas are one or two packets.
-    */
-    struct IpcRates
-    {
-        double   sampled_at    = 0.0; ///< ImGui::GetTime() of the last sample
-        uint64_t last_packets  = 0;
-        uint64_t last_bytes    = 0;
-        double   packets_per_s = 0.0;
-        double   bytes_per_s   = 0.0;
-
-        void update(const IpcActivity &now, double time);
-    };
-    IpcRates m_ipc_rates;
+    /// The rates the activity readout shows; created on first use by draw_ipc_gui().
+    std::shared_ptr<IpcRates> m_ipc_rates;
 
     // Each applies one already-decoded packet, on the main thread. Decoding happens on the receive thread;
     // see start_ipc_listening().
@@ -932,50 +895,11 @@ private:
     // Linear search by title; only ever called from a user-triggered action, never per-frame.
     PopupDialog &dialog(const string &title);
 
-    // A parsed session file waiting on the user to confirm closing currently-open images before it starts loading.
-    struct PendingSessionLoad
-    {
-        json     j;
-        fs::path dir;
-    };
-    optional<PendingSessionLoad> m_pending_session_load;
+    /// A parsed session file waiting on the user to confirm closing the currently-open images.
+    std::shared_ptr<PendingSessionLoad> m_pending_session_load;
 
-    // Same as PendingSessionLoad, but for a session bundled inside a zip; the zip's bytes are owned here
-    // until the user confirms, since begin_bundle_session_load() needs them again then.
-    struct PendingZipSessionLoad
-    {
-        string zip_bytes;
-        string zip_name;
-        json   j;
-    };
-    optional<PendingZipSessionLoad> m_pending_zip_session_load;
-
-    // A session whose images have been issued to the BackgroundImageLoader and are loading asynchronously;
-    // the rest of it (selection, blend mode, view settings) is applied by finish_pending_session() once every
-    // entry here has been resolved, successfully or not.
-    struct PendingSession
-    {
-        struct Entry
-        {
-            fs::path             path;
-            string               channel_selector;
-            optional<AlphaType_> alpha_override; ///< Empty when the file's own interpretation was used
-            int                  selected_group = 0, reference_group = 0;
-            vector<string>       selected_channels; ///< The multi-selection, by channel name; see Channel::selected
-            ImagePtr loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
-        };
-        vector<Entry> entries; ///< One per saved "images" entry, in file order; the same path may repeat
-        int           current_index = -1, reference_index = -1; ///< Index into entries, or -1 if unset
-        BlendMode_    blend_mode;
-        json          view; ///< The session file's "view" sub-object, applied verbatim once loading completes
-
-        // An arriving image is matched to the earliest not-yet-filled entry sharing its load options. Entries
-        // sharing that key are content-identical, so any one-to-one assignment among them is correct however
-        // the async loads finish -- which is what makes it safe to load the same file twice in one session.
-        using Key = std::tuple<fs::path, string, optional<AlphaType_>>; ///< path, channel_selector, alpha_override
-        map<Key, deque<int>> unresolved;
-    };
-    optional<PendingSession> m_pending_session;
+    /// The session whose images are loading asynchronously; see begin_session_load().
+    std::shared_ptr<PendingSession> m_pending_session;
 };
 
 /// Create the global singleton HDRViewApp instance

--- a/src/app.h
+++ b/src/app.h
@@ -512,8 +512,8 @@ private:
     //-----------------------------------------------------------------------------
     // Subsystem state, defined in the .cpp file that owns it
     //-----------------------------------------------------------------------------
-    struct PendingSessionLoad; // app-file-io.cpp
-    struct PendingSession;     // app-file-io.cpp
+    struct UnconfirmedSession; // app-file-io.cpp
+    struct LoadingSession;     // app-file-io.cpp
     struct RunningFilter;      // app-edit.cpp
 #if HDRVIEW_ENABLE_IPC
     struct IpcRates; // app-ipc.cpp
@@ -521,14 +521,14 @@ private:
 
     void load_fonts();
 
-    // Begins asynchronously loading the images `load` lists, populating m_pending_session; the rest of the
-    // session is applied by finish_pending_session() once every image has arrived.
-    void begin_session_load(const PendingSessionLoad &load);
+    // Begins asynchronously loading the images `load` lists, populating m_loading_session; the rest of the
+    // session is applied by finish_loading_session() once every image has arrived.
+    void begin_session_load(const UnconfirmedSession &load);
     // Matches an image that has just finished loading to the session entry that asked for it.
-    void resolve_pending_session_image(const ImagePtr &new_image);
-    // Called once every image in m_pending_session has been resolved (successfully or not); rebuilds m_images
+    void resolve_loading_session_image(const ImagePtr &new_image);
+    // Called once every image in m_loading_session has been resolved (successfully or not); rebuilds m_images
     // in the saved order, then applies current/reference selection, blend mode, and view settings.
-    void finish_pending_session();
+    void finish_loading_session();
 
     void   handle_mouse_interaction();
     void   calculate_viewport();
@@ -896,10 +896,10 @@ private:
     PopupDialog &dialog(const string &title);
 
     /// A parsed session file waiting on the user to confirm closing the currently-open images.
-    std::shared_ptr<PendingSessionLoad> m_pending_session_load;
+    std::shared_ptr<UnconfirmedSession> m_unconfirmed_session;
 
     /// The session whose images are loading asynchronously; see begin_session_load().
-    std::shared_ptr<PendingSession> m_pending_session;
+    std::shared_ptr<LoadingSession> m_loading_session;
 };
 
 /// Create the global singleton HDRViewApp instance


### PR DESCRIPTION
`app.h` declares the god-object, and over the last month it absorbed every subsystem's private state, so opening the header to see what the class offers meant wading through structs that one `.cpp` each ever touches.

## What changed

**Four structs move to the file that owns them.** The two session states and `LoadingSession` to `app-file-io.cpp`, `RunningFilter` to `app-edit.cpp`, `IpcRates` to `app-ipc.cpp`. The header forward-declares each and holds a `shared_ptr`, not `unique_ptr`, whose destructor needs the definition — which for these is in a different translation unit each.

**The two session loaders were 109 lines differing only in where the bytes came from.** One struct now carries both cases, an empty `zip_bytes` meaning a plain `.hsess`, and one loader picks between `load_image()` and `background_load()` on that. 74 lines, and the confirm dialog no longer branches on which of two optionals is set.

**The alpha override's tokens** go through the enum id tables that already sat ten lines above the hand-written pair in the same file.

| | |
|---|---|
| `app.h` | 986 → 910 |
| doctest | 327 cases, 361,735 assertions |
| GUI tests | 101 / 101 |

## From review

**The two session structs are renamed** `UnconfirmedSession` and `LoadingSession`. They previously differed by one word and neither said which came first: one holds a parsed file while a modal asks whether to discard the open images, the other holds the load already in flight.

They stay separate rather than merging, which was the question asked. They are consecutive phases with disjoint fields, so one struct would leave half its members inert at any moment, and the two nullable members are what say which phase the app is in.

**Four struct-level comment blocks are gone**, their content moved onto the members they were about — why a bundled session keeps its zip bytes, and why the IPC rates sample over a window instead of per frame. The arrival-matching note went from four lines to two.

## Two things worth knowing

**I predicted −250 lines and delivered −76.** That estimate came from the audit, which measured against the 1173-line header and counted comment reduction that had already landed in #212. The struct bodies are 92 lines, so the ceiling was always about −76. The loader merge and the enum tables stand on their own regardless.

**The "Replace session?" confirm path has no test.** Every GUI session test closes its images first, so nothing exercises it. Its code changed here and is verified by inspection plus a manual run of the real binary against a hand-written session file with out-of-order arrivals and a bogus token, and against a zip bundle with a missing entry. A test would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
