### PR TITLE
Say only whether an image's alpha kind was a guess

### DIFF
--- a/src/app-draw.cpp
+++ b/src/app-draw.cpp
@@ -295,7 +295,7 @@ void HDRViewApp::draw_image() const
             M_to_sRGB = float4x4{
                 {img->M_to_sRGB[0], 0.f}, {img->M_to_sRGB[1], 0.f}, {img->M_to_sRGB[2], 0.f}, {0.f, 0.f, 0.f, 1.f}};
             channels_type  = (int)group.type;
-            straight_alpha = (int)(img->alpha_type == AlphaType_Straight);
+            straight_alpha = (int)(img->transparency == TransparencyType_Straight);
             yw             = img->luminance_weights;
         }
 

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -49,8 +49,8 @@ const char *const g_bg_mode_ids[BGMode_COUNT]   = {"black", "white", "dark_check
 // A session records the alpha override the user chose, not the interpretation it produced: with no override
 // the file is read afresh, so a corrected loader or an edited file is picked up. The trailing entry is that
 // "no override" case, which is why this table is one longer than the enum.
-const char *const g_alpha_type_ids[AlphaType_Count + 1] = {"none", "premultiplied-linear", "premultiplied-nonlinear",
-                                                           "straight", ""};
+const char *const g_transparency_type_ids[TransparencyType_Count + 1] = {"none", "premultiplied-linear",
+                                                                         "premultiplied-nonlinear", "straight", ""};
 
 template <typename Enum, size_t N>
 string enum_to_id(Enum value, const char *const (&ids)[N])
@@ -73,10 +73,11 @@ Enum id_to_enum(const json &j, const char *key, const char *const (&ids)[N], Enu
 }
 
 // The alpha override an image entry asks for, empty when it uses the file's own interpretation.
-optional<AlphaType_> alpha_override_from_id(const json &j)
+optional<TransparencyType_> transparency_override_from_id(const json &j)
 {
-    auto at = id_to_enum(j, "alpha_override", g_alpha_type_ids, (AlphaType_)AlphaType_Count);
-    return at == AlphaType_Count ? optional<AlphaType_>{} : at;
+    auto at =
+        id_to_enum(j, "transparency_override", g_transparency_type_ids, (TransparencyType_)TransparencyType_Count);
+    return at == TransparencyType_Count ? optional<TransparencyType_>{} : at;
 }
 
 // Checks "type"/"version" on a parsed session manifest (`source_name` is a filename or zip archive name,
@@ -693,11 +694,11 @@ void HDRViewApp::reload_image(ImagePtr image, bool should_select)
     }
 
     spdlog::info("Reloading file '{}' with channel selector '{}'...", image->filename, image->channel_selector);
-    auto opts             = load_image_options();
-    opts.channel_selector = image->channel_selector;
-    opts.override_alpha   = image->alpha_override.has_value();
-    if (image->alpha_override)
-        opts.alpha_override = *image->alpha_override;
+    auto opts                  = load_image_options();
+    opts.channel_selector      = image->channel_selector;
+    opts.override_transparency = image->transparency_override.has_value();
+    if (image->transparency_override)
+        opts.transparency_override = *image->transparency_override;
 
 #if defined(__EMSCRIPTEN__)
     // A URL was never on a filesystem to be re-read from; fetch it again instead.
@@ -895,8 +896,8 @@ json HDRViewApp::build_session_manifest(const std::function<string(ConstImagePtr
         json entry;
         entry["path"]             = path_of(img);
         entry["channel_selector"] = img->channel_selector;
-        if (img->alpha_override)
-            entry["alpha_override"] = enum_to_id(*img->alpha_override, g_alpha_type_ids);
+        if (img->transparency_override)
+            entry["transparency_override"] = enum_to_id(*img->transparency_override, g_transparency_type_ids);
         entry["selected_group"]  = img->selected_group;
         entry["reference_group"] = img->reference_group;
 
@@ -1075,12 +1076,12 @@ struct HDRViewApp::LoadingSession
 {
     struct Entry
     {
-        fs::path             path;
-        string               channel_selector;
-        optional<AlphaType_> alpha_override; ///< Empty when the file's own interpretation was used
-        int                  selected_group = 0, reference_group = 0;
-        vector<string>       selected_channels; ///< The multi-selection, by channel name; see Channel::selected
-        ImagePtr             loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
+        fs::path                    path;
+        string                      channel_selector;
+        optional<TransparencyType_> transparency_override; ///< Empty when the file's own interpretation was used
+        int                         selected_group = 0, reference_group = 0;
+        vector<string>              selected_channels; ///< The multi-selection, by channel name; see Channel::selected
+        ImagePtr loaded; ///< Set once this entry's image arrives; still null => not yet arrived, or failed
     };
     vector<Entry> entries;                                  ///< One per saved "images" entry, in file order
     int           current_index = -1, reference_index = -1; ///< Index into entries, or -1 if unset
@@ -1089,7 +1090,8 @@ struct HDRViewApp::LoadingSession
 
     // An arrival fills the earliest entry sharing its load options. Entries sharing a key ask for identical
     // content, so any one-to-one assignment is right whatever order the loads finish in.
-    using Key = std::tuple<fs::path, string, optional<AlphaType_>>; ///< path, channel_selector, alpha_override
+    using Key =
+        std::tuple<fs::path, string, optional<TransparencyType_>>; ///< path, channel_selector, transparency_override
     map<Key, deque<int>> unresolved;
 };
 
@@ -1233,12 +1235,12 @@ void HDRViewApp::begin_session_load(const UnconfirmedSession &load)
         // get (see extract_and_schedule() in image_loader.cpp), so "reveal in file manager" and
         // reload_image() need no session-specific handling.
         LoadingSession::Entry e;
-        e.path              = from_zip ? fs::path(load.zip_name) / fs::u8path(rel) : resolve(rel);
-        e.channel_selector  = entry.value<string>("channel_selector", "");
-        e.alpha_override    = alpha_override_from_id(entry);
-        e.selected_group    = entry.value<int>("selected_group", 0);
-        e.reference_group   = entry.value<int>("reference_group", 0);
-        e.selected_channels = entry.value<vector<string>>("selected_channels", {});
+        e.path                  = from_zip ? fs::path(load.zip_name) / fs::u8path(rel) : resolve(rel);
+        e.channel_selector      = entry.value<string>("channel_selector", "");
+        e.transparency_override = transparency_override_from_id(entry);
+        e.selected_group        = entry.value<int>("selected_group", 0);
+        e.reference_group       = entry.value<int>("reference_group", 0);
+        e.selected_channels     = entry.value<vector<string>>("selected_channels", {});
 
         int idx = (int)pending.entries.size();
         pending.entries.push_back(e);
@@ -1257,13 +1259,13 @@ void HDRViewApp::begin_session_load(const UnconfirmedSession &load)
             }
         }
 
-        pending.unresolved[{e.path, e.channel_selector, e.alpha_override}].push_back(idx);
+        pending.unresolved[{e.path, e.channel_selector, e.transparency_override}].push_back(idx);
 
         ImageLoadOptions opts;
-        opts.channel_selector = e.channel_selector;
-        opts.override_alpha   = e.alpha_override.has_value();
-        if (e.alpha_override)
-            opts.alpha_override = *e.alpha_override;
+        opts.channel_selector      = e.channel_selector;
+        opts.override_transparency = e.transparency_override.has_value();
+        if (e.transparency_override)
+            opts.transparency_override = *e.transparency_override;
         if (from_zip)
             m_image_loader.background_load(e.path.string(), *bytes, false, nullptr, opts);
         else
@@ -1285,7 +1287,7 @@ void HDRViewApp::resolve_loading_session_image(const ImagePtr &new_image)
 
     // Resolve this arrival to the earliest not-yet-filled entry sharing its load options; see LoadingSession
     // for why that key is the right one to match on.
-    auto key = LoadingSession::Key{new_image->path, new_image->channel_selector, new_image->alpha_override};
+    auto key = LoadingSession::Key{new_image->path, new_image->channel_selector, new_image->transparency_override};
     auto it  = m_loading_session->unresolved.find(key);
     if (it == m_loading_session->unresolved.end())
         return;

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -506,8 +506,7 @@ void HDRViewApp::load_images(const vector<string> &filenames)
             continue;
         }
 
-        // A .zip might be a session bundle; see zip_bundle_hook, checked inside background_load() once it
-        // has the zip's bytes in hand.
+        // A .zip might be a session bundle, which background_load() checks for once it has the bytes in hand.
         load_image(filenames[i], std::nullopt, i == 0, opts);
     }
 }
@@ -535,7 +534,7 @@ void HDRViewApp::open_image()
                 spdlog::debug("User uploaded a {:.0h} file with filename '{}' of mime-type '{}'",
                               human_readible{buffer.size()}, filename, mime_type);
 
-                // A zip might be a session bundle -- see load_image()/background_load()'s zip_bundle_hook.
+                // A zip might be a session bundle; background_load() checks for that.
                 hdrview()->load_image(filename, buffer, true, load_image_options());
             }
         });
@@ -815,13 +814,14 @@ void HDRViewApp::close_image_immediately(int index)
         }
 
         spdlog::debug("Watched directories after closing image:");
-        m_image_loader.remove_implicitly_watched_directories(
+        m_image_loader.remove_watched_directories(
             [this](const fs::path &path)
             {
                 spdlog::debug("{} watched directory: {}",
                               m_active_directories.count(path) == 0 ? "Removing" : "Keeping", path.u8string());
                 return m_active_directories.count(path) == 0;
-            });
+            },
+            /* keep_explicit */ true);
 #endif
     }
 
@@ -869,7 +869,7 @@ void HDRViewApp::close_all_images_immediately()
     m_active_directories.clear();
     // Only the folders opened alongside these images; one the user asked to watch stays watched, since it
     // is there for files that do not exist yet.
-    m_image_loader.remove_implicitly_watched_directories([](const fs::path &) { return true; });
+    m_image_loader.remove_watched_directories([](const fs::path &) { return true; }, /* keep_explicit */ true);
     update_visibility(); // this also calls set_image_textures();
 }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -105,11 +105,6 @@ void HDRViewApp::setup_window_and_backend(optional<bool> force_sdr)
     Imf::setGlobalThreadCount(threads);
     spdlog::debug("OpenEXR reports global thread count as {}", Imf::globalThreadCount());
 
-    // Lets any zip opened through m_image_loader (drag-and-drop, CLI args, "Open image...") be recognized as
-    // a session bundle; see try_load_zip_as_session().
-    m_image_loader.zip_bundle_hook = [this](string_view zip_bytes, const string &zip_name)
-    { return try_load_zip_as_session(zip_bytes, zip_name); };
-
 #if defined(__APPLE__)
     // if there is a screen with a non-retina resolution connected to an otherwise retina mac, the fonts may
     // look blurry. Here we force that macs always use the 2X retina scale factor for fonts. Produces crisp

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -476,19 +476,19 @@ static const char *s_transfer_function_names[TransferFunction::Count + 1] = {
     "DCI-P3",                  // TransferFunction::DCI_P3
     nullptr};
 
-static const char *s_alpha_type_names[] = {"None", "Premultiplied Linear", "Premultiplied Non-Linear", "Straight",
-                                           nullptr};
+static const char *s_transparency_type_names[] = {"None", "Premultiplied Linear", "Premultiplied Non-Linear",
+                                                  "Straight", nullptr};
 
-// Spelled out, unlike s_alpha_type_names: the metadata panel reports what the file turned out to hold,
+// Spelled out, unlike s_transparency_type_names: the metadata panel reports what the file turned out to hold,
 // where one word is enough, while the combo asks the user to choose between the kinds.
-static const char *s_alpha_override_names[] = {"None (channel is data)", "Premultiplied, in linear light",
-                                               "Premultiplied, after transfer", "Straight", nullptr};
+static const char *s_transparency_override_names[] = {"None", "Premultiplied, in linear light",
+                                                      "Premultiplied, after transfer", "Straight", nullptr};
 
-const char *alpha_type_name(AlphaType_ at) { return s_alpha_type_names[at]; }
+const char *transparency_type_name(TransparencyType_ at) { return s_transparency_type_names[at]; }
 
-const char *alpha_override_name(AlphaType_ at) { return s_alpha_override_names[at]; }
+const char *transparency_override_name(TransparencyType_ at) { return s_transparency_override_names[at]; }
 
-const char **alpha_type_names() { return s_alpha_type_names; }
+const char **transparency_type_names() { return s_transparency_type_names; }
 
 namespace
 {

--- a/src/colorspace.cpp
+++ b/src/colorspace.cpp
@@ -484,14 +484,7 @@ static const char *s_alpha_type_names[] = {"None", "Premultiplied Linear", "Prem
 static const char *s_alpha_override_names[] = {"None (channel is data)", "Premultiplied, in linear light",
                                                "Premultiplied, after transfer", "Straight", nullptr};
 
-static const char *s_alpha_source_suffixes[] = {"assumed", "per the format", "from the file", nullptr};
-static const char *s_alpha_source_phrases[]  = {"assumed", "the format says", "the file said", nullptr};
-
 const char *alpha_type_name(AlphaType_ at) { return s_alpha_type_names[at]; }
-
-const char *alpha_source_suffix(AlphaSource_ as) { return s_alpha_source_suffixes[as]; }
-
-const char *alpha_source_phrase(AlphaSource_ as) { return s_alpha_source_phrases[as]; }
 
 const char *alpha_override_name(AlphaType_ at) { return s_alpha_override_names[at]; }
 

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -17,20 +17,20 @@
 #include <string>
 #include <vector>
 
-using AlphaType_ = int;
-enum AlphaType : AlphaType_
+using TransparencyType_ = int;
+enum TransparencyType : TransparencyType_
 {
-    AlphaType_None = 0,
-    AlphaType_PremultipliedLinear,
-    AlphaType_PremultipliedNonLinear, // values are premultiplied in e.g. gamma- or sRGB-encoded space
-    AlphaType_Straight,
-    AlphaType_Count
+    TransparencyType_None = 0,
+    TransparencyType_PremultipliedLinear,
+    TransparencyType_PremultipliedNonLinear, // values are premultiplied in e.g. gamma- or sRGB-encoded space
+    TransparencyType_Straight,
+    TransparencyType_Count
 };
 
-const char *alpha_type_name(AlphaType_ at);
+const char *transparency_type_name(TransparencyType_ at);
 /// Name for the alpha-override combo, which needs to say more than the metadata panel's one-word label.
-const char  *alpha_override_name(AlphaType_ at);
-const char **alpha_type_names();
+const char  *transparency_override_name(TransparencyType_ at);
+const char **transparency_type_names();
 
 /**
  * Computes the luminance as ``l = 0.299r + 0.587g + 0.144b + 0.0a``.  If

--- a/src/colorspace.h
+++ b/src/colorspace.h
@@ -27,31 +27,7 @@ enum AlphaType : AlphaType_
     AlphaType_Count
 };
 
-/// Where an image's AlphaType_ came from, which is not the same question as what it is.
-/**
-    A file can state its alpha kind, or its format can settle it for every conforming file, or nothing can
-    say and the loader has to pick. Only the last is a guess, and it is where an override is most likely
-    wanted. An explicit tag is not automatically the most trustworthy of the three -- ImageMagick and vips
-    both write premultiplied TIFF samples tagged unassociated -- so this records provenance rather than
-    confidence.
-*/
-using AlphaSource_ = int;
-enum AlphaSource : AlphaSource_
-{
-    AlphaSource_Assumed = 0, ///< Nothing stated it; the loader picked a default
-    AlphaSource_Format,      ///< The format settles it for every conforming file
-    AlphaSource_File,        ///< This file said so, in a tag or flag of its own
-    AlphaSource_Count
-};
-
 const char *alpha_type_name(AlphaType_ at);
-/// How the alpha kind was arrived at, phrased to follow it: "Straight (from the file)".
-const char *alpha_source_suffix(AlphaSource_ as);
-/// The same, phrased to introduce a kind instead: "the file said Straight".
-/**
-    For where an override has displaced a kind and both have to appear.
-*/
-const char *alpha_source_phrase(AlphaSource_ as);
 /// Name for the alpha-override combo, which needs to say more than the metadata panel's one-word label.
 const char  *alpha_override_name(AlphaType_ at);
 const char **alpha_type_names();

--- a/src/edit/commands/tonal.cpp
+++ b/src/edit/commands/tonal.cpp
@@ -151,7 +151,7 @@ public:
         if (auto img = ctx.image; img && img->is_valid_group(img->active_group_index(Target_Primary)))
         {
             const auto &group = img->groups[size_t(img->active_group_index(Target_Primary))];
-            if (img->alpha_type != AlphaType_None && group_has_alpha(group.type))
+            if (img->transparency != TransparencyType_None && group_has_alpha(group.type))
             {
                 premultiplied = true;
                 alpha_slot    = group.num_channels - 1;

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1286,15 +1286,15 @@ void Image::draw_info()
                                           ICON_MY_TIMES, display_window.min.y, display_window.max.y));
             // An override says what it displaced, since contradicting a kind the file stated is not the
             // same as filling in one nothing ever did.
-            filtered_property(
-                "Alpha",
-                alpha_override ? fmt::format("{} (override; {} {})", alpha_type_name(alpha_type),
-                                             alpha_source_phrase(alpha_source), alpha_type_name(alpha_type_from_file))
-                               : fmt::format("{} ({})", alpha_type_name(alpha_type), alpha_source_suffix(alpha_source)),
-                "How this image's alpha is being read: whether the color channels are multiplied "
-                "by it, and in what space, and where that came from. \"Assumed\" means nothing "
-                "stated it and the loader picked a default, which is where the override below is "
-                "most likely wanted.");
+            const string from_file =
+                fmt::format("{}{}", alpha_type_name(alpha_type_from_file), alpha_assumed ? " (assumed)" : "");
+            filtered_property("Alpha",
+                              alpha_override
+                                  ? fmt::format("{} (override; was {})", alpha_type_name(alpha_type), from_file)
+                                  : from_file,
+                              "How this image's alpha is being read: whether the color channels are multiplied "
+                              "by it, and in what space. \"Assumed\" means nothing in the file stated it and the "
+                              "loader picked a default, which is where the override below is most likely wanted.");
 
             if (filter.PassFilter("Alpha override"))
             {

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -1286,12 +1286,12 @@ void Image::draw_info()
                                           ICON_MY_TIMES, display_window.min.y, display_window.max.y));
             // An override says what it displaced, since contradicting a kind the file stated is not the
             // same as filling in one nothing ever did.
-            const string from_file =
-                fmt::format("{}{}", alpha_type_name(alpha_type_from_file), alpha_assumed ? " (assumed)" : "");
+            const string from_file = fmt::format("{}{}", transparency_type_name(transparency_from_file),
+                                                 transparency_assumed ? " (assumed)" : "");
             filtered_property("Alpha",
-                              alpha_override
-                                  ? fmt::format("{} (override; was {})", alpha_type_name(alpha_type), from_file)
-                                  : from_file,
+                              transparency_override ? fmt::format("{} (override; was {})",
+                                                                  transparency_type_name(transparency), from_file)
+                                                    : from_file,
                               "How this image's alpha is being read: whether the color channels are multiplied "
                               "by it, and in what space. \"Assumed\" means nothing in the file stated it and the "
                               "loader picked a default, which is where the override below is most likely wanted.");
@@ -1318,19 +1318,21 @@ void Image::draw_info()
 
                         bool changed = false;
                         if (ImGui::BeginCombo("##Alpha override",
-                                              alpha_override ? alpha_override_name(*alpha_override) : k_not_overridden))
+                                              transparency_override ? transparency_override_name(*transparency_override)
+                                                                    : k_not_overridden))
                         {
-                            if (ImGui::Selectable(k_not_overridden, !alpha_override))
+                            if (ImGui::Selectable(k_not_overridden, !transparency_override))
                             {
-                                alpha_override.reset();
+                                transparency_override.reset();
                                 changed = true;
                             }
 
-                            for (AlphaType_ a = 0; a < AlphaType_Count; ++a)
-                                if (ImGui::Selectable(alpha_override_name(a), alpha_override && *alpha_override == a))
+                            for (TransparencyType_ a = 0; a < TransparencyType_Count; ++a)
+                                if (ImGui::Selectable(transparency_override_name(a),
+                                                      transparency_override && *transparency_override == a))
                                 {
-                                    alpha_override = a;
-                                    changed        = true;
+                                    transparency_override = a;
+                                    changed               = true;
                                 }
 
                             ImGui::EndCombo();

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -865,7 +865,7 @@ Image::Image(int2 size, int num_channels) : Image()
         }
     }
     display_window = data_window = Box2i{int2{0}, channels.front().size()};
-    set_default_alpha_type();
+    set_default_transparency();
 }
 
 Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
@@ -877,27 +877,28 @@ Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
     for (const auto &name : channel_names) channels.emplace_back(name, size);
 
     display_window = data_window = Box2i{int2{0}, size};
-    set_default_alpha_type();
+    set_default_transparency();
 }
 
-void Image::set_alpha(AlphaType_ from_file, const std::optional<AlphaType_> &override_with, bool assumed)
+void Image::set_transparency(TransparencyType_ from_file, const std::optional<TransparencyType_> &override_with,
+                             bool assumed)
 {
-    alpha_type_from_file = from_file;
-    alpha_assumed        = assumed;
-    alpha_type           = override_with.value_or(from_file);
+    transparency_from_file = from_file;
+    transparency_assumed   = assumed;
+    transparency           = override_with.value_or(from_file);
 }
 
-void Image::set_default_alpha_type()
+void Image::set_default_transparency()
 {
     for (const auto &c : channels)
         if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
         {
-            // Assembled rather than read, so nothing declared this; see set_default_alpha_type()'s comment.
-            set_alpha(AlphaType_PremultipliedLinear, std::nullopt, true);
+            // Assembled rather than read, so nothing declared this; see set_default_transparency()'s comment.
+            set_transparency(TransparencyType_PremultipliedLinear, std::nullopt, true);
             return;
         }
 
-    set_alpha(AlphaType_None, std::nullopt, true);
+    set_transparency(TransparencyType_None, std::nullopt, true);
 }
 
 map<string, int> Image::channels_in_layer(const string &layer) const
@@ -1250,30 +1251,30 @@ ImagePtr Image::duplicate(const Box2i &region) const
 
     // Everything that says what the samples mean. A copy that lost its primaries or its alpha convention
     // would be read differently from the image it was made of, which is not what "duplicate" means.
-    copy->filename             = filename;
-    copy->partname             = partname;
-    copy->channel_selector     = channel_selector;
-    copy->chromaticities       = chromaticities;
-    copy->adopted_neutral      = adopted_neutral;
-    copy->M_RGB_to_XYZ         = M_RGB_to_XYZ;
-    copy->M_XYZ_to_RGB         = M_XYZ_to_RGB;
-    copy->M_to_sRGB            = M_to_sRGB;
-    copy->luminance_weights    = luminance_weights;
-    copy->adaptation_method    = adaptation_method;
-    copy->color_space          = color_space;
-    copy->white_point          = white_point;
-    copy->alpha_type           = alpha_type;
-    copy->alpha_type_from_file = alpha_type_from_file;
-    copy->alpha_assumed        = alpha_assumed;
-    copy->alpha_override       = alpha_override;
-    copy->metadata             = metadata;
-    copy->exif                 = exif;
-    copy->xmp_data             = xmp_data;
-    copy->icc_data             = icc_data;
-    copy->orientation_applied  = orientation_applied;
-    copy->path                 = path;
-    copy->last_modified        = last_modified;
-    copy->size_bytes           = size_bytes;
+    copy->filename               = filename;
+    copy->partname               = partname;
+    copy->channel_selector       = channel_selector;
+    copy->chromaticities         = chromaticities;
+    copy->adopted_neutral        = adopted_neutral;
+    copy->M_RGB_to_XYZ           = M_RGB_to_XYZ;
+    copy->M_XYZ_to_RGB           = M_XYZ_to_RGB;
+    copy->M_to_sRGB              = M_to_sRGB;
+    copy->luminance_weights      = luminance_weights;
+    copy->adaptation_method      = adaptation_method;
+    copy->color_space            = color_space;
+    copy->white_point            = white_point;
+    copy->transparency           = transparency;
+    copy->transparency_from_file = transparency_from_file;
+    copy->transparency_assumed   = transparency_assumed;
+    copy->transparency_override  = transparency_override;
+    copy->metadata               = metadata;
+    copy->exif                   = exif;
+    copy->xmp_data               = xmp_data;
+    copy->icc_data               = icc_data;
+    copy->orientation_applied    = orientation_applied;
+    copy->path                   = path;
+    copy->last_modified          = last_modified;
+    copy->size_bytes             = size_bytes;
 
     // Not copied: `id`, which the constructor hands out; `history`, since nothing has been done to the
     // copy; `is_live`, since these samples are a snapshot; and `vector_overlay`, which annotates what a
@@ -1580,7 +1581,7 @@ void Image::finalize()
 
     // if we have a straight alpha channel, premultiply the other channels by it.
     // this needs to be done after the values have been made linear
-    if (alpha_type == AlphaType_Straight)
+    if (transparency == TransparencyType_Straight)
     {
         for (auto &g : groups)
         {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -880,10 +880,10 @@ Image::Image(int2 size, const std::vector<std::string> &channel_names) : Image()
     set_default_alpha_type();
 }
 
-void Image::set_alpha(AlphaType_ from_file, AlphaSource_ source, const std::optional<AlphaType_> &override_with)
+void Image::set_alpha(AlphaType_ from_file, const std::optional<AlphaType_> &override_with, bool assumed)
 {
     alpha_type_from_file = from_file;
-    alpha_source         = source;
+    alpha_assumed        = assumed;
     alpha_type           = override_with.value_or(from_file);
 }
 
@@ -893,11 +893,11 @@ void Image::set_default_alpha_type()
         if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
         {
             // Assembled rather than read, so nothing declared this; see set_default_alpha_type()'s comment.
-            set_alpha(AlphaType_PremultipliedLinear, AlphaSource_Assumed, std::nullopt);
+            set_alpha(AlphaType_PremultipliedLinear, std::nullopt, true);
             return;
         }
 
-    set_alpha(AlphaType_None, AlphaSource_Assumed, std::nullopt);
+    set_alpha(AlphaType_None, std::nullopt, true);
 }
 
 map<string, int> Image::channels_in_layer(const string &layer) const
@@ -1264,7 +1264,7 @@ ImagePtr Image::duplicate(const Box2i &region) const
     copy->white_point          = white_point;
     copy->alpha_type           = alpha_type;
     copy->alpha_type_from_file = alpha_type_from_file;
-    copy->alpha_source         = alpha_source;
+    copy->alpha_assumed        = alpha_assumed;
     copy->alpha_override       = alpha_override;
     copy->metadata             = metadata;
     copy->exif                 = exif;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1249,36 +1249,11 @@ ImagePtr Image::duplicate(const Box2i &region) const
 
     auto copy = std::make_shared<Image>();
 
-    // Everything that says what the samples mean. A copy that lost its primaries or its alpha convention
-    // would be read differently from the image it was made of, which is not what "duplicate" means.
-    copy->filename               = filename;
-    copy->partname               = partname;
-    copy->channel_selector       = channel_selector;
-    copy->chromaticities         = chromaticities;
-    copy->adopted_neutral        = adopted_neutral;
-    copy->M_RGB_to_XYZ           = M_RGB_to_XYZ;
-    copy->M_XYZ_to_RGB           = M_XYZ_to_RGB;
-    copy->M_to_sRGB              = M_to_sRGB;
-    copy->luminance_weights      = luminance_weights;
-    copy->adaptation_method      = adaptation_method;
-    copy->color_space            = color_space;
-    copy->white_point            = white_point;
-    copy->transparency           = transparency;
-    copy->transparency_from_file = transparency_from_file;
-    copy->transparency_assumed   = transparency_assumed;
-    copy->transparency_override  = transparency_override;
-    copy->metadata               = metadata;
-    copy->exif                   = exif;
-    copy->xmp_data               = xmp_data;
-    copy->icc_data               = icc_data;
-    copy->orientation_applied    = orientation_applied;
-    copy->path                   = path;
-    copy->last_modified          = last_modified;
-    copy->size_bytes             = size_bytes;
-
-    // Not copied: `id`, which the constructor hands out; `history`, since nothing has been done to the
-    // copy; `is_live`, since these samples are a snapshot; and `vector_overlay`, which annotates what a
-    // renderer is producing.
+    // Everything that says what the samples mean: a copy that lost its primaries or its alpha convention
+    // would be read differently from the image it was made of. Left behind are `id`, which the constructor
+    // hands out; `history`, since nothing has been done to the copy; `is_live`, since these samples are a
+    // snapshot; and `vector_overlay`, which annotates what a renderer is producing.
+    static_cast<ImageMetadata &>(*copy) = *this;
 
     const int2 extent = clipped.size();
     const int2 offset = clipped.min - data_window.min;
@@ -1286,8 +1261,8 @@ ImagePtr Image::duplicate(const Box2i &region) const
     copy->channels.reserve(channels.size());
     for (const auto &channel : channels)
     {
-        // Channel cannot be copied -- the deleted copy is what stops a texture or a statistics task being
-        // duplicated by accident -- so a fresh one is filled from this one's samples.
+        // Channel cannot be copied; the deleted copy is what stops a texture or a statistics task being
+        // duplicated by accident, so a fresh one is filled from this one's samples.
         Channel out{channel.name, extent};
         out.bits_per_sample = channel.bits_per_sample;
 
@@ -1302,18 +1277,12 @@ ImagePtr Image::duplicate(const Box2i &region) const
         copy->channels.push_back(std::move(out));
     }
 
-    // A duplicated region is a whole image, not a crop sitting inside the old canvas -- but one of the
-    // whole image keeps the frame it had, display window and all.
-    if (clipped == data_window)
-    {
-        copy->data_window    = data_window;
-        copy->display_window = display_window;
-    }
-    else
+    // A duplicated region becomes a whole image of its own; a copy of the whole one keeps both windows.
+    if (clipped != data_window)
         copy->data_window = copy->display_window = clipped;
 
     // The layers and groups follow from the channel names, and finalize() would premultiply a
-    // straight-alpha image a second time -- these samples are already whatever this image's are.
+    // straight-alpha image a second time; these samples are already whatever this image's are.
     copy->rebuild_layers();
 
     return copy;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1249,10 +1249,7 @@ ImagePtr Image::duplicate(const Box2i &region) const
 
     auto copy = std::make_shared<Image>();
 
-    // Everything that says what the samples mean: a copy that lost its primaries or its alpha convention
-    // would be read differently from the image it was made of. Left behind are `id`, which the constructor
-    // hands out; `history`, since nothing has been done to the copy; `is_live`, since these samples are a
-    // snapshot; and `vector_overlay`, which annotates what a renderer is producing.
+    // the copy gets a fresh id and an empty history, and is neither live nor annotated
     static_cast<ImageMetadata &>(*copy) = *this;
 
     const int2 extent = clipped.size();

--- a/src/image.h
+++ b/src/image.h
@@ -26,6 +26,7 @@
 #include <set>
 #include <smallthreadpool.h>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <filesystem>
@@ -434,20 +435,10 @@ struct LayerTreeNode
     void calculate_visibility(const Image *img);
 };
 
-struct Image
+/// Everything describing an image except its pixel data.
+/** Split out from Image so that duplicate() can copy all of it in one assignment. */
+struct ImageMetadata
 {
-public:
-    static bool                         loadable(const std::string &extension);
-    static const std::set<std::string> &loadable_formats(); /// Set of supported formats for image loading
-    static void                         make_default_textures();
-    static void                         cleanup_default_textures();
-    static Texture                     *black_texture();
-    static Texture                     *white_texture();
-    static Texture                     *dither_texture();
-    static Texture                     *chromaticity_texture();
-
-    int id;
-
     std::string filename;
     std::string partname;
     std::string channel_selector;
@@ -458,7 +449,6 @@ public:
     std::optional<TransparencyType_> transparency_override;
     Box2i                            data_window;
     Box2i                            display_window;
-    std::vector<Channel>             channels;
     std::optional<Chromaticities>    chromaticities;             ///< The chromaticities of the file
     std::optional<float2>            adopted_neutral;            ///< The adopted neutral of the file, if any
     float3x3                         M_RGB_to_XYZ, M_XYZ_to_RGB; ///< The RGB to XYZ and XYZ to RGB conversion matrices
@@ -487,6 +477,23 @@ public:
     fs::path           path;
     fs::file_time_type last_modified;
     size_t             size_bytes = 0;
+};
+
+struct Image : ImageMetadata
+{
+public:
+    static bool                         loadable(const std::string &extension);
+    static const std::set<std::string> &loadable_formats(); /// Set of supported formats for image loading
+    static void                         make_default_textures();
+    static void                         cleanup_default_textures();
+    static Texture                     *black_texture();
+    static Texture                     *white_texture();
+    static Texture                     *dither_texture();
+    static Texture                     *chromaticity_texture();
+
+    int id;
+
+    std::vector<Channel> channels;
 
     /// True for an image whose pixels arrive from a running process rather than from a file.
     /**
@@ -819,6 +826,9 @@ private:
     void traverse_tree(const LayerTreeNode *node, std::function<void(const LayerTreeNode *, int)> callback,
                        int level = 0) const;
 };
+
+static_assert(std::is_copy_assignable_v<ImageMetadata>, "duplicate() copies the metadata base in one assignment");
+static_assert(!std::is_copy_constructible_v<Image>, "an Image owns textures and statistics tasks; move it instead");
 
 /**
     Widen an interleaved 8-bit buffer to three or four channels, for a format that stores nothing narrower.

--- a/src/image.h
+++ b/src/image.h
@@ -474,14 +474,11 @@ public:
         it before calling. Equal to alpha_type_from_file unless alpha_override replaced it.
     */
     AlphaType_ alpha_type = AlphaType_None;
-    /// What the loader concluded before any override, and how it got there.
-    /**
-        Kept so an override can say what it displaced. set_alpha() maintains these together with
-        alpha_type.
-    */
-    AlphaType_           alpha_type_from_file = AlphaType_None;
-    AlphaSource_         alpha_source         = AlphaSource_Assumed;
-    json                 metadata             = json::object();
+    /// What the loader concluded before any override, so the override can say what it displaced.
+    AlphaType_ alpha_type_from_file = AlphaType_None;
+    /// True when nothing in the file stated the alpha kind and the loader picked a default.
+    bool                 alpha_assumed = false;
+    json                 metadata      = json::object();
     Exif                 exif;     ///< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; ///< The raw XMP data from the file, if any
     std::vector<uint8_t> icc_data; ///< The raw ICC profile data from the file, if any
@@ -553,11 +550,12 @@ public:
 
     /// Record what a loader concluded about the file's alpha, and apply any override to it.
     /**
-        The one place alpha_type, alpha_type_from_file and alpha_source are written, so they cannot drift
+        The one place alpha_type, alpha_type_from_file and alpha_assumed are written, so they cannot drift
         apart. Loaders call this instead of assigning alpha_type, then read back alpha_type for the
-        premultiplication decisions they have to make while the samples are still encoded.
+        premultiplication decisions they have to make while the samples are still encoded. Pass
+        `assumed` when nothing in the file stated the kind.
     */
-    void set_alpha(AlphaType_ from_file, AlphaSource_ source, const std::optional<AlphaType_> &override_with);
+    void set_alpha(AlphaType_ from_file, const std::optional<AlphaType_> &override_with, bool assumed = false);
 
     /// Set alpha_type from the channel names alone, for an image not built from a file.
     /**

--- a/src/image.h
+++ b/src/image.h
@@ -455,30 +455,30 @@ public:
     /**
         Empty when the file's own interpretation was used, which is then re-derived on reload.
     */
-    std::optional<AlphaType_>     alpha_override;
-    Box2i                         data_window;
-    Box2i                         display_window;
-    std::vector<Channel>          channels;
-    std::optional<Chromaticities> chromaticities;             ///< The chromaticities of the file
-    std::optional<float2>         adopted_neutral;            ///< The adopted neutral of the file, if any
-    float3x3                      M_RGB_to_XYZ, M_XYZ_to_RGB; ///< The RGB to XYZ and XYZ to RGB conversion matrices
-    float3x3                      M_to_sRGB         = la::identity;
-    float3                        luminance_weights = sRGB_Yw();
-    AdaptationMethod              adaptation_method = AdaptationMethod_Bradford;
-    ColorGamut_                   color_space       = ColorGamut_Unspecified;
-    WhitePoint_                   white_point       = WhitePoint_Unspecified;
+    std::optional<TransparencyType_> transparency_override;
+    Box2i                            data_window;
+    Box2i                            display_window;
+    std::vector<Channel>             channels;
+    std::optional<Chromaticities>    chromaticities;             ///< The chromaticities of the file
+    std::optional<float2>            adopted_neutral;            ///< The adopted neutral of the file, if any
+    float3x3                         M_RGB_to_XYZ, M_XYZ_to_RGB; ///< The RGB to XYZ and XYZ to RGB conversion matrices
+    float3x3                         M_to_sRGB         = la::identity;
+    float3                           luminance_weights = sRGB_Yw();
+    AdaptationMethod                 adaptation_method = AdaptationMethod_Bradford;
+    ColorGamut_                      color_space       = ColorGamut_Unspecified;
+    WhitePoint_                      white_point       = WhitePoint_Unspecified;
     /// How an 'A' channel is to be read: whether it is coverage at all, and if so how it is applied.
     /**
-        Whether the color channels are multiplied by it, and in what space. AlphaType_None keeps the
+        Whether the color channels are multiplied by it, and in what space. TransparencyType_None keeps the
         channel out of an alpha-bearing group, so nothing is multiplied by it. Read by finalize(), so set
-        it before calling. Equal to alpha_type_from_file unless alpha_override replaced it.
+        it before calling. Equal to transparency_from_file unless transparency_override replaced it.
     */
-    AlphaType_ alpha_type = AlphaType_None;
+    TransparencyType_ transparency = TransparencyType_None;
     /// What the loader concluded before any override, so the override can say what it displaced.
-    AlphaType_ alpha_type_from_file = AlphaType_None;
+    TransparencyType_ transparency_from_file = TransparencyType_None;
     /// True when nothing in the file stated the alpha kind and the loader picked a default.
-    bool                 alpha_assumed = false;
-    json                 metadata      = json::object();
+    bool                 transparency_assumed = false;
+    json                 metadata             = json::object();
     Exif                 exif;     ///< The raw EXIF data from the file, if any
     std::vector<uint8_t> xmp_data; ///< The raw XMP data from the file, if any
     std::vector<uint8_t> icc_data; ///< The raw ICC profile data from the file, if any
@@ -550,20 +550,21 @@ public:
 
     /// Record what a loader concluded about the file's alpha, and apply any override to it.
     /**
-        The one place alpha_type, alpha_type_from_file and alpha_assumed are written, so they cannot drift
-        apart. Loaders call this instead of assigning alpha_type, then read back alpha_type for the
+        The one place transparency, transparency_from_file and transparency_assumed are written, so they cannot drift
+        apart. Loaders call this instead of assigning transparency, then read back transparency for the
         premultiplication decisions they have to make while the samples are still encoded. Pass
         `assumed` when nothing in the file stated the kind.
     */
-    void set_alpha(AlphaType_ from_file, const std::optional<AlphaType_> &override_with, bool assumed = false);
+    void set_transparency(TransparencyType_ from_file, const std::optional<TransparencyType_> &override_with,
+                          bool assumed = false);
 
-    /// Set alpha_type from the channel names alone, for an image not built from a file.
+    /// Set transparency from the channel names alone, for an image not built from a file.
     /**
         An image assembled in memory -- over IPC, by an edit, by a test -- already holds samples in
         HDRView's working representation, which is premultiplied and linear, so that is what its alpha
         says. A loader overwrites this the moment it knows what the file declared.
     */
-    void set_default_alpha_type();
+    void set_default_transparency();
     Image();
     Image(const Image &) = delete;
     Image(Image &&)      = default;
@@ -758,12 +759,12 @@ public:
     }
 
     /// An 'A' channel is coverage rather than ordinary data.
-    bool alpha_is_transparency() const { return alpha_type != AlphaType_None; }
+    bool alpha_is_transparency() const { return transparency != TransparencyType_None; }
 
     /// True when finalize() premultiplied `group`, so it must be divided back out; straight-alpha only.
     bool unpremultiplies(const ChannelGroup &group) const
     {
-        return alpha_type == AlphaType_Straight && group.num_channels > 1 && group_has_alpha(group.type);
+        return transparency == TransparencyType_Straight && group.num_channels > 1 && group_has_alpha(group.type);
     }
 
     /// Flatten the selected group into an interleaved buffer, applying gain and a transfer function.

--- a/src/imageio/alpha.cpp
+++ b/src/imageio/alpha.cpp
@@ -28,25 +28,25 @@ void scale_colors_by_alpha(float *pixels, int3 size, F &&factor)
                  });
 }
 
-bool needs_undoing(int3 size, AlphaType_ alpha_type)
+bool needs_undoing(int3 size, TransparencyType_ transparency)
 {
-    return alpha_type == AlphaType_PremultipliedNonLinear && size.z > 1;
+    return transparency == TransparencyType_PremultipliedNonLinear && size.z > 1;
 }
 
 } // namespace
 
-void unpremultiply_before_transfer(float *pixels, int3 size, AlphaType_ alpha_type)
+void unpremultiply_before_transfer(float *pixels, int3 size, TransparencyType_ transparency)
 {
-    if (!needs_undoing(size, alpha_type))
+    if (!needs_undoing(size, transparency))
         return;
 
     // a fully transparent pixel carries no color to recover; don't divide by zero
     scale_colors_by_alpha(pixels, size, [](float a) { return a == 0.f ? 1.f : 1.f / a; });
 }
 
-void repremultiply_after_transfer(float *pixels, int3 size, AlphaType_ alpha_type)
+void repremultiply_after_transfer(float *pixels, int3 size, TransparencyType_ transparency)
 {
-    if (!needs_undoing(size, alpha_type))
+    if (!needs_undoing(size, transparency))
         return;
 
     scale_colors_by_alpha(pixels, size, [](float a) { return a; });

--- a/src/imageio/alpha.h
+++ b/src/imageio/alpha.h
@@ -10,18 +10,18 @@
 #include <optional>
 
 /// The alpha override from the load options, or nullopt. Loaders need it before linearizing.
-inline std::optional<AlphaType_> alpha_override_of(const ImageLoadOptions &opts)
+inline std::optional<TransparencyType_> transparency_override_of(const ImageLoadOptions &opts)
 {
-    return opts.override_alpha ? std::optional<AlphaType_>{opts.alpha_override} : std::nullopt;
+    return opts.override_transparency ? std::optional<TransparencyType_>{opts.transparency_override} : std::nullopt;
 }
 
 /** \name Premultiplied alpha across a transfer function
     \f$EOTF(a \cdot C) \neq a \cdot EOTF(C)\f$, so color premultiplied after encoding must be divided by
     alpha before the transfer is inverted and multiplied back once it is. Call these in pairs around a
-    loader's linearization; both are no-ops for every other AlphaType_. `pixels` is interleaved with `size.z`
+    loader's linearization; both are no-ops for every other TransparencyType_. `pixels` is interleaved with `size.z`
     channels, alpha last.
 */
 /**@{*/
-void unpremultiply_before_transfer(float *pixels, int3 size, AlphaType_ alpha_type);
-void repremultiply_after_transfer(float *pixels, int3 size, AlphaType_ alpha_type);
+void unpremultiply_before_transfer(float *pixels, int3 size, TransparencyType_ transparency);
+void repremultiply_after_transfer(float *pixels, int3 size, TransparencyType_ transparency);
 /**@}*/

--- a/src/imageio/dds.cpp
+++ b/src/imageio/dds.cpp
@@ -737,9 +737,10 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
             const bool has_alpha = num_ch >= 4 || num_ch == 2;
             // a DX9 header has no misc_flags2, so outside DXT2/DXT4 nothing states the kind
             const bool assumed = has_alpha && !premultiplied && dds.alpha_mode == DDSFile::ALPHA_MODE_UNKNOWN;
-            image->set_alpha(has_alpha ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
-                                       : AlphaType_None,
-                             alpha_override_of(opts), assumed);
+            image->set_transparency(
+                has_alpha ? (premultiplied ? TransparencyType_PremultipliedLinear : TransparencyType_Straight)
+                          : TransparencyType_None,
+                transparency_override_of(opts), assumed);
 
             // sRGB to linear for uncompressed sRGB formats
             if (dds.is_sRGB())
@@ -749,7 +750,7 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
                 // color premultiplied after encoding has to be divided out across the conversion; the
                 // channels are planar here, so alpha is addressed directly. See alpha.h.
                 const Channel *alpha =
-                    image->alpha_type == AlphaType_PremultipliedNonLinear && (num_ch >= 4 || num_ch == 2)
+                    image->transparency == TransparencyType_PremultipliedNonLinear && (num_ch >= 4 || num_ch == 2)
                         ? &image->channels[num_ch - 1]
                         : nullptr;
                 for (int c = 0; c < std::min(3, dds.num_channels); ++c)

--- a/src/imageio/dds.cpp
+++ b/src/imageio/dds.cpp
@@ -736,12 +736,10 @@ vector<ImagePtr> load_dds_image(istream &is, string_view filename, const ImageLo
             const int  num_ch    = (int)image->channels.size();
             const bool has_alpha = num_ch >= 4 || num_ch == 2;
             // a DX9 header has no misc_flags2, so outside DXT2/DXT4 nothing states the kind
-            const AlphaSource_ alpha_source =
-                !has_alpha || premultiplied || dds.alpha_mode != DDSFile::ALPHA_MODE_UNKNOWN ? AlphaSource_File
-                                                                                             : AlphaSource_Assumed;
+            const bool assumed = has_alpha && !premultiplied && dds.alpha_mode == DDSFile::ALPHA_MODE_UNKNOWN;
             image->set_alpha(has_alpha ? (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight)
                                        : AlphaType_None,
-                             alpha_source, alpha_override_of(opts));
+                             alpha_override_of(opts), assumed);
 
             // sRGB to linear for uncompressed sRGB formats
             if (dds.is_sRGB())

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -236,12 +236,6 @@ void           Exif::reset() { m_impl.reset(); }
 size_t         Exif::size() const { return m_impl ? m_impl->data.size() : 0; }
 const uint8_t *Exif::data() const { return m_impl ? m_impl->data.data() : nullptr; }
 
-// see exif.h for why this compares by subtraction
-bool maker_note_range_within(uint32_t offset, uint32_t size, uint32_t bound)
-{
-    return offset <= bound && size <= bound - offset;
-}
-
 /// Walk the entries of an Apple maker note, which libexif has no decoder for.
 /**
     The note is a TIFF-style IFD preceded by a 12-byte "Apple iOS" header, with its own byte order and
@@ -336,7 +330,9 @@ static bool for_each_apple_makernote_entry(ExifData *ed, F &&visit)
         // if the data fits in 4 bytes, it sits at location 8, otherwise location 8 stores a 32-bit offset
         // to where the data is
         uint32_t entry_offset = (entry_size > 4) ? read_as<uint32_t>(mn_data + ofs + 8, endian) : uint32_t(ofs + 8);
-        if (!maker_note_range_within(entry_offset, entry_size, uint32_t(mn_size)))
+        // compared by subtraction, since these are 32-bit file fields and offset + size wraps where size_t
+        // is no wider (wasm32)
+        if (entry_offset > mn_size || entry_size > uint32_t(mn_size) - entry_offset)
         {
             spdlog::warn("ExifMnoteApple: tag 0x{:04x} points outside the maker note; skipping.", tag);
             continue;

--- a/src/imageio/exif.h
+++ b/src/imageio/exif.h
@@ -10,13 +10,6 @@
 #include <cstdint>
 #include <optional>
 
-/// Whether a maker-note tag's [offset, offset + size) lies inside a note of \p bound bytes.
-/**
-    Compared by subtraction: these are 32-bit file fields, and offset + size wraps where size_t is no wider
-    (wasm32).
-*/
-bool maker_note_range_within(uint32_t offset, uint32_t size, uint32_t bound);
-
 json        entry_to_json(void *entry, int boi, unsigned int ifd_idx_i = 0);
 json        exif_to_json(const uint8_t *data_ptr, size_t data_size);
 inline json exif_to_json(const std::vector<uint8_t> &data) { return exif_to_json(data.data(), data.size()); }

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -513,7 +513,7 @@ vector<ImagePtr> load_exr_image(istream &is_, string_view filename, const ImageL
             if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
             {
                 // OpenEXR's spec makes alpha associated, and its samples are linear
-                img->set_alpha(AlphaType_PremultipliedLinear, AlphaSource_Format, alpha_override_of(opts));
+                img->set_alpha(AlphaType_PremultipliedLinear, alpha_override_of(opts));
                 break;
             }
 

--- a/src/imageio/exr.cpp
+++ b/src/imageio/exr.cpp
@@ -513,7 +513,7 @@ vector<ImagePtr> load_exr_image(istream &is_, string_view filename, const ImageL
             if (auto tail = Channel::tail(c.name); tail == "A" || tail == "a")
             {
                 // OpenEXR's spec makes alpha associated, and its samples are linear
-                img->set_alpha(AlphaType_PremultipliedLinear, alpha_override_of(opts));
+                img->set_transparency(TransparencyType_PremultipliedLinear, transparency_override_of(opts));
                 break;
             }
 

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -41,8 +41,6 @@ void save_heif_image(const Image &, std::ostream &, std::string_view, const stru
     throw std::runtime_error("HEIF/AVIF support not enabled in this build.");
 }
 
-std::vector<std::string> heif_encoder_names(HEIFCodec) { return {}; }
-
 HEIFSaveOptions *heif_parameters_gui(HEIFCodec) { return nullptr; }
 
 #else
@@ -92,7 +90,7 @@ struct HEIFSaveOptions
     bool             use_alpha = true;
     TransferFunction tf        = {TransferFunction::sRGB, 2.2f};
     size_t           encoder   = 0u;
-    HEIFCodec        codec     = HEIFCodec::Any;
+    HEIFCodec        codec     = HEIFCodec::HEIF;
 };
 
 static HEIFSaveOptions s_opts;
@@ -132,8 +130,8 @@ static bool codec_admits(HEIFCodec codec, heif_compression_format format)
     {
     case HEIFCodec::HEVC: return format == heif_compression_HEVC;
     case HEIFCodec::AV1: return format == heif_compression_AV1;
-    case HEIFCodec::HEIF: return format != heif_compression_AV1;
-    default: return true;
+    case HEIFCodec::HEIF:
+    default: return format != heif_compression_AV1;
     }
 }
 
@@ -148,29 +146,18 @@ static std::vector<size_t> encoders_for(HEIFCodec codec)
     return result;
 }
 
-/// The encoder to start on: the first that implements `codec`.
-/**
-    Prefers HEVC when any codec will do and, where there is a choice, one that can store alpha.
-*/
+/// The encoder to start on: the first that implements `codec`, preferring one that can store alpha.
 static size_t default_encoder_for(HEIFCodec codec, bool need_alpha)
 {
     auto candidates = encoders_for(codec);
     if (candidates.empty())
         return 0u;
 
-    auto first_matching = [&](heif_compression_format format) -> const size_t *
-    {
+    // a .heif conventionally holds HEVC
+    if (codec == HEIFCodec::HEIF)
         for (const auto &i : candidates)
-            if (heif_encoder_descriptor_get_compression_format(s_encoder_descriptors[i]) == format)
-                return &i;
-        return nullptr;
-    };
-
-    // a .heif conventionally holds HEVC, and a caller that named no codec takes AV1 as the next best
-    if (codec == HEIFCodec::Any || codec == HEIFCodec::HEIF)
-        for (auto format : {heif_compression_HEVC, heif_compression_AV1})
-            if (auto *i = first_matching(format))
-                return *i;
+            if (heif_encoder_descriptor_get_compression_format(s_encoder_descriptors[i]) == heif_compression_HEVC)
+                return i;
 
     if (need_alpha)
         for (const auto &i : candidates)
@@ -354,6 +341,47 @@ static auto chroma_name(heif_chroma ch)
     }
 }
 
+/// Copy one decoded plane into `out` as interleaved floats in [0,1], returning its bits per channel.
+static int normalize_heif_plane(heif_image *himage, heif_channel plane, int2 size, int cpp, float *out)
+{
+    int            bytes_per_line = 0;
+    const uint8_t *pixels         = heif_image_get_plane(himage, plane, &bytes_per_line);
+    if (!pixels)
+        throw runtime_error{"HEIF image plane has no pixel data"};
+
+    const int bpp_storage = heif_image_get_bits_per_pixel(himage, plane);
+    const int bpc         = heif_image_get_bits_per_pixel_range(himage, plane);
+    spdlog::debug("Bits per pixel: {}; Bits per pixel storage: {}; Channels per pixel: {}; Bytes per line: {}", bpc,
+                  bpp_storage, cpp, bytes_per_line);
+    if (bpp_storage != cpp * 16 && bpp_storage != cpp * 8)
+        throw runtime_error(fmt::format("Unsupported bits per pixel: {}", bpp_storage));
+
+    // branching on the sample width per row lets each loop vectorize
+    const float bpc_div    = 1.f / ((1 << bpc) - 1);
+    const bool  is_16bit   = (bpp_storage == cpp * 16);
+    const int   block_size = std::max(1, 1024 * 1024 / (size.x * cpp));
+    parallel_for(blocked_range<int>(0, size.y, block_size),
+                 [&](int begin_y, int end_y, int, int)
+                 {
+                     for (int y = begin_y; y < end_y; ++y)
+                     {
+                         float *row_out = out + (size_t)y * size.x * cpp;
+                         if (is_16bit)
+                         {
+                             auto row = reinterpret_cast<const uint16_t *>(pixels + y * (size_t)bytes_per_line);
+                             for (int i = 0; i < size.x * cpp; ++i) row_out[i] = bpc_div * row[i];
+                         }
+                         else
+                         {
+                             auto row = reinterpret_cast<const uint8_t *>(pixels + y * (size_t)bytes_per_line);
+                             for (int i = 0; i < size.x * cpp; ++i) row_out[i] = bpc_div * row[i];
+                         }
+                     }
+                 });
+
+    return bpc;
+}
+
 // Process decoded heif image: create an Image, populate metadata, linearize and copy channels.
 static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_profile_nclx *handle_level_nclx,
                                            const std::vector<uint8_t> &handle_level_icc_profile,
@@ -443,45 +471,14 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
     // the code below works for both interleaved (RGBA) and planar (YA) channel layouts
     for (int p = 0; p < num_planes; ++p)
     {
-        int            bytes_per_line = 0;
-        const uint8_t *pixels         = heif_image_get_plane(himage, out_planes[p], &bytes_per_line);
-        int            bpp_storage    = heif_image_get_bits_per_pixel(himage, out_planes[p]);
-        int            bpc            = heif_image_get_bits_per_pixel_range(himage, out_planes[p]);
-        spdlog::debug("Bits per pixel: {}; Bits per pixel storage: {}; Channels per pixel: {}; Bytes per line: {}", bpc,
-                      bpp_storage, cpp, bytes_per_line);
-        if (bpp_storage != cpp * 16 && bpp_storage != cpp * 8)
-            throw runtime_error(fmt::format("Unsupported bits per pixel: {}", bpp_storage));
+        // a unique_ptr to skip a vector's value-init, which the normalization immediately overwrites
+        auto      float_pixels = std::unique_ptr<float[]>(new float[(size_t)size.x * size.y * cpp]);
+        const int bpc          = normalize_heif_plane(himage, out_planes[p], size.xy(), cpp, float_pixels.get());
         if (p == 0)
         {
             image->metadata["pixel format"] = fmt::format("{}-bit ({} bpc)", size.z * bpc, bpc);
             image->set_bits_per_sample(bpc);
         }
-        float bpc_div = 1.f / ((1 << bpc) - 1);
-
-        // copy the pixels into a contiguous float buffer, normalized to [0,1]. Branching on the sample width
-        // per row lets each loop vectorize; the buffer is a unique_ptr to skip a vector's value-init, which
-        // this immediately overwrites.
-        auto       float_pixels = std::unique_ptr<float[]>(new float[(size_t)size.x * size.y * cpp]);
-        const bool is_16bit     = (bpp_storage == cpp * 16);
-        const int  block_size   = std::max(1, 1024 * 1024 / (size.x * cpp));
-        parallel_for(blocked_range<int>(0, size.y, block_size),
-                     [&](int begin_y, int end_y, int, int)
-                     {
-                         for (int y = begin_y; y < end_y; ++y)
-                         {
-                             float *out = &float_pixels[(size_t)y * size.x * cpp];
-                             if (is_16bit)
-                             {
-                                 auto row = reinterpret_cast<const uint16_t *>(pixels + y * (size_t)bytes_per_line);
-                                 for (int i = 0; i < size.x * cpp; ++i) out[i] = bpc_div * row[i];
-                             }
-                             else
-                             {
-                                 auto row = reinterpret_cast<const uint8_t *>(pixels + y * (size_t)bytes_per_line);
-                                 for (int i = 0; i < size.x * cpp; ++i) out[i] = bpc_div * row[i];
-                             }
-                         }
-                     });
 
         // alpha carries neither a transfer function nor primaries, so copy it through as decoded. Only the
         // monochrome path arrives here with a separate alpha plane; elsewhere linearize_pixels() gets the
@@ -583,32 +580,11 @@ static GainmapImage decode_aux_gainmap(heif_image_handle *aux_handle)
     if (w <= 0 || h <= 0)
         throw runtime_error{"HEIF auxiliary image decoded to an empty plane"};
 
-    int            bytes_per_line = 0;
-    const uint8_t *plane          = heif_image_get_plane(himage.get(), out_plane, &bytes_per_line);
-    if (!plane)
-        throw runtime_error{"HEIF auxiliary image has no pixel data"};
-
-    const int bpp_storage = heif_image_get_bits_per_pixel(himage.get(), out_plane);
-    const int bpc         = heif_image_get_bits_per_pixel_range(himage.get(), out_plane);
-    if (bpp_storage != channels * 16 && bpp_storage != channels * 8)
-        throw runtime_error{fmt::format("Unsupported bits per pixel in HEIF auxiliary image: {}", bpp_storage)};
-
-    const bool  is_16bit = (bpp_storage == channels * 16);
-    const float bpc_div  = 1.f / ((1 << bpc) - 1);
-
     GainmapImage out;
     out.size     = int2{w, h};
     out.channels = channels;
     out.pixels.resize(size_t(w) * h * channels);
-    for (int y = 0; y < h; ++y)
-    {
-        auto row8  = reinterpret_cast<const uint8_t *>(plane + y * (size_t)bytes_per_line);
-        auto row16 = reinterpret_cast<const uint16_t *>(plane + y * (size_t)bytes_per_line);
-        for (int x = 0; x < w; ++x)
-            for (int c = 0; c < channels; ++c)
-                out.pixels[(size_t(y) * w + x) * channels + c] =
-                    bpc_div * (is_16bit ? row16[channels * x + c] : row8[channels * x + c]);
-    }
+    normalize_heif_plane(himage.get(), out_plane, out.size, channels, out.pixels.data());
 
     return out;
 }
@@ -866,8 +842,7 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
 
                 // preserve file-level metadata that comes from the handle/context
                 image->filename = filename;
-                image->set_alpha(from_file, premultiplied ? AlphaSource_File : AlphaSource_Format,
-                                 alpha_override_of(opts));
+                image->set_alpha(from_file, alpha_override_of(opts));
                 image->metadata["header"]["MIME type"]  = {{"value", mime}, {"string", mime}, {"type", "string"}};
                 image->metadata["header"]["Main brand"] = {
                     {"value", main_brand}, {"string", main_brand}, {"type", "string"}};
@@ -1305,15 +1280,6 @@ void save_heif_image(const Image &img, std::ostream &os, std::string_view filena
 }
 
 // GUI parameter function
-std::vector<std::string> heif_encoder_names(HEIFCodec codec)
-{
-    init_heif_supported_formats();
-
-    std::vector<std::string> names;
-    for (size_t i : encoders_for(codec)) names.emplace_back(heif_encoder_descriptor_get_name(s_encoder_descriptors[i]));
-    return names;
-}
-
 HEIFSaveOptions *heif_parameters_gui(HEIFCodec codec)
 {
     init_heif_supported_formats();

--- a/src/imageio/heif.cpp
+++ b/src/imageio/heif.cpp
@@ -387,7 +387,7 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
                                            const std::vector<uint8_t> &handle_level_icc_profile,
                                            const ImageLoadOptions &opts, int3 &size, int cpp, int num_planes,
                                            const heif_channel out_planes[], const string &partname,
-                                           AlphaType_ alpha_type)
+                                           TransparencyType_ transparency)
 {
     int img_w = heif_image_get_width(himage, out_planes[0]);
     int img_h = heif_image_get_height(himage, out_planes[0]);
@@ -486,7 +486,7 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
         if (out_planes[p] != heif_channel_Alpha)
         {
             // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
-            unpremultiply_before_transfer(float_pixels.get(), int3{size.xy(), cpp}, alpha_type);
+            unpremultiply_before_transfer(float_pixels.get(), int3{size.xy(), cpp}, transparency);
 
             if (opts.override_profile)
             {
@@ -531,7 +531,7 @@ static ImagePtr process_decoded_heif_image(heif_image *himage, const heif_color_
                 image->metadata["color profile"] = profile_desc;
             }
 
-            repremultiply_after_transfer(float_pixels.get(), int3{size.xy(), cpp}, alpha_type);
+            repremultiply_after_transfer(float_pixels.get(), int3{size.xy(), cpp}, transparency);
         }
 
         // copy the interleaved float pixels into the channels
@@ -828,21 +828,22 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
                     heif_image_release);
                 // MIAF marks premultiplied alpha with a 'prem' reference from the master item to the alpha
                 // one; its absence means straight, so only its presence is something the file stated
-                const bool       premultiplied = heif_image_handle_is_premultiplied_alpha(ihandle.get());
-                const AlphaType_ from_file =
-                    !has_alpha ? AlphaType_None : (premultiplied ? AlphaType_PremultipliedLinear : AlphaType_Straight);
+                const bool              premultiplied = heif_image_handle_is_premultiplied_alpha(ihandle.get());
+                const TransparencyType_ from_file =
+                    !has_alpha ? TransparencyType_None
+                               : (premultiplied ? TransparencyType_PremultipliedLinear : TransparencyType_Straight);
 
                 // resolved before decoding, since the color management below brackets itself with it
-                const AlphaType_ alpha_type = alpha_override_of(opts).value_or(from_file);
+                const TransparencyType_ transparency = transparency_override_of(opts).value_or(from_file);
 
                 // create Image from decoded heif_image; process_decoded_heif_image will create and fill pixel data
-                ImagePtr image =
-                    process_decoded_heif_image(himage.get(), handle_level_nclx.get(), handle_level_icc_profile, opts,
-                                               size, cpp, num_planes, out_planes, fmt::format("{:d}", id), alpha_type);
+                ImagePtr image = process_decoded_heif_image(himage.get(), handle_level_nclx.get(),
+                                                            handle_level_icc_profile, opts, size, cpp, num_planes,
+                                                            out_planes, fmt::format("{:d}", id), transparency);
 
                 // preserve file-level metadata that comes from the handle/context
                 image->filename = filename;
-                image->set_alpha(from_file, alpha_override_of(opts));
+                image->set_transparency(from_file, transparency_override_of(opts));
                 image->metadata["header"]["MIME type"]  = {{"value", mime}, {"string", mime}, {"type", "string"}};
                 image->metadata["header"]["Main brand"] = {
                     {"value", main_brand}, {"string", main_brand}, {"type", "string"}};
@@ -1018,7 +1019,7 @@ vector<ImagePtr> load_heif_image(istream &is, string_view filename, const ImageL
 
                     heif_channel out_planes[2] = {heif_channel_interleaved, heif_channel_Alpha};
                     ImagePtr image = process_decoded_heif_image(himage.get(), nullptr, {}, opts, size, 3, 1, out_planes,
-                                                                partname, AlphaType_None);
+                                                                partname, TransparencyType_None);
                     image->filename                         = filename;
                     image->metadata["header"]["MIME type"]  = {{"value", mime}, {"string", mime}, {"type", "string"}};
                     image->metadata["header"]["Main brand"] = {

--- a/src/imageio/heif.h
+++ b/src/imageio/heif.h
@@ -25,22 +25,14 @@ std::vector<ImagePtr> load_heif_image(std::istream &is, std::string_view filenam
 /// Which codec family goes inside the HEIF container. Several encoders may implement any one of these.
 enum class HEIFCodec
 {
-    Any = 0, ///< whatever the build has, preferring HEVC and then AV1; the default for non-GUI callers
-    HEIF,    ///< any codec a .heif may carry (HEVC, JPEG, JPEG 2000), but not AV1
-    HEVC,    ///< HEVC specifically
-    AV1,     ///< AV1, which libheif brands 'avif' whatever the file is named
+    HEIF = 0, ///< any codec a .heif may carry (HEVC, JPEG, JPEG 2000), but not AV1
+    HEVC,     ///< HEVC specifically
+    AV1,      ///< AV1, which libheif brands 'avif' whatever the file is named
 };
 
 void save_heif_image(const Image &img, std::ostream &os, std::string_view filename, float gain = 1.f, int quality = 95,
-                     bool lossless = false, bool use_alpha = true, HEIFCodec codec = HEIFCodec::Any,
+                     bool lossless = false, bool use_alpha = true, HEIFCodec codec = HEIFCodec::HEIF,
                      TransferFunction tf = TransferFunction::sRGB);
-
-/// Names of the encoders offered for `codec`, in the order the save dialog lists them.
-/**
-    Empty when the libheif build has none: distributions package each codec separately, so reading doesn't
-    imply writing.
-*/
-std::vector<std::string> heif_encoder_names(HEIFCodec codec);
 
 struct HEIFSaveOptions;
 /// Draws the options for `codec`, listing only the encoders that implement it.

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -902,22 +902,22 @@ void draw_load_image_options_dialog(bool &open)
                        "only load layers which contain either of these two words, and \"-.A\" would exclude channels "
                        "named \"A\". Leave empty to load all parts.");
 
-        ImGui::Checkbox("Override file's alpha", &s_opts.override_alpha);
+        ImGui::Checkbox("Override file's alpha", &s_opts.override_transparency);
         ImGui::Tooltip("By default HDRView follows what the file says about its alpha channel. Enable this to state "
                        "the interpretation yourself, for a file whose semi-transparent areas read too dark or too "
                        "bright, or whose fourth channel is really a mask rather than transparency.");
 
-        if (s_opts.override_alpha)
+        if (s_opts.override_transparency)
         {
             ImGui::Indent();
             ImGui::PushItemWidth(ImGui::CalcItemWidth() - ImGui::GetStyle().IndentSpacing);
-            if (ImGui::BeginCombo("Alpha", alpha_override_name(s_opts.alpha_override)))
+            if (ImGui::BeginCombo("Alpha", transparency_override_name(s_opts.transparency_override)))
             {
-                for (AlphaType_ a = 0; a < AlphaType_Count; ++a)
+                for (TransparencyType_ a = 0; a < TransparencyType_Count; ++a)
                 {
-                    const bool is_selected = s_opts.alpha_override == a;
-                    if (ImGui::Selectable(alpha_override_name(a), is_selected))
-                        s_opts.alpha_override = a;
+                    const bool is_selected = s_opts.transparency_override == a;
+                    if (ImGui::Selectable(transparency_override_name(a), is_selected))
+                        s_opts.transparency_override = a;
 
                     if (is_selected)
                         ImGui::SetItemDefaultFocus();
@@ -1208,10 +1208,10 @@ vector<ImagePtr> load_image(istream &is, string_view filename, const ImageLoadOp
 
                 i->filename   = filename;
                 i->size_bytes = static_cast<size_t>(size);
-                // the loaders have already applied the override to alpha_type; record the option itself so a
+                // the loaders have already applied the override to transparency; record the option itself so a
                 // reload or a saved session can repeat it
-                if (opts.override_alpha)
-                    i->alpha_override = opts.alpha_override;
+                if (opts.override_transparency)
+                    i->transparency_override = opts.transparency_override;
                 // If multiple image "parts" were loaded and they have names, store these names in the image's
                 // channel selector. This is useful if we later want to reload a specific image part from the
                 // original file.

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -313,21 +313,68 @@ vector<string> BackgroundImageLoader::recent_files_short(int head_length, int ta
     return short_names;
 }
 
+/// A miniz reader over an in-memory archive, ended when it goes out of scope.
+class ZipReader
+{
+public:
+    explicit ZipReader(string_view bytes)
+    {
+        memset(&m_zip, 0, sizeof(m_zip));
+        m_open = mz_zip_reader_init_mem(&m_zip, bytes.data(), bytes.size(), 0);
+    }
+    ~ZipReader()
+    {
+        if (m_open)
+            mz_zip_reader_end(&m_zip);
+    }
+    ZipReader(const ZipReader &)            = delete;
+    ZipReader &operator=(const ZipReader &) = delete;
+
+    explicit operator bool() const { return m_open; }
+
+    int num_entries() { return (int)mz_zip_reader_get_num_files(&m_zip); }
+    int locate(const string &entry_path) { return mz_zip_reader_locate_file(&m_zip, entry_path.c_str(), nullptr, 0); }
+
+    /// Stat entry `index`, failing for a directory.
+    bool stat(int index, mz_zip_archive_file_stat &st)
+    {
+        return mz_zip_reader_file_stat(&m_zip, index, &st) && !st.m_is_directory;
+    }
+
+    /// Read a stat'ed entry into `buffer`, failing for an implausible declared size or a failed decompression.
+    bool extract(const mz_zip_archive_file_stat &st, std::vector<char> &buffer)
+    {
+        if (!zip_entry_size_is_plausible(st.m_uncomp_size, st.m_comp_size, st.m_filename))
+            return false;
+
+        buffer.resize(st.m_uncomp_size);
+        if (!mz_zip_reader_extract_to_mem(&m_zip, st.m_file_index, buffer.data(), buffer.size(), 0))
+        {
+            spdlog::warn("Failed to extract '{}' from the zip archive", st.m_filename);
+            return false;
+        }
+        return true;
+    }
+
+private:
+    mz_zip_archive m_zip;
+    bool           m_open = false;
+};
+
 vector<std::pair<string, string>> zip_root_entries_with_suffix(string_view zip_bytes, const string &suffix)
 {
     vector<std::pair<string, string>> found;
 
-    mz_zip_archive zip;
-    memset(&zip, 0, sizeof(zip));
-    if (!mz_zip_reader_init_mem(&zip, zip_bytes.data(), zip_bytes.size(), 0))
+    ZipReader zip{zip_bytes};
+    if (!zip)
         return found;
 
-    string suffix_lower = to_lower(suffix);
-    int    num          = (int)mz_zip_reader_get_num_files(&zip);
-    for (int i = 0; i < num; ++i)
+    string            suffix_lower = to_lower(suffix);
+    std::vector<char> buffer;
+    for (int i = 0, num = zip.num_entries(); i < num; ++i)
     {
         mz_zip_archive_file_stat stat;
-        if (!mz_zip_reader_file_stat(&zip, i, &stat) || stat.m_is_directory)
+        if (!zip.stat(i, stat))
             continue;
 
         fs::path entry_path = fs::path(stat.m_filename);
@@ -339,53 +386,25 @@ vector<std::pair<string, string>> zip_root_entries_with_suffix(string_view zip_b
             to_lower(name.substr(name.size() - suffix_lower.size())) != suffix_lower)
             continue;
 
-        if (!zip_entry_size_is_plausible(stat.m_uncomp_size, stat.m_comp_size, name))
+        if (!zip.extract(stat, buffer))
             continue;
 
-        std::vector<char> buffer(stat.m_uncomp_size);
-        if (!mz_zip_reader_extract_to_mem(&zip, i, buffer.data(), buffer.size(), 0))
-        {
-            spdlog::warn("Failed to extract '{}' while scanning a zip for session manifests", name);
-            continue;
-        }
         found.emplace_back(name, string(buffer.begin(), buffer.end()));
     }
 
-    mz_zip_reader_end(&zip);
     return found;
 }
 
 std::optional<string> zip_extract_entry(string_view zip_bytes, const string &entry_path)
 {
-    mz_zip_archive zip;
-    memset(&zip, 0, sizeof(zip));
-    if (!mz_zip_reader_init_mem(&zip, zip_bytes.data(), zip_bytes.size(), 0))
+    ZipReader zip{zip_bytes};
+    if (!zip)
         return std::nullopt;
 
-    int index = mz_zip_reader_locate_file(&zip, entry_path.c_str(), nullptr, 0);
-    if (index < 0)
-    {
-        mz_zip_reader_end(&zip);
-        return std::nullopt;
-    }
-
+    int                      index = zip.locate(entry_path);
     mz_zip_archive_file_stat stat;
-    if (!mz_zip_reader_file_stat(&zip, index, &stat))
-    {
-        mz_zip_reader_end(&zip);
-        return std::nullopt;
-    }
-
-    if (!zip_entry_size_is_plausible(stat.m_uncomp_size, stat.m_comp_size, entry_path))
-    {
-        mz_zip_reader_end(&zip);
-        return std::nullopt;
-    }
-
-    std::vector<char> buffer(stat.m_uncomp_size);
-    bool              ok = mz_zip_reader_extract_to_mem(&zip, index, buffer.data(), buffer.size(), 0);
-    mz_zip_reader_end(&zip);
-    if (!ok)
+    std::vector<char>        buffer;
+    if (index < 0 || !zip.stat(index, stat) || !zip.extract(stat, buffer))
         return std::nullopt;
 
     return string(buffer.begin(), buffer.end());
@@ -416,15 +435,14 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
     auto extract_and_schedule = [&](string_view zip_buffer, const string &zip_name, bool select_first,
                                     ImagePtr to_replace, const string &entry_pattern = "")
     {
-        mz_zip_archive zip;
-        memset(&zip, 0, sizeof(zip));
-        if (!mz_zip_reader_init_mem(&zip, zip_buffer.data(), zip_buffer.size(), 0))
+        ZipReader zip{zip_buffer};
+        if (!zip)
         {
             spdlog::error("Failed to open zip archive '{}'", zip_name);
             return 0;
         }
 
-        int num        = (int)mz_zip_reader_get_num_files(&zip);
+        int num        = zip.num_entries();
         int num_images = 0;
 
         spdlog::debug("Zip '{}' contains {} files, loading...", zip_name, num);
@@ -433,9 +451,7 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
         for (int i = 0; i < num; ++i)
         {
             mz_zip_archive_file_stat stat;
-            if (!mz_zip_reader_file_stat(&zip, i, &stat))
-                continue;
-            if (stat.m_is_directory)
+            if (!zip.stat(i, stat))
                 continue;
 
             fs::path entry_path = fs::path(stat.m_filename);
@@ -453,17 +469,10 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
             if (!entry_pattern.empty() && entry_path.u8string() != entry_pattern)
                 continue;
 
-            if (!zip_entry_size_is_plausible(stat.m_uncomp_size, stat.m_comp_size, entry_path.u8string()))
+            if (!zip.extract(stat, buffer))
                 continue;
 
-            buffer.resize(stat.m_uncomp_size);
-            if (!mz_zip_reader_extract_to_mem(&zip, i, buffer.data(), buffer.size(), 0))
-            {
-                spdlog::warn("Failed to extract '{}' from '{}'", entry_path.u8string(), zip_name);
-                continue;
-            }
-
-            string_view data{reinterpret_cast<char *>(buffer.data()), buffer.size()};
+            string_view data{buffer.data(), buffer.size()};
             // build a combined filename that prepends the zip path to the entry path
             string combined = zip_name + "/" + entry_path.u8string();
             // schedule async load; do not add each entry to recent files
@@ -477,8 +486,6 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
 
         if (!num_images)
             spdlog::warn("No loadable images found in '{}'", zip_name);
-
-        mz_zip_reader_end(&zip);
 
         spdlog::info("Loading files in the zip archive took {:f} seconds.", timer.elapsed() / 1000.f);
 
@@ -495,7 +502,8 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
 
         if (to_lower(get_extension(filename)) == ".zip")
         {
-            if (zip_bundle_hook && zip_bundle_hook(*buffer, filename))
+            // a zip opened in its own right may be a session bundle
+            if (hdrview()->try_load_zip_as_session(*buffer, filename))
                 return;
 
             remove_recent_file(filename);
@@ -591,7 +599,7 @@ void BackgroundImageLoader::background_load(const string filename, std::optional
 
             // a non-empty entry_fn means "re-extract this one already-known entry", not "a zip was just
             // opened"; only the latter is a candidate session bundle
-            if (entry_fn.empty() && zip_bundle_hook && zip_bundle_hook(string_view(buf.data(), buf.size()), zip_fn))
+            if (entry_fn.empty() && hdrview()->try_load_zip_as_session(string_view(buf.data(), buf.size()), zip_fn))
                 return;
 
             if (extract_and_schedule(string_view(buf.data(), buf.size()), zip_fn, should_select, to_replace, entry_fn))
@@ -637,18 +645,8 @@ bool BackgroundImageLoader::add_watched_directory(const std::filesystem::path &d
     return true;
 }
 
-void BackgroundImageLoader::remove_watched_directories(std::function<bool(const fs::path &)> criterion)
-{
-    remove_watched_directories_if(criterion, /* keep_explicit */ false);
-}
-
-void BackgroundImageLoader::remove_implicitly_watched_directories(std::function<bool(const fs::path &)> criterion)
-{
-    remove_watched_directories_if(criterion, /* keep_explicit */ true);
-}
-
-void BackgroundImageLoader::remove_watched_directories_if(const std::function<bool(const fs::path &)> &criterion,
-                                                          bool                                         keep_explicit)
+void BackgroundImageLoader::remove_watched_directories(std::function<bool(const fs::path &)> criterion,
+                                                       bool                                  keep_explicit)
 {
     // Remove directories that match the criterion
     for (auto it = m_directories.begin(); it != m_directories.end();)

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -93,10 +93,12 @@ struct BackgroundImageLoader
     const set<fs::path> &watched_directories() const { return m_directories; }
     /// Watch `dir` in its own right, whether or not anything has been loaded from it.
     bool add_watched_directory(const fs::path &dir, bool ignore_existing);
-    /// Remove all watched directories that match the criterion, however they came to be watched.
-    void remove_watched_directories(function<bool(const fs::path &)> remove_criterion);
-    /// Same, but spares the ones add_watched_directory() was asked for, which hold no loaded images of their own.
-    void remove_implicitly_watched_directories(function<bool(const fs::path &)> remove_criterion);
+    /// Remove the watched directories matching the criterion, sparing explicitly added ones if asked.
+    /**
+        A directory add_watched_directory() was asked for holds no loaded images of its own, so a criterion
+        phrased as "nothing loaded came from here" would always discard it.
+    */
+    void remove_watched_directories(function<bool(const fs::path &)> criterion, bool keep_explicit = false);
 
     void load_new_and_modified_files();
 
@@ -111,11 +113,6 @@ struct BackgroundImageLoader
 
     void draw_gui();
 
-    // Called with the raw bytes of a top-level zip archive before it's extracted as a folder of images (not
-    // called for a single-entry re-extraction from within a zip). Returning true means "handled, don't also
-    // extract this zip's images normally".
-    function<bool(string_view zip_bytes, const string &zip_name)> zip_bundle_hook;
-
 private:
     struct PendingImages;
     vector<shared_ptr<PendingImages>> pending_images;
@@ -128,8 +125,6 @@ private:
 
     // the subset of m_directories that add_watched_directory() was asked for
     set<fs::path> m_explicit_directories;
-
-    void remove_watched_directories_if(const function<bool(const fs::path &)> &criterion, bool keep_explicit);
 
     // don't treat these files as new (they are either currently loaded, or we've previously loaded them from a watched
     // directory and manually closed them, so don't want to automatically reload them)

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -27,9 +27,9 @@ struct ImageLoadOptions
     /// Comma-separated list of channel names to include or exclude from the image. If empty, all channels are selected.
     string channel_selector;
 
-    bool override_alpha = false;
-    /// Override what the file says about its alpha and interpret it this way instead. See Image::alpha_type.
-    AlphaType_ alpha_override = AlphaType_Straight;
+    bool override_transparency = false;
+    /// Override what the file says about its alpha and interpret it this way instead. See Image::transparency.
+    TransparencyType_ transparency_override = TransparencyType_Straight;
 
     bool override_profile = false;
     /// Override any metadata in the file and decode pixel values using this color gamut.
@@ -93,10 +93,10 @@ struct BackgroundImageLoader
     const set<fs::path> &watched_directories() const { return m_directories; }
     /// Watch `dir` in its own right, whether or not anything has been loaded from it.
     bool add_watched_directory(const fs::path &dir, bool ignore_existing);
-    /// Remove the watched directories matching the criterion, sparing explicitly added ones if asked.
+    /// Stop watching every directory \p criterion returns true for.
     /**
-        A directory add_watched_directory() was asked for holds no loaded images of its own, so a criterion
-        phrased as "nothing loaded came from here" would always discard it.
+        \p keep_explicit spares the ones add_watched_directory() was asked for. Those are watched for files
+        that do not exist yet, so they hold no loaded images and would match a "nothing came from here" rule.
     */
     void remove_watched_directories(function<bool(const fs::path &)> criterion, bool keep_explicit = false);
 

--- a/src/imageio/jxl.cpp
+++ b/src/imageio/jxl.cpp
@@ -692,7 +692,7 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
             image->set_alpha(!info.alpha_bits
                                  ? AlphaType_None
                                  : (info.alpha_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight),
-                             info.alpha_bits ? AlphaSource_File : AlphaSource_Format, alpha_override_of(opts));
+                             alpha_override_of(opts));
             image->metadata["loader"]                     = "libjxl";
             image->metadata["header"]["original profile"] = {
                 {"value", (bool)info.uses_original_profile},

--- a/src/imageio/jxl.cpp
+++ b/src/imageio/jxl.cpp
@@ -689,10 +689,11 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
             image->partname = frame_name;
             // JxlBasicInfo always carries alpha_premultiplied, so a file with alpha has stated its kind,
             // though not the space it means; see where this is undone below
-            image->set_alpha(!info.alpha_bits
-                                 ? AlphaType_None
-                                 : (info.alpha_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight),
-                             alpha_override_of(opts));
+            image->set_transparency(
+                !info.alpha_bits
+                    ? TransparencyType_None
+                    : (info.alpha_premultiplied ? TransparencyType_PremultipliedNonLinear : TransparencyType_Straight),
+                transparency_override_of(opts));
             image->metadata["loader"]                     = "libjxl";
             image->metadata["header"]["original profile"] = {
                 {"value", (bool)info.uses_original_profile},
@@ -811,7 +812,7 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
 
             // JXL premultiplies in encoded space; JxlDecoderSetUnpremultiplyAlpha() ignores the main alpha
             // channel, so undo it here (see alpha.h)
-            unpremultiply_before_transfer(pixels.data(), size, image->alpha_type);
+            unpremultiply_before_transfer(pixels.data(), size, image->transparency);
 
             vector<float> alpha_copy;
 
@@ -900,7 +901,7 @@ vector<ImagePtr> load_jxl_image(istream &is, string_view filename, const ImageLo
                 spdlog::info("Swapped alpha channel in interleaved array back with black channel data.");
             }
 
-            repremultiply_after_transfer(pixels.data(), size, image->alpha_type);
+            repremultiply_after_transfer(pixels.data(), size, image->transparency);
 
             // copy the interleaved float pixels into the channels
             for (int c = 0; c < size.z; ++c)

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -704,7 +704,8 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         auto image      = make_shared<Image>(size.xy(), size.z);
         image->filename = filename;
         // PNG's spec makes alpha unassociated; a file carries no signal of its own
-        image->set_alpha(size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
+        image->set_transparency(size.z == 4 || size.z == 2 ? TransparencyType_Straight : TransparencyType_None,
+                                transparency_override_of(opts));
         image->chromaticities = chr;
         image->metadata       = metadata;
         // a palette's IHDR depth counts bits per index; png_set_palette_to_rgb() expands those to 8-bit RGB
@@ -754,7 +755,7 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         string profile_desc = color_profile_name(chr ? named_color_gamut(*chr) : ColorGamut_Unspecified, tf);
 
         // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
-        unpremultiply_before_transfer(float_pixels.data(), size, image->alpha_type);
+        unpremultiply_before_transfer(float_pixels.data(), size, image->transparency);
 
         if (opts.override_profile)
         {
@@ -805,7 +806,7 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
                 spdlog::info("Image is already in linear color space.");
         }
 
-        repremultiply_after_transfer(float_pixels.data(), size, image->alpha_type);
+        repremultiply_after_transfer(float_pixels.data(), size, image->transparency);
 
         image->metadata["color profile"] = profile_desc;
 

--- a/src/imageio/png.cpp
+++ b/src/imageio/png.cpp
@@ -704,8 +704,7 @@ vector<ImagePtr> load_png_image(istream &is, string_view filename, const ImageLo
         auto image      = make_shared<Image>(size.xy(), size.z);
         image->filename = filename;
         // PNG's spec makes alpha unassociated; a file carries no signal of its own
-        image->set_alpha(size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None, AlphaSource_Format,
-                         alpha_override_of(opts));
+        image->set_alpha(size.z == 4 || size.z == 2 ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
         image->chromaticities = chr;
         image->metadata       = metadata;
         // a palette's IHDR depth counts bits per index; png_set_palette_to_rgb() expands those to 8-bit RGB

--- a/src/imageio/qoi.cpp
+++ b/src/imageio/qoi.cpp
@@ -102,7 +102,7 @@ vector<ImagePtr> load_qoi_image(istream &is, string_view filename, const ImageLo
     auto image      = make_shared<Image>(size.xy(), size.z);
     image->filename = filename;
     // QOI's spec makes alpha unassociated
-    image->set_alpha(size.z > 3 ? AlphaType_Straight : AlphaType_None, AlphaSource_Format, alpha_override_of(opts));
+    image->set_alpha(size.z > 3 ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
     image->metadata["loader"]       = "qoi";
     image->metadata["pixel format"] = fmt::format("{}-bit (8 bpc)", size.z * 8);
     image->set_bits_per_sample(8);

--- a/src/imageio/qoi.cpp
+++ b/src/imageio/qoi.cpp
@@ -102,7 +102,8 @@ vector<ImagePtr> load_qoi_image(istream &is, string_view filename, const ImageLo
     auto image      = make_shared<Image>(size.xy(), size.z);
     image->filename = filename;
     // QOI's spec makes alpha unassociated
-    image->set_alpha(size.z > 3 ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
+    image->set_transparency(size.z > 3 ? TransparencyType_Straight : TransparencyType_None,
+                            transparency_override_of(opts));
     image->metadata["loader"]       = "qoi";
     image->metadata["pixel format"] = fmt::format("{}-bit (8 bpc)", size.z * 8);
     image->set_bits_per_sample(8);

--- a/src/imageio/stb.cpp
+++ b/src/imageio/stb.cpp
@@ -294,8 +294,7 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
         image           = make_shared<Image>(size.xy(), size.z);
         image->filename = filename;
         // none of the stb-decoded formats carries an alpha-kind signal; all specify unassociated
-        image->set_alpha(size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None, AlphaSource_Format,
-                         alpha_override_of(opts));
+        image->set_alpha(size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
         if (size.w > 1)
             image->partname = fmt::format("frame {:04}", frame);
         image->metadata["loader"] = fmt::format("stb_image ({})", j["format"].get<string>());

--- a/src/imageio/stb.cpp
+++ b/src/imageio/stb.cpp
@@ -294,7 +294,8 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
         image           = make_shared<Image>(size.xy(), size.z);
         image->filename = filename;
         // none of the stb-decoded formats carries an alpha-kind signal; all specify unassociated
-        image->set_alpha(size.z > 3 || size.z == 2 ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
+        image->set_transparency(size.z > 3 || size.z == 2 ? TransparencyType_Straight : TransparencyType_None,
+                                transparency_override_of(opts));
         if (size.w > 1)
             image->partname = fmt::format("frame {:04}", frame);
         image->metadata["loader"] = fmt::format("stb_image ({})", j["format"].get<string>());
@@ -358,7 +359,7 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
         string profile_desc = color_profile_name(cg, tf);
 
         // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
-        unpremultiply_before_transfer(float_pixels.data(), size.xyz(), image->alpha_type);
+        unpremultiply_before_transfer(float_pixels.data(), size.xyz(), image->transparency);
 
         if (opts.override_profile)
         {
@@ -392,7 +393,7 @@ vector<ImagePtr> load_stb_image(istream &is, const string_view filename, const I
                 spdlog::info("Image is already in linear color space.");
         }
 
-        repremultiply_after_transfer(float_pixels.data(), size.xyz(), image->alpha_type);
+        repremultiply_after_transfer(float_pixels.data(), size.xyz(), image->transparency);
 
         image->metadata["color profile"] = profile_desc;
 

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -323,6 +323,21 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
             num_channels = 3; // Will be adjusted if alpha is detected
         }
 
+        // The widths the manual read path can dequantize: unpack_bits() accumulates an integer sample into
+        // a uint32_t, and convert_to_float() reads a float sample as half, float or double. The RGBA
+        // interface converts any width to 8-bit RGBA itself.
+        if (!use_rgba_interface)
+        {
+            if (sample_format != SAMPLEFORMAT_IEEEFP && (file_bits_per_sample == 0 || file_bits_per_sample > 32))
+                throw invalid_argument{
+                    fmt::format("TIFF: {}-bit integer samples are not supported", file_bits_per_sample)};
+
+            if (sample_format == SAMPLEFORMAT_IEEEFP && bits_per_sample != 16 && bits_per_sample != 32 &&
+                bits_per_sample != 64)
+                throw invalid_argument{
+                    fmt::format("TIFF: {}-bit floating-point samples are not supported", bits_per_sample)};
+        }
+
         // Handle palette/indexed color
         // uint16_t *palette_r = nullptr, *palette_g = nullptr, *palette_b = nullptr;
         const uint16_t *palette[3] = {};
@@ -375,13 +390,13 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
 
         // only guess when the file said nothing; an EXTRASAMPLES tag naming EXTRASAMPLE_UNSPECIFIED is the
         // file saying the extra sample is arbitrary data
-        AlphaSource_ alpha_source = AlphaSource_File;
+        bool assumed = false;
         if (!has_alpha && !has_extra_samples && num_channels == 4)
         {
             has_alpha = true;
             // straight is the likelier reading for an unlabeled RGBA TIFF, but it is a guess
             is_premultiplied = false;
-            alpha_source     = AlphaSource_Assumed;
+            assumed          = true;
             spdlog::debug("Inferred alpha channel from channel count (assuming straight alpha)");
         }
 
@@ -390,7 +405,7 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         // vips all do this)
         image->set_alpha(has_alpha ? (is_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight)
                                    : AlphaType_None,
-                         alpha_source, alpha_override_of(opts));
+                         alpha_override_of(opts), assumed);
         image->metadata["loader"] = "libtiff";
         image->partname           = partname;
 
@@ -533,16 +548,14 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         }
         else
         {
-            // Pre-compute bias and inverse divisor for integer formats from the file's bit depth. That
-            // depth comes straight from the tag and reaches 64 (libtiff's own caspian.tif), so guard the
-            // shifts: 1ull << 64 is undefined, and a declared zero would shift by -1.
-            const uint64_t int_max_value   = file_bits_per_sample == 0    ? 1ull
-                                             : file_bits_per_sample >= 64 ? ~0ull
-                                                                          : ((1ull << file_bits_per_sample) - 1);
-            float          int_inv_divisor = 1.0f / (float)int_max_value;
-            float          int_bias        = sample_format == SAMPLEFORMAT_INT && file_bits_per_sample > 0
-                                                 ? (float)(1ull << (file_bits_per_sample - 1))
-                                                 : 0.0f;
+            // Bias and inverse divisor for integer formats, from the file's bit depth
+            float int_inv_divisor = 1.0f;
+            float int_bias        = 0.0f;
+            if (sample_format != SAMPLEFORMAT_IEEEFP)
+            {
+                int_inv_divisor = 1.0f / (float)((1ull << file_bits_per_sample) - 1);
+                int_bias        = sample_format == SAMPLEFORMAT_INT ? (float)(1ull << (file_bits_per_sample - 1)) : 0.f;
+            }
 
             // TIFF has no video-range field, but a profile carrying CICP code points (ICC.1:2022) states
             // it. Narrow range puts black at 16 and white at 235, scaled by the sample depth: the same
@@ -561,10 +574,9 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
             auto unpack_bits =
                 [&](const uint8_t *input, size_t input_size, int bitwidth, vector<uint32_t> &output, bool handle_sign)
             {
-                // masks for a sample as wide as the accumulator: 1u << 32 is undefined, and a 32-bit
-                // sample needs every bit anyway. Wider samples are rejected before this ever runs.
+                // 1u << 32 is undefined, and a sample as wide as the accumulator needs every bit anyway
                 const uint32_t value_mask = bitwidth >= 32 ? ~0u : ((1u << bitwidth) - 1);
-                const uint32_t sign_bit   = (bitwidth >= 1 && bitwidth <= 32) ? (1u << (bitwidth - 1)) : 0u;
+                const uint32_t sign_bit   = 1u << (bitwidth - 1);
 
                 // a byte-aligned sample arrives in host order: libtiff byte-swaps 8-, 16-, 24- and 32-bit
                 // samples on the way out (tif_dir.c installs _TIFFSwab*BitData when the file's byte order
@@ -686,16 +698,6 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
             // Always unpack integer formats (unpack_bits handles both byte-aligned and bit-packed efficiently)
             const bool       needs_unpacking = sample_format != SAMPLEFORMAT_IEEEFP;
             vector<uint32_t> unpacked_buffer;
-
-            // unpack_bits accumulates into uint32_t, so a wider integer sample has nowhere to land
-            if (needs_unpacking && file_bits_per_sample > 32)
-                throw invalid_argument{
-                    fmt::format("TIFF: {}-bit integer samples are not supported", file_bits_per_sample)};
-
-            // convert_to_float() reads a float sample as half, float or double, and nothing else
-            if (!needs_unpacking && bits_per_sample != 16 && bits_per_sample != 32 && bits_per_sample != 64)
-                throw invalid_argument{
-                    fmt::format("TIFF: {}-bit floating-point samples are not supported", bits_per_sample)};
 
             // Store tile/strip information in metadata
             image->metadata["header"]["Pixel organization"] = {

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -403,9 +403,10 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         auto image = make_shared<Image>(int2{(int)width, (int)height}, num_channels);
         // TIFF associated alpha is multiplied into the encoded samples (Photoshop, OIIO, ImageMagick and
         // vips all do this)
-        image->set_alpha(has_alpha ? (is_premultiplied ? AlphaType_PremultipliedNonLinear : AlphaType_Straight)
-                                   : AlphaType_None,
-                         alpha_override_of(opts), assumed);
+        image->set_transparency(
+            has_alpha ? (is_premultiplied ? TransparencyType_PremultipliedNonLinear : TransparencyType_Straight)
+                      : TransparencyType_None,
+            transparency_override_of(opts), assumed);
         image->metadata["loader"] = "libtiff";
         image->partname           = partname;
 
@@ -874,7 +875,7 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         Chromaticities chr;
 
         // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
-        unpremultiply_before_transfer(float_pixels.data(), size, image->alpha_type);
+        unpremultiply_before_transfer(float_pixels.data(), size, image->transparency);
 
         if (opts.override_profile)
         {
@@ -976,11 +977,11 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
             }
         }
 
-        repremultiply_after_transfer(float_pixels.data(), size, image->alpha_type);
+        repremultiply_after_transfer(float_pixels.data(), size, image->transparency);
 
         image->metadata["color profile"] = profile_desc;
 
-        // Image::finalize() premultiplies straight alpha, keyed off the alpha_type set above
+        // Image::finalize() premultiplies straight alpha, keyed off the transparency set above
 
         // Copy processed pixels to image channels
         for (int c = 0; c < num_channels; ++c)

--- a/src/imageio/uhdr.cpp
+++ b/src/imageio/uhdr.cpp
@@ -238,7 +238,7 @@ vector<ImagePtr> load_uhdr_image(istream &is, string_view filename, const ImageL
 
     auto image      = make_shared<Image>(size, 4);
     image->filename = filename;
-    image->set_alpha(AlphaType_Straight, AlphaSource_Format, alpha_override_of(opts));
+    image->set_alpha(AlphaType_Straight, alpha_override_of(opts));
     image->metadata["loader"] = "libuhdr";
 
     if (auto md = uhdr_dec_get_gainmap_metadata(decoder.get()))

--- a/src/imageio/uhdr.cpp
+++ b/src/imageio/uhdr.cpp
@@ -238,7 +238,7 @@ vector<ImagePtr> load_uhdr_image(istream &is, string_view filename, const ImageL
 
     auto image      = make_shared<Image>(size, 4);
     image->filename = filename;
-    image->set_alpha(AlphaType_Straight, alpha_override_of(opts));
+    image->set_transparency(TransparencyType_Straight, transparency_override_of(opts));
     image->metadata["loader"] = "libuhdr";
 
     if (auto md = uhdr_dec_get_gainmap_metadata(decoder.get()))

--- a/src/imageio/webp.cpp
+++ b/src/imageio/webp.cpp
@@ -331,7 +331,8 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
             frame_image->filename      = filename;
             frame_image->partname      = partname;
             // WebP's spec makes alpha unassociated
-            frame_image->set_alpha(has_alpha ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
+            frame_image->set_transparency(has_alpha ? TransparencyType_Straight : TransparencyType_None,
+                                          transparency_override_of(opts));
             frame_image->icc_data       = icc_data;
             frame_image->exif           = Exif{exif_data};
             frame_image->xmp_data       = xmp_data;
@@ -393,7 +394,7 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
             int3 frame_size{frame_width, frame_height, num_channels};
 
             // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
-            unpremultiply_before_transfer(frame_pixels.data(), frame_size, frame_image->alpha_type);
+            unpremultiply_before_transfer(frame_pixels.data(), frame_size, frame_image->transparency);
 
             if (opts.override_profile)
             {
@@ -420,7 +421,7 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
                 frame_image->metadata["color profile"] = profile_desc;
             }
 
-            repremultiply_after_transfer(frame_pixels.data(), frame_size, frame_image->alpha_type);
+            repremultiply_after_transfer(frame_pixels.data(), frame_size, frame_image->transparency);
 
             float        *pixels = frame_pixels.data();
             vector<float> canvas_float;

--- a/src/imageio/webp.cpp
+++ b/src/imageio/webp.cpp
@@ -331,8 +331,7 @@ vector<ImagePtr> load_webp_image(istream &is, string_view filename, const ImageL
             frame_image->filename      = filename;
             frame_image->partname      = partname;
             // WebP's spec makes alpha unassociated
-            frame_image->set_alpha(has_alpha ? AlphaType_Straight : AlphaType_None, AlphaSource_Format,
-                                   alpha_override_of(opts));
+            frame_image->set_alpha(has_alpha ? AlphaType_Straight : AlphaType_None, alpha_override_of(opts));
             frame_image->icc_data       = icc_data;
             frame_image->exif           = Exif{exif_data};
             frame_image->xmp_data       = xmp_data;

--- a/tests/gui/test_gui_edit.cpp
+++ b/tests/gui/test_gui_edit.cpp
@@ -874,7 +874,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
         auto        img   = hdrview()->current_image();
         const auto &group = img->groups[img->selected_group];
         // loudly, not silently: a test that skips itself here would pass while fill was wrong
-        IM_CHECK_EQ(int(img->alpha_type != AlphaType_None), 1);
+        IM_CHECK_EQ(int(img->transparency != TransparencyType_None), 1);
         IM_CHECK_EQ(int(group_has_alpha(group.type)), 1);
 
         // half-transparent red: finalize() premultiplies a straight-alpha image, so what lands in the
@@ -1446,7 +1446,7 @@ void RegisterTests_Edit(ImGuiTestEngine *engine)
 
         // what the samples mean travels with them; a copy read in different primaries is a different picture
         IM_CHECK_EQ(copy->color_space, original->color_space);
-        IM_CHECK_EQ(copy->alpha_type, original->alpha_type);
+        IM_CHECK_EQ(copy->transparency, original->transparency);
         IM_CHECK_EQ(copy->groups.size(), original->groups.size());
 
         reset_images(ctx);

--- a/tests/test_alpha.cpp
+++ b/tests/test_alpha.cpp
@@ -46,9 +46,10 @@ float linear_premult(float c, float a) { return from_linear(a * c, TransferFunct
 
 TEST_CASE("The alpha pair is a no-op for every kind but post-transfer premultiplication")
 {
-    for (AlphaType_ at : {AlphaType_None, AlphaType_PremultipliedLinear, AlphaType_Straight})
+    for (TransparencyType_ at :
+         {TransparencyType_None, TransparencyType_PremultipliedLinear, TransparencyType_Straight})
     {
-        CAPTURE(alpha_type_name(at));
+        CAPTURE(transparency_type_name(at));
         auto px = pixel(0.25f, 0.5f, 0.75f, 0.5f);
 
         unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, at);
@@ -67,13 +68,13 @@ TEST_CASE("Post-transfer premultiplication is divided out and restored around a 
     // what such a file holds: the encoded color, multiplied by alpha
     auto px = pixel(post_transfer(straight, a), post_transfer(straight, a), post_transfer(straight, a), a);
 
-    unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, TransparencyType_PremultipliedNonLinear);
     // dividing by alpha recovers the encoded straight color the inverse transfer expects
     CHECK(px[0] == doctest::Approx(from_linear(straight, TransferFunction::sRGB)));
 
     for (int c = 0; c < 3; ++c) px[c] = to_linear(px[c], TransferFunction::sRGB);
 
-    repremultiply_after_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    repremultiply_after_transfer(px.data(), int3{1, 1, 4}, TransparencyType_PremultipliedNonLinear);
     // ending in HDRView's working form: linear color, multiplied by alpha
     CHECK(px[0] == doctest::Approx(a * straight));
     CHECK(px[3] == doctest::Approx(a)); // alpha itself is never scaled
@@ -105,11 +106,11 @@ TEST_CASE("A fully transparent pixel keeps its color rather than dividing by zer
 {
     auto px = pixel(0.25f, 0.5f, 0.75f, 0.f);
 
-    unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 4}, TransparencyType_PremultipliedNonLinear);
     CHECK(px[0] == doctest::Approx(0.25f));
     CHECK(std::isfinite(px[0]));
 
-    repremultiply_after_transfer(px.data(), int3{1, 1, 4}, AlphaType_PremultipliedNonLinear);
+    repremultiply_after_transfer(px.data(), int3{1, 1, 4}, TransparencyType_PremultipliedNonLinear);
     // restoring multiplies by the alpha that is there, so a transparent pixel ends at zero either way
     CHECK(px[0] == doctest::Approx(0.f));
 }
@@ -119,7 +120,7 @@ TEST_CASE("A two-channel gray+alpha buffer is handled like RGBA")
     const float        a = 0.5f, straight = 0.8f;
     std::vector<float> px{post_transfer(straight, a), a};
 
-    unpremultiply_before_transfer(px.data(), int3{1, 1, 2}, AlphaType_PremultipliedNonLinear);
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 2}, TransparencyType_PremultipliedNonLinear);
     CHECK(px[0] == doctest::Approx(from_linear(straight, TransferFunction::sRGB)));
     CHECK(px[1] == doctest::Approx(a));
 }
@@ -127,53 +128,54 @@ TEST_CASE("A two-channel gray+alpha buffer is handled like RGBA")
 TEST_CASE("A single-channel buffer has no alpha to divide by and is left alone")
 {
     std::vector<float> px{0.25f};
-    unpremultiply_before_transfer(px.data(), int3{1, 1, 1}, AlphaType_PremultipliedNonLinear);
+    unpremultiply_before_transfer(px.data(), int3{1, 1, 1}, TransparencyType_PremultipliedNonLinear);
     CHECK(px[0] == doctest::Approx(0.25f));
 }
 
-TEST_CASE("set_alpha records what the file said, and what an override replaced it with")
+TEST_CASE("set_transparency records what the file said, and what an override replaced it with")
 {
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
 
     // no override: the effective kind is the file's
-    for (AlphaType_ at :
-         {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
+    for (TransparencyType_ at : {TransparencyType_None, TransparencyType_Straight, TransparencyType_PremultipliedLinear,
+                                 TransparencyType_PremultipliedNonLinear})
     {
-        img->set_alpha(at, std::nullopt);
-        CHECK(img->alpha_type == at);
-        CHECK(img->alpha_type_from_file == at);
-        CHECK_FALSE(img->alpha_assumed);
+        img->set_transparency(at, std::nullopt);
+        CHECK(img->transparency == at);
+        CHECK(img->transparency_from_file == at);
+        CHECK_FALSE(img->transparency_assumed);
     }
 
     // overridden: the effective kind changes, what the file said does not
-    for (AlphaType_ forced :
-         {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
-        for (AlphaType_ from_file :
-             {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
+    for (TransparencyType_ forced : {TransparencyType_None, TransparencyType_Straight,
+                                     TransparencyType_PremultipliedLinear, TransparencyType_PremultipliedNonLinear})
+        for (TransparencyType_ from_file :
+             {TransparencyType_None, TransparencyType_Straight, TransparencyType_PremultipliedLinear,
+              TransparencyType_PremultipliedNonLinear})
         {
-            img->set_alpha(from_file, forced, true);
-            CHECK(img->alpha_type == forced);
-            CHECK(img->alpha_type_from_file == from_file);
-            CHECK(img->alpha_assumed);
+            img->set_transparency(from_file, forced, true);
+            CHECK(img->transparency == forced);
+            CHECK(img->transparency_from_file == from_file);
+            CHECK(img->transparency_assumed);
         }
 }
 
 TEST_CASE("finalize() premultiplies straight alpha and leaves the other kinds alone")
 {
-    auto make = [](AlphaType_ at)
+    auto make = [](TransparencyType_ at)
     {
         auto img = std::make_shared<Image>(int2{1, 1}, 4);
         for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
         img->channels[3](0, 0) = 0.5f;
-        img->alpha_type        = at;
+        img->transparency      = at;
         img->finalize();
         return img;
     };
 
-    CHECK(make(AlphaType_Straight)->channels[0](0, 0) == doctest::Approx(0.5f));
+    CHECK(make(TransparencyType_Straight)->channels[0](0, 0) == doctest::Approx(0.5f));
     // already multiplied, whichever space it happened in
-    CHECK(make(AlphaType_PremultipliedLinear)->channels[0](0, 0) == doctest::Approx(1.f));
-    CHECK(make(AlphaType_PremultipliedNonLinear)->channels[0](0, 0) == doctest::Approx(1.f));
+    CHECK(make(TransparencyType_PremultipliedLinear)->channels[0](0, 0) == doctest::Approx(1.f));
+    CHECK(make(TransparencyType_PremultipliedNonLinear)->channels[0](0, 0) == doctest::Approx(1.f));
 }
 
 // The override exists for files that contradict their own format's convention.
@@ -197,7 +199,7 @@ TEST_CASE("An associated-alpha PNG can be read as premultiplied, against the PNG
         std::istringstream in(out.str(), std::ios::binary);
         auto               images = load_image(in, "premul.png", ImageLoadOptions{});
         REQUIRE(images.size() == 1);
-        CHECK(images[0]->alpha_type == AlphaType_Straight);
+        CHECK(images[0]->transparency == TransparencyType_Straight);
         // taken as straight: EOTF(0.5) linearized, then multiplied by coverage a second time
         CHECK(channel_value(images[0], "R") ==
               doctest::Approx(0.5f * to_linear(0.5f, TransferFunction::sRGB)).epsilon(0.05));
@@ -206,13 +208,13 @@ TEST_CASE("An associated-alpha PNG can be read as premultiplied, against the PNG
     // read as what it is: divided out across the transfer, then restored, ending where it started
     {
         ImageLoadOptions opts;
-        opts.override_alpha = true;
-        opts.alpha_override = AlphaType_PremultipliedNonLinear;
+        opts.override_transparency = true;
+        opts.transparency_override = TransparencyType_PremultipliedNonLinear;
 
         std::istringstream in(out.str(), std::ios::binary);
         auto               images = load_image(in, "premul.png", opts);
         REQUIRE(images.size() == 1);
-        CHECK(images[0]->alpha_type == AlphaType_PremultipliedNonLinear);
+        CHECK(images[0]->transparency == TransparencyType_PremultipliedNonLinear);
         // the bright color the file encodes, times its coverage
         CHECK(channel_value(images[0], "R") == doctest::Approx(0.5f).epsilon(0.05));
     }
@@ -234,19 +236,19 @@ TEST_CASE("A straight-alpha EXR can be read as straight, against the EXR spec")
         std::istringstream in(out.str(), std::ios::binary);
         auto               images = load_image(in, "straight.exr", ImageLoadOptions{});
         REQUIRE(images.size() == 1);
-        CHECK(images[0]->alpha_type == AlphaType_PremultipliedLinear);
+        CHECK(images[0]->transparency == TransparencyType_PremultipliedLinear);
         CHECK(channel_value(images[0], "R") == doctest::Approx(1.f).epsilon(0.01));
     }
 
     {
         ImageLoadOptions opts;
-        opts.override_alpha = true;
-        opts.alpha_override = AlphaType_Straight;
+        opts.override_transparency = true;
+        opts.transparency_override = TransparencyType_Straight;
 
         std::istringstream in(out.str(), std::ios::binary);
         auto               images = load_image(in, "straight.exr", opts);
         REQUIRE(images.size() == 1);
-        CHECK(images[0]->alpha_type == AlphaType_Straight);
+        CHECK(images[0]->transparency == TransparencyType_Straight);
         // finalize() now multiplies by the coverage the file's samples were never scaled by
         CHECK(channel_value(images[0], "R") == doctest::Approx(0.5f).epsilon(0.01));
     }
@@ -260,22 +262,24 @@ TEST_CASE("Every loader reports the alpha kind its format settles")
     {
         const char                                        *name;
         std::function<void(const Image &, std::ostream &)> save;
-        AlphaType_                                         from_file;
+        TransparencyType_                                  from_file;
     };
 
     const std::vector<Case> cases = {
         {"a.png", [](const Image &i, std::ostream &o)
-         { save_png_image(i, o, "a.png", 1.f, false, false, false, TransferFunction::sRGB); }, AlphaType_Straight},
+         { save_png_image(i, o, "a.png", 1.f, false, false, false, TransferFunction::sRGB); },
+         TransparencyType_Straight},
         {"a.exr", [](const Image &i, std::ostream &o) { save_exr_image(i, o, "a.exr"); },
-         AlphaType_PremultipliedLinear},
+         TransparencyType_PremultipliedLinear},
         {"a.qoi", [](const Image &i, std::ostream &o) { save_qoi_image(i, o, "a.qoi", 1.f, true, false); },
-         AlphaType_Straight},
+         TransparencyType_Straight},
         {"a.tga", [](const Image &i, std::ostream &o)
-         { save_stb_tga(i, o, "a.tga", 1.f, TransferFunction::sRGB, false); }, AlphaType_Straight},
+         { save_stb_tga(i, o, "a.tga", 1.f, TransferFunction::sRGB, false); }, TransparencyType_Straight},
 #if HDRVIEW_ENABLE_LIBTIFF
         // written with an EXTRASAMPLES tag, so the file itself carries the signal
-        {"a.tif", [](const Image &i, std::ostream &o)
-         { save_tiff_image(i, o, "a.tif", 1.f, TransferFunction::sRGB, 0, 0); }, AlphaType_PremultipliedNonLinear},
+        {"a.tif",
+         [](const Image &i, std::ostream &o) { save_tiff_image(i, o, "a.tif", 1.f, TransferFunction::sRGB, 0, 0); },
+         TransparencyType_PremultipliedNonLinear},
 #endif
     };
 
@@ -295,11 +299,11 @@ TEST_CASE("Every loader reports the alpha kind its format settles")
         auto               images = load_image(in, c.name, ImageLoadOptions{});
         REQUIRE(images.size() == 1);
 
-        CHECK_FALSE(images[0]->alpha_assumed);
-        CHECK(images[0]->alpha_type_from_file == c.from_file);
+        CHECK_FALSE(images[0]->transparency_assumed);
+        CHECK(images[0]->transparency_from_file == c.from_file);
         // with nothing overridden the effective kind is the file's, and no override is recorded
-        CHECK(images[0]->alpha_type == c.from_file);
-        CHECK_FALSE(images[0]->alpha_override.has_value());
+        CHECK(images[0]->transparency == c.from_file);
+        CHECK_FALSE(images[0]->transparency_override.has_value());
     }
 }
 
@@ -308,11 +312,11 @@ TEST_CASE("An image assembled in memory reports its alpha as assumed")
     // Nothing read it from anywhere: the samples are already in HDRView's working form. The IPC path relies
     // on that for tiles arriving before the alpha channel they would be scaled by.
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
-    CHECK(img->alpha_type == AlphaType_PremultipliedLinear);
-    CHECK(img->alpha_assumed);
+    CHECK(img->transparency == TransparencyType_PremultipliedLinear);
+    CHECK(img->transparency_assumed);
 
     // and one with no alpha channel says None, still without claiming anyone stated it
     auto rgb = std::make_shared<Image>(int2{1, 1}, 3);
-    CHECK(rgb->alpha_type == AlphaType_None);
-    CHECK(rgb->alpha_assumed);
+    CHECK(rgb->transparency == TransparencyType_None);
+    CHECK(rgb->transparency_assumed);
 }

--- a/tests/test_alpha.cpp
+++ b/tests/test_alpha.cpp
@@ -139,10 +139,10 @@ TEST_CASE("set_alpha records what the file said, and what an override replaced i
     for (AlphaType_ at :
          {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
     {
-        img->set_alpha(at, AlphaSource_File, std::nullopt);
+        img->set_alpha(at, std::nullopt);
         CHECK(img->alpha_type == at);
         CHECK(img->alpha_type_from_file == at);
-        CHECK(img->alpha_source == AlphaSource_File);
+        CHECK_FALSE(img->alpha_assumed);
     }
 
     // overridden: the effective kind changes, what the file said does not
@@ -151,10 +151,10 @@ TEST_CASE("set_alpha records what the file said, and what an override replaced i
         for (AlphaType_ from_file :
              {AlphaType_None, AlphaType_Straight, AlphaType_PremultipliedLinear, AlphaType_PremultipliedNonLinear})
         {
-            img->set_alpha(from_file, AlphaSource_Assumed, forced);
+            img->set_alpha(from_file, forced, true);
             CHECK(img->alpha_type == forced);
             CHECK(img->alpha_type_from_file == from_file);
-            CHECK(img->alpha_source == AlphaSource_Assumed);
+            CHECK(img->alpha_assumed);
         }
 }
 
@@ -252,33 +252,30 @@ TEST_CASE("A straight-alpha EXR can be read as straight, against the EXR spec")
     }
 }
 
-TEST_CASE("Every loader says where its alpha kind came from")
+TEST_CASE("Every loader reports the alpha kind its format settles")
 {
-    // A loader reports both what it concluded and how it knows, and both have to agree with what the format
-    // settles. A loader claiming a file stated something it did not is invisible in the pixels.
+    // Each of these formats states the kind for every conforming file, so no loader here may mark it
+    // assumed. A loader claiming the wrong kind is invisible in the pixels.
     struct Case
     {
         const char                                        *name;
         std::function<void(const Image &, std::ostream &)> save;
-        AlphaSource_                                       source;
         AlphaType_                                         from_file;
     };
 
     const std::vector<Case> cases = {
         {"a.png", [](const Image &i, std::ostream &o)
-         { save_png_image(i, o, "a.png", 1.f, false, false, false, TransferFunction::sRGB); }, AlphaSource_Format,
-         AlphaType_Straight},
-        {"a.exr", [](const Image &i, std::ostream &o) { save_exr_image(i, o, "a.exr"); }, AlphaSource_Format,
+         { save_png_image(i, o, "a.png", 1.f, false, false, false, TransferFunction::sRGB); }, AlphaType_Straight},
+        {"a.exr", [](const Image &i, std::ostream &o) { save_exr_image(i, o, "a.exr"); },
          AlphaType_PremultipliedLinear},
         {"a.qoi", [](const Image &i, std::ostream &o) { save_qoi_image(i, o, "a.qoi", 1.f, true, false); },
-         AlphaSource_Format, AlphaType_Straight},
+         AlphaType_Straight},
         {"a.tga", [](const Image &i, std::ostream &o)
-         { save_stb_tga(i, o, "a.tga", 1.f, TransferFunction::sRGB, false); }, AlphaSource_Format, AlphaType_Straight},
+         { save_stb_tga(i, o, "a.tga", 1.f, TransferFunction::sRGB, false); }, AlphaType_Straight},
 #if HDRVIEW_ENABLE_LIBTIFF
-        // the one format here carrying a per-file signal, so the only one that may say File
-        {"a.tif",
-         [](const Image &i, std::ostream &o) { save_tiff_image(i, o, "a.tif", 1.f, TransferFunction::sRGB, 0, 0); },
-         AlphaSource_File, AlphaType_PremultipliedNonLinear},
+        // written with an EXTRASAMPLES tag, so the file itself carries the signal
+        {"a.tif", [](const Image &i, std::ostream &o)
+         { save_tiff_image(i, o, "a.tif", 1.f, TransferFunction::sRGB, 0, 0); }, AlphaType_PremultipliedNonLinear},
 #endif
     };
 
@@ -298,7 +295,7 @@ TEST_CASE("Every loader says where its alpha kind came from")
         auto               images = load_image(in, c.name, ImageLoadOptions{});
         REQUIRE(images.size() == 1);
 
-        CHECK(images[0]->alpha_source == c.source);
+        CHECK_FALSE(images[0]->alpha_assumed);
         CHECK(images[0]->alpha_type_from_file == c.from_file);
         // with nothing overridden the effective kind is the file's, and no override is recorded
         CHECK(images[0]->alpha_type == c.from_file);
@@ -312,10 +309,10 @@ TEST_CASE("An image assembled in memory reports its alpha as assumed")
     // on that for tiles arriving before the alpha channel they would be scaled by.
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
     CHECK(img->alpha_type == AlphaType_PremultipliedLinear);
-    CHECK(img->alpha_source == AlphaSource_Assumed);
+    CHECK(img->alpha_assumed);
 
     // and one with no alpha channel says None, still without claiming anyone stated it
     auto rgb = std::make_shared<Image>(int2{1, 1}, 3);
     CHECK(rgb->alpha_type == AlphaType_None);
-    CHECK(rgb->alpha_source == AlphaSource_Assumed);
+    CHECK(rgb->alpha_assumed);
 }

--- a/tests/test_dds_io.cpp
+++ b/tests/test_dds_io.cpp
@@ -93,8 +93,8 @@ TEST_CASE("DDS premultiplied-alpha formats are not premultiplied a second time")
     REQUIRE(straight->channels.size() == 4);
     REQUIRE(premultiplied->channels.size() == 4);
 
-    CHECK(straight->alpha_type == AlphaType_Straight);
-    CHECK(premultiplied->alpha_type == AlphaType_PremultipliedLinear);
+    CHECK(straight->transparency == TransparencyType_Straight);
+    CHECK(premultiplied->transparency == TransparencyType_PremultipliedLinear);
 
     // both decode to the same alpha, which has to be well away from 0 and 1 for the rest to mean anything
     for (auto *img : {straight.get(), premultiplied.get()})
@@ -121,6 +121,6 @@ TEST_CASE("DDS DXT4 is premultiplied and DXT5 is straight")
     auto dxt5 = load_dds(make_one_block_dds("DXT5"), "dxt5.dds");
     auto dxt4 = load_dds(make_one_block_dds("DXT4"), "dxt4.dds");
 
-    CHECK(dxt5->alpha_type == AlphaType_Straight);
-    CHECK(dxt4->alpha_type == AlphaType_PremultipliedLinear);
+    CHECK(dxt5->transparency == TransparencyType_Straight);
+    CHECK(dxt4->transparency == TransparencyType_PremultipliedLinear);
 }

--- a/tests/test_exif.cpp
+++ b/tests/test_exif.cpp
@@ -19,6 +19,10 @@
 namespace
 {
 
+constexpr uint16_t k_tag_make = 0x010f, k_tag_compression = 0x0103, k_tag_orientation = 0x0112, k_tag_exif_ifd = 0x8769,
+                   k_tag_maker_note = 0x927c;
+constexpr uint16_t k_fmt_ascii = 2, k_fmt_short = 3, k_fmt_long = 4, k_fmt_rational = 5, k_fmt_undefined = 7;
+
 /// Builds a little-endian TIFF header with one IFD0, which is what an EXIF block is.
 struct TiffBuilder
 {
@@ -30,7 +34,8 @@ struct TiffBuilder
         bool                 external = false;
     };
 
-    std::vector<Entry> entries;
+    std::vector<Entry> entries;      ///< IFD0
+    std::vector<Entry> exif_entries; ///< the EXIF sub-IFD, which IFD0 points to when non-empty
 
     void add_inline(uint16_t tag, uint16_t format, uint32_t components, std::vector<uint8_t> four_bytes)
     {
@@ -40,6 +45,11 @@ struct TiffBuilder
     void add_external(uint16_t tag, uint16_t format, uint32_t components, std::vector<uint8_t> payload)
     {
         entries.push_back({tag, format, components, std::move(payload), true});
+    }
+    /// A maker note lives in the EXIF IFD, the only IFD libexif accepts the tag in.
+    void add_maker_note(std::vector<uint8_t> note)
+    {
+        exif_entries.push_back({k_tag_maker_note, k_fmt_undefined, (uint32_t)note.size(), std::move(note), true});
     }
 
     std::vector<uint8_t> build() const
@@ -55,12 +65,13 @@ struct TiffBuilder
         u16(42);
         u32(8); // IFD0 starts right after the header
 
-        // count + 12 bytes per entry + the next-IFD offset; external payloads follow
-        const uint32_t ifd_end    = 8 + 2 + 12 * (uint32_t)entries.size() + 4;
-        uint32_t       payload_at = ifd_end;
+        // each IFD is a count + 12 bytes per entry + the next-IFD offset; external payloads follow both
+        const uint32_t ifd0_count = (uint32_t)entries.size() + (exif_entries.empty() ? 0u : 1u);
+        const uint32_t sub_at     = 8 + 2 + 12 * ifd0_count + 4;
+        const uint32_t sub_end    = exif_entries.empty() ? sub_at : sub_at + 2 + 12 * (uint32_t)exif_entries.size() + 4;
 
-        u16((uint16_t)entries.size());
-        for (const auto &e : entries)
+        uint32_t payload_at = sub_end;
+        auto     emit       = [&](const Entry &e)
         {
             u16(e.tag);
             u16(e.format);
@@ -72,19 +83,34 @@ struct TiffBuilder
             }
             else
                 out.insert(out.end(), e.inline_or_external.begin(), e.inline_or_external.end());
+        };
+
+        u16((uint16_t)ifd0_count);
+        for (const auto &e : entries) emit(e);
+        if (!exif_entries.empty())
+        {
+            u16(k_tag_exif_ifd);
+            u16(k_fmt_long);
+            u32(1);
+            u32(sub_at);
         }
         u32(0); // no IFD1
 
-        for (const auto &e : entries)
-            if (e.external)
-                out.insert(out.end(), e.inline_or_external.begin(), e.inline_or_external.end());
+        if (!exif_entries.empty())
+        {
+            u16((uint16_t)exif_entries.size());
+            for (const auto &e : exif_entries) emit(e);
+            u32(0);
+        }
+
+        for (const auto *list : {&entries, &exif_entries})
+            for (const auto &e : *list)
+                if (e.external)
+                    out.insert(out.end(), e.inline_or_external.begin(), e.inline_or_external.end());
 
         return out;
     }
 };
-
-constexpr uint16_t k_tag_make = 0x010f, k_tag_compression = 0x0103, k_tag_orientation = 0x0112;
-constexpr uint16_t k_fmt_ascii = 2, k_fmt_short = 3;
 
 json parse(const std::vector<uint8_t> &blob) { return exif_to_json(blob.data(), blob.size()); }
 
@@ -95,6 +121,44 @@ bool has_tag_named(const json &j, const std::string &title)
         if (tags.is_object() && tags.contains(title))
             return true;
     return false;
+}
+
+/// One entry of an Apple maker note's IFD.
+struct MakerNoteEntry
+{
+    uint16_t tag, format;
+    uint32_t components;
+    uint32_t inline_or_offset; ///< the value itself where it fits in four bytes, else an offset into the note
+};
+
+/// Where apple_maker_note() places \p data in a note holding \p count entries.
+constexpr uint32_t maker_note_data_at(size_t count) { return 16 + 12 * (uint32_t)count + 4; }
+
+/// Builds an Apple maker note: a 12-byte signature, a little-endian IFD, then \p data.
+std::vector<uint8_t> apple_maker_note(const std::vector<MakerNoteEntry> &entries, const std::vector<uint8_t> &data)
+{
+    std::vector<uint8_t> n;
+    auto                 u16 = [&](uint16_t v) { n.insert(n.end(), {uint8_t(v & 0xff), uint8_t(v >> 8)}); };
+    auto                 u32 = [&](uint32_t v)
+    {
+        for (int i = 0; i < 4; ++i) n.push_back(uint8_t((v >> (8 * i)) & 0xff));
+    };
+
+    const char *signature = "Apple iOS";
+    n.insert(n.end(), signature, signature + 10);
+    n.insert(n.end(), {0, 1});
+    n.insert(n.end(), {'I', 'I'});
+    u16((uint16_t)entries.size());
+    for (const auto &e : entries)
+    {
+        u16(e.tag);
+        u16(e.format);
+        u32(e.components);
+        u32(e.inline_or_offset);
+    }
+    u32(0); // no next IFD
+    n.insert(n.end(), data.begin(), data.end());
+    return n;
 }
 
 } // namespace
@@ -159,22 +223,34 @@ TEST_CASE("One tag the file describes oddly does not discard the rest of the EXI
     }
 }
 
-TEST_CASE("A maker-note tag's range is bounded without the arithmetic wrapping")
+TEST_CASE("A maker-note entry is followed only where its data lies inside the note")
 {
-    // ranges that fit, including the empty and full ones
-    CHECK(maker_note_range_within(0, 0, 0));
-    CHECK(maker_note_range_within(0, 100, 100));
-    CHECK(maker_note_range_within(90, 10, 100));
-    CHECK(maker_note_range_within(100, 0, 100));
+    // the note holds one rational, 84/2, in the data area right after its two entries
+    constexpr uint32_t k_data_at  = maker_note_data_at(2);
+    constexpr uint16_t k_gain_tag = 0x30, k_headroom_tag = 0x21;
 
-    // ranges that do not
-    CHECK_FALSE(maker_note_range_within(91, 10, 100));
-    CHECK_FALSE(maker_note_range_within(101, 0, 100));
-    CHECK_FALSE(maker_note_range_within(0, 101, 100));
+    // offsets high enough that offset + size wraps back into range, which a check written as an addition
+    // reads as "fits" wherever size_t is 32 bits wide, as in the wasm build; then one far past the note and
+    // one that overruns it by a single byte
+    for (uint32_t bad_offset : {0xFFFFFFF8u, 0xFFFFFFFFu, 0x80000000u, 1000u, k_data_at + 1u})
+    {
+        CAPTURE(bad_offset);
+        TiffBuilder t;
+        t.add_external(k_tag_make, k_fmt_ascii, 8, {'H', 'D', 'R', 'V', 'i', 'e', 'w', 0});
+        t.add_maker_note(apple_maker_note(
+            {{k_gain_tag, k_fmt_rational, 1, bad_offset}, {k_headroom_tag, k_fmt_rational, 1, k_data_at}},
+            {84, 0, 0, 0, 2, 0, 0, 0}));
 
-    // an offset high enough that offset + size wraps back into range, which a check written as an addition
-    // reads as "fits" wherever size_t is 32 bits wide, as in the wasm build
-    CHECK_FALSE(maker_note_range_within(0xFFFFFFF8u, 32u, 100u));
-    CHECK_FALSE(maker_note_range_within(0xFFFFFFFFu, 1u, 100u));
-    CHECK_FALSE(maker_note_range_within(0x80000000u, 0x80000000u, 100u));
+        const auto blob = t.build();
+        Exif       exif{blob.data(), blob.size()};
+        REQUIRE(exif.valid());
+
+        CHECK_FALSE(exif.apple_makernote_value(k_gain_tag).has_value());
+
+        // the entry the note does describe well is still read, so the walk neither stops at the bad one nor
+        // rejects every offset
+        auto headroom = exif.apple_makernote_value(k_headroom_tag);
+        REQUIRE(headroom.has_value());
+        CHECK(*headroom == doctest::Approx(42.0));
+    }
 }

--- a/tests/test_export_roundtrip.cpp
+++ b/tests/test_export_roundtrip.cpp
@@ -162,7 +162,7 @@ ImagePtr make_image(const Layout &layout, float alpha)
     }
     // as every loader does for a straight-alpha file, so finalize() premultiplies and the writers'
     // unpremultiply step has something to undo
-    img->alpha_type = AlphaType_Straight;
+    img->transparency = TransparencyType_Straight;
     img->finalize();
     return img;
 }

--- a/tests/test_exr_io.cpp
+++ b/tests/test_exr_io.cpp
@@ -173,14 +173,14 @@ TEST_CASE("EXR load reports the format's premultiplied alpha convention")
 
         auto reloaded = save_and_reload(*img);
         REQUIRE(reloaded.size() == 1);
-        CHECK(reloaded[0]->alpha_type == AlphaType_PremultipliedLinear);
+        CHECK(reloaded[0]->transparency == TransparencyType_PremultipliedLinear);
     }
 
     SUBCASE("a part without an alpha channel")
     {
         auto reloaded = save_and_reload(*make_test_image(int2{2, 2}));
         REQUIRE(reloaded.size() == 1);
-        CHECK(reloaded[0]->alpha_type == AlphaType_None);
+        CHECK(reloaded[0]->transparency == TransparencyType_None);
     }
 }
 

--- a/tests/test_heif_io.cpp
+++ b/tests/test_heif_io.cpp
@@ -78,17 +78,3 @@ TEST_CASE("The HEIF and AVIF save entries write files branded as what their exte
 }
 
 #endif
-
-TEST_CASE("The HEIF and AVIF entries offer disjoint encoders")
-{
-    // aom offered under HEIF would write a file libheif brands 'avif' under a .heif name
-    const auto heif = heif_encoder_names(HEIFCodec::HEIF);
-    const auto avif = heif_encoder_names(HEIFCodec::AV1);
-
-    // a build with no encoder at all has nothing to say here
-    if (heif.empty() && avif.empty())
-        return;
-
-    for (const auto &a : avif)
-        CHECK_MESSAGE(std::find(heif.begin(), heif.end(), a) == heif.end(), "AV1 encoder also offered under HEIF: ", a);
-}

--- a/tests/test_image_groups.cpp
+++ b/tests/test_image_groups.cpp
@@ -14,12 +14,12 @@ namespace
 {
 
 // A 1x1 RGBA image with color channels of 1 and alpha 0.5, so a premultiply is visible.
-ImagePtr make_rgba_image(AlphaType_ alpha_type)
+ImagePtr make_rgba_image(TransparencyType_ transparency)
 {
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
     for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
     img->channels[3](0, 0) = 0.5f;
-    img->alpha_type        = alpha_type;
+    img->transparency      = transparency;
     img->finalize();
     return img;
 }
@@ -36,7 +36,7 @@ const ChannelGroup *find_group(const ImagePtr &img, const std::string &name)
 
 TEST_CASE("straight alpha is premultiplied into one RGBA group by default")
 {
-    auto img = make_rgba_image(AlphaType_Straight);
+    auto img = make_rgba_image(TransparencyType_Straight);
 
     REQUIRE(img->groups.size() == 1);
     auto *rgba = find_group(img, "R,G,B,A");
@@ -47,9 +47,9 @@ TEST_CASE("straight alpha is premultiplied into one RGBA group by default")
     CHECK(img->channels[0](0, 0) == doctest::Approx(0.5f));
 }
 
-TEST_CASE("AlphaType_None splits alpha off and skips the premultiply")
+TEST_CASE("TransparencyType_None splits alpha off and skips the premultiply")
 {
-    auto img = make_rgba_image(AlphaType_None);
+    auto img = make_rgba_image(TransparencyType_None);
 
     // R,G,B group next in the table, with A left over as its own single-channel group
     REQUIRE(img->groups.size() == 2);
@@ -72,7 +72,7 @@ TEST_CASE("raw_pixel reports the file's values for a straight-alpha image")
 {
     SUBCASE("straight alpha is divided back out")
     {
-        auto img = make_rgba_image(AlphaType_Straight);
+        auto img = make_rgba_image(TransparencyType_Straight);
 
         // stored premultiplied as 0.5; the file held 1.0
         CHECK(img->channels[0](0, 0) == doctest::Approx(0.5f));
@@ -84,7 +84,7 @@ TEST_CASE("raw_pixel reports the file's values for a straight-alpha image")
     SUBCASE("a premultiplied file is reported as stored")
     {
         // its alpha=0 pixels have no straight form, so its values are what the author intended
-        auto img = make_rgba_image(AlphaType_PremultipliedLinear);
+        auto img = make_rgba_image(TransparencyType_PremultipliedLinear);
 
         auto p = img->raw_pixel(int2{0, 0});
         CHECK(p.x == doctest::Approx(1.f));
@@ -98,7 +98,7 @@ TEST_CASE("An image whose default alpha type is left alone keeps its samples")
     auto img = std::make_shared<Image>(int2{1, 1}, 4);
     for (int c = 0; c < 3; ++c) img->channels[c](0, 0) = 1.f;
     img->channels[3](0, 0) = 0.5f;
-    REQUIRE(img->alpha_type == AlphaType_PremultipliedLinear);
+    REQUIRE(img->transparency == TransparencyType_PremultipliedLinear);
     img->finalize();
 
     // coverage, so it groups as RGBA, and already multiplied, so finalize() leaves it alone

--- a/tests/test_png_io.cpp
+++ b/tests/test_png_io.cpp
@@ -450,7 +450,7 @@ TEST_CASE("PngSuite's gray+alpha files survive a save/reload round trip")
         REQUIRE(original->channels.size() == 2);
         REQUIRE(original->groups.size() == 1);
         REQUIRE(original->groups[0].type == ChannelGroup::YA_Channels);
-        REQUIRE(original->alpha_type == AlphaType_Straight);
+        REQUIRE(original->transparency == TransparencyType_Straight);
 
         std::ostringstream out(std::ios::binary);
         save_png_image(*original, out, file, /*gain*/ 1.f, /*dither*/ false, /*interlaced*/ false,
@@ -506,8 +506,8 @@ TEST_CASE("PNG save/load round-trips gray+alpha without corrupting the alpha cha
             img->channels[1](x, y) = alpha[i];
         }
 
-    img->alpha_type = AlphaType_Straight; // what the PNG loader records for a gray+alpha file
-    img->finalize();                      // premultiplies Y by A, and builds the Y,A group
+    img->transparency = TransparencyType_Straight; // what the PNG loader records for a gray+alpha file
+    img->finalize();                               // premultiplies Y by A, and builds the Y,A group
 
     REQUIRE(img->groups.size() == 1);
     REQUIRE(img->groups[0].type == ChannelGroup::YA_Channels);
@@ -550,7 +550,7 @@ TEST_CASE("saving gray+alpha applies the exposure gain to the color channel only
             img->channels[0](x, y) = straight_y;
             img->channels[1](x, y) = a; // a gain of 2 would saturate this to 1
         }
-    img->alpha_type = AlphaType_Straight;
+    img->transparency = TransparencyType_Straight;
     img->finalize(); // premultiplies Y by A
 
     std::ostringstream out(std::ios::binary);

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -156,7 +156,7 @@ TEST_CASE("TIFF with unassociated alpha is premultiplied exactly once")
     auto img = load_tiff(tiff_with_extra_samples(2));
 
     REQUIRE(img->channels.size() == 4);
-    CHECK(img->alpha_type == AlphaType_Straight);
+    CHECK(img->transparency == TransparencyType_Straight);
     CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
 
     // premultiplying twice would leave k_half*k_half here
@@ -170,7 +170,7 @@ TEST_CASE("TIFF tagged EXTRASAMPLE_UNSPECIFIED keeps its fourth sample as data")
     auto img = load_tiff(tiff_with_extra_samples(0));
 
     REQUIRE(img->channels.size() == 4);
-    CHECK(img->alpha_type == AlphaType_None);
+    CHECK(img->transparency == TransparencyType_None);
     CHECK_FALSE(img->alpha_is_transparency());
     CHECK(img->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
     CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
@@ -188,7 +188,7 @@ TEST_CASE("TIFF associated alpha is read as multiplied into the encoded samples"
     auto img = load_tiff(tiff_with_second_pixel_color(1, 0x80));
 
     REQUIRE(img->channels.size() == 4);
-    CHECK(img->alpha_type == AlphaType_PremultipliedNonLinear);
+    CHECK(img->transparency == TransparencyType_PremultipliedNonLinear);
     CHECK(img->channels[3](1, 0) == doctest::Approx(k_half).epsilon(0.001));
 
     // dividing alpha out before the inverse transfer recovers straight 1.0, and multiplying back gives
@@ -205,30 +205,30 @@ TEST_CASE("An alpha override replaces what the TIFF declared")
     // Read a file the tag says is associated as straight, so finalize() multiplies instead of the loader
     // dividing. ImageMagick and vips both write premultiplied samples tagged unassociated.
     ImageLoadOptions opts;
-    opts.override_alpha = true;
-    opts.alpha_override = AlphaType_Straight;
+    opts.override_transparency = true;
+    opts.transparency_override = TransparencyType_Straight;
 
     std::istringstream in(tiff_with_second_pixel_color(1, 0x80), std::ios::binary);
     auto               images = load_image(in, "rgba.tif", opts);
     REQUIRE(images.size() == 1);
 
-    CHECK(images[0]->alpha_type == AlphaType_Straight);
+    CHECK(images[0]->transparency == TransparencyType_Straight);
     // straight 128/255 linearizes to 0.216, which finalize() then multiplies by alpha
     CHECK(images[0]->channels[0](1, 0) == doctest::Approx(0.216f * k_half).epsilon(0.02));
 }
 
-TEST_CASE("Overriding to AlphaType_None loads a declared alpha channel as data")
+TEST_CASE("Overriding to TransparencyType_None loads a declared alpha channel as data")
 {
     // the file declares real alpha and the user says it is a mask, so nothing is multiplied by it
     ImageLoadOptions opts;
-    opts.override_alpha = true;
-    opts.alpha_override = AlphaType_None;
+    opts.override_transparency = true;
+    opts.transparency_override = TransparencyType_None;
 
     std::istringstream in(tiff_with_extra_samples(2), std::ios::binary);
     auto               images = load_image(in, "rgba.tif", opts);
     REQUIRE(images.size() == 1);
 
-    CHECK(images[0]->alpha_type == AlphaType_None);
+    CHECK(images[0]->transparency == TransparencyType_None);
     CHECK_FALSE(images[0]->alpha_is_transparency());
     CHECK(images[0]->channels[0](1, 0) == doctest::Approx(1.f).epsilon(0.001));
     REQUIRE(images[0]->groups.size() == 2);
@@ -242,20 +242,20 @@ TEST_CASE("A TIFF says whether its alpha kind was stated or guessed")
     {
         CAPTURE(tag);
         auto img = load_tiff(tiff_with_extra_samples(tag));
-        CHECK_FALSE(img->alpha_assumed);
+        CHECK_FALSE(img->transparency_assumed);
     }
 
     // with the tag gone, nothing in the file states a kind and straight is the loader's guess
     auto guessed = load_tiff(tiff_without_extra_samples());
-    CHECK(guessed->alpha_assumed);
-    CHECK(guessed->alpha_type == AlphaType_Straight);
+    CHECK(guessed->transparency_assumed);
+    CHECK(guessed->transparency == TransparencyType_Straight);
 }
 
 TEST_CASE("An override leaves what the file said intact")
 {
     ImageLoadOptions opts;
-    opts.override_alpha = true;
-    opts.alpha_override = AlphaType_PremultipliedNonLinear;
+    opts.override_transparency = true;
+    opts.transparency_override = TransparencyType_PremultipliedNonLinear;
 
     std::istringstream in(tiff_with_extra_samples(2), std::ios::binary); // unassociated
     auto               images = load_image(in, "rgba.tif", opts);
@@ -263,9 +263,9 @@ TEST_CASE("An override leaves what the file said intact")
 
     // what is used and what the file declared both stay answerable, so the Info panel can say the override
     // contradicts the file instead of filling a gap
-    CHECK(images[0]->alpha_type == AlphaType_PremultipliedNonLinear);
-    CHECK(images[0]->alpha_type_from_file == AlphaType_Straight);
-    CHECK_FALSE(images[0]->alpha_assumed);
+    CHECK(images[0]->transparency == TransparencyType_PremultipliedNonLinear);
+    CHECK(images[0]->transparency_from_file == TransparencyType_Straight);
+    CHECK_FALSE(images[0]->transparency_assumed);
 }
 
 TEST_CASE("A saved TIFF multiplies alpha into its encoded samples")
@@ -296,7 +296,7 @@ TEST_CASE("A saved TIFF multiplies alpha into its encoded samples")
 
     // and it reads back as what it started as
     auto reloaded = load_tiff(out.str());
-    CHECK(reloaded->alpha_type == AlphaType_PremultipliedNonLinear);
+    CHECK(reloaded->transparency == TransparencyType_PremultipliedNonLinear);
     CHECK(reloaded->channels[0](0, 0) == doctest::Approx(0.5f).epsilon(0.02));
 }
 

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -235,19 +235,19 @@ TEST_CASE("Overriding to AlphaType_None loads a declared alpha channel as data")
     CHECK(images[0]->groups[1].type == ChannelGroup::Single_Channel);
 }
 
-TEST_CASE("A TIFF says where its alpha kind came from")
+TEST_CASE("A TIFF says whether its alpha kind was stated or guessed")
 {
     // EXTRASAMPLES settles it, whichever value it carries, including the one saying the sample is data
     for (uint16_t tag : {uint16_t(0), uint16_t(1), uint16_t(2)})
     {
         CAPTURE(tag);
         auto img = load_tiff(tiff_with_extra_samples(tag));
-        CHECK(img->alpha_source == AlphaSource_File);
+        CHECK_FALSE(img->alpha_assumed);
     }
 
     // with the tag gone, nothing in the file states a kind and straight is the loader's guess
     auto guessed = load_tiff(tiff_without_extra_samples());
-    CHECK(guessed->alpha_source == AlphaSource_Assumed);
+    CHECK(guessed->alpha_assumed);
     CHECK(guessed->alpha_type == AlphaType_Straight);
 }
 
@@ -261,11 +261,11 @@ TEST_CASE("An override leaves what the file said intact")
     auto               images = load_image(in, "rgba.tif", opts);
     REQUIRE(images.size() == 1);
 
-    // what is used, what the file declared, and how it declared it all stay answerable, so the Info panel
-    // can say the override contradicts the file rather than fills a gap
+    // what is used and what the file declared both stay answerable, so the Info panel can say the override
+    // contradicts the file instead of filling a gap
     CHECK(images[0]->alpha_type == AlphaType_PremultipliedNonLinear);
     CHECK(images[0]->alpha_type_from_file == AlphaType_Straight);
-    CHECK(images[0]->alpha_source == AlphaSource_File);
+    CHECK_FALSE(images[0]->alpha_assumed);
 }
 
 TEST_CASE("A saved TIFF multiplies alpha into its encoded samples")


### PR DESCRIPTION
**Based on #214.** Review that first; this diff shows only its own change.

## Alpha provenance becomes one bool

`AlphaSource_` had three values and exactly one consumer: the phrase in the Info panel. `Format` and `File` differed nowhere in behavior, yet four loaders carried logic choosing between them. A `bool` says the only thing anything ever asked.

| the loader | Info panel before | after |
|---|---|---|
| read it from the file's own field | Straight (from the file) | Straight |
| knew it from the format | Straight (per the format) | Straight |
| guessed | Straight (assumed) | Straight (assumed) |

Only TIFF without `EXTRASAMPLES` and DDS with a DX9 header guess.

## Alpha becomes transparency

`AlphaType_None` had to be read as "the alpha channel is not transparency", which is not what "alpha type: none" says. The combo spelled it out as `"None (channel is data)"` — a parenthetical apologising for the name. As `TransparencyType` the values read as themselves and the parenthetical is gone.

Renamed with it: the type and its values, `transparency_type_name()` and its override twin, `Image::transparency`, `transparency_from_file`, `transparency_override`, `transparency_assumed`, `set_transparency()`, `set_default_transparency()`, and the session file's key.

**Not renamed:** anything naming the alpha *channel*. `has_alpha`, `group_has_alpha`, `alpha_channel_index`, `alpha_bits`, and the unpremultiply/repremultiply pair all describe a channel that really is called alpha. What this renames is how to read it.

## Four things one file was doing several ways

- The miniz open, stat, size-check, extract sequence had **three copies** in `image_loader.cpp`, each ending every early return with its own `mz_zip_reader_end`. One helper.
- `remove_watched_directories()`, `remove_implicitly_watched_directories()` and `remove_watched_directories_if()` were one loop behind three names.
- `zip_bundle_hook` was a `std::function` member with a single binder, in a file that already calls `hdrview()` directly a dozen lines away.
- `heif_encoder_names()` had no caller outside its own test, and `HEIFCodec::Any` was never passed explicitly.

Plus: `decode_aux_gainmap()` was a serial copy of the plane-normalization loop beside it, and `tiff.cpp` special-cased sample widths that a `throw` a few lines later already rejected, once that throw moves above them.

## The maker-note bound, and a bug it caught

`maker_note_range_within()` was a one-line helper exported from `exif.h` only so a test could call it directly. It is inlined at its one call site, and the test now builds a maker note and asks the parser for a tag instead of asking the helper about three integers.

That change is worth a look, because **the new test caught a bug the same change introduced**. Inverting `size <= bound - offset` gives `size > bound - offset`; the first attempt wrote `>=`, one notch too far, which silently drops any entry whose data ends exactly at the end of the note — where the last entry's data always sits. The test failed, which is how it was found. Mutation check is therefore real rather than ceremonial: it fails with `>=` and passes with `>`.

| | |
|---|---|
| doctest | 326 cases, 361,742 assertions |
| GUI tests | 101 / 101 |

The case count is one below #214's because the dead `heif_encoder_names()` test went with the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
