### PR TITLE
Read the six cube faces one way, not three

### DIFF
--- a/src/array2d.h
+++ b/src/array2d.h
@@ -72,7 +72,13 @@ public:
     //@}
 
     //@{ \name Dimension sizes
-    int  num_elements() const { return m_size.x * m_size.y; }
+    int num_elements() const { return m_size.x * m_size.y; }
+    /// Value at (\p x, \p y), with a coordinate outside the array clamped to the nearest sample inside.
+    const T &clamped(int x, int y) const
+    {
+        return operator()(std::clamp(x, 0, width() - 1), std::clamp(y, 0, height() - 1));
+    }
+
     int2 size() const { return m_size; }
     int  width() const { return m_size.x; }
     int  height() const { return m_size.y; }
@@ -107,13 +113,6 @@ template <typename T>
 inline void Array2D<T>::operator=(const T &value)
 {
     reset(value);
-}
-
-/// Value of \p a at (\p x, \p y), with a coordinate outside it clamped to the nearest sample inside.
-template <typename T>
-inline T clamped(const Array2D<T> &a, int x, int y)
-{
-    return a(std::clamp(x, 0, a.width() - 1), std::clamp(y, 0, a.height() - 1));
 }
 
 using Array2Di = Array2D<int>;

--- a/src/array2d.h
+++ b/src/array2d.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fwd.h"
+#include <algorithm>
 #include <vector>
 
 /// Generic, resizable, 2D array class.
@@ -106,6 +107,13 @@ template <typename T>
 inline void Array2D<T>::operator=(const T &value)
 {
     reset(value);
+}
+
+/// Value of \p a at (\p x, \p y), with a coordinate outside it clamped to the nearest sample inside.
+template <typename T>
+inline T clamped(const Array2D<T> &a, int x, int y)
+{
+    return a(std::clamp(x, 0, a.width() - 1), std::clamp(y, 0, a.height() - 1));
 }
 
 using Array2Di = Array2D<int>;

--- a/src/edit/commands/envmap_commands.cpp
+++ b/src/edit/commands/envmap_commands.cpp
@@ -115,7 +115,7 @@ public:
             ImGui::SliderInt("Max anisotropy", &m_supersample, 1, 32);
             ImGui::Tooltip("How much longer than it is wide the footprint may be before it is widened to "
                            "fit. The mip level covers the short axis and the filter walks the long one, so "
-                           "this is what keeps a stretched footprint sharp -- and what it costs, since each "
+                           "this is what keeps a stretched footprint sharp, and what it costs, since each "
                            "step along that axis is another texel read.");
         }
         else
@@ -135,10 +135,9 @@ public:
         if (out_size.x <= 0 || out_size.y <= 0)
             return;
 
-        // no bias: the level the footprint asks for is the right one
         ctx.resample_image_async("Remap envmap", out_size,
                                  [s, d, out_size, ss, mode](const Array2Df &src, AtomicProgress p)
-                                 { return remapped_envmap(src, out_size, d, s, mode, ss, 0.f, p); });
+                                 { return remapped_envmap(src, out_size, d, s, mode, ss, p); });
     }
 
 private:

--- a/src/edit/envmap.cpp
+++ b/src/edit/envmap.cpp
@@ -20,7 +20,129 @@ namespace
 constexpr float k_pi      = 3.14159265358979323846f;
 constexpr float k_half_pi = k_pi / 2.f;
 
-float sqr(float x) { return x * x; }
+// -------------------------------------------------------------------------------------------------
+// The six faces of the cube, in the one orientation convention both cube layouts arrange
+// -------------------------------------------------------------------------------------------------
+
+/// The six faces of the cube, in the order everything below indexes them.
+enum CubeFace : int
+{
+    Face_PosX = 0,
+    Face_NegX,
+    Face_PosY,
+    Face_NegY,
+    Face_PosZ,
+    Face_NegZ,
+
+    Face_COUNT
+};
+
+/// Direction for \p st on \p face, in that face's own [0,1]^2; not normalized.
+/**
+    Not clamped: an \p st outside [0,1]^2 names a direction past that edge of the cube, which is how a face
+    reaches its neighbors.
+*/
+float3 cube_face_vector(int face, float2 st)
+{
+    const float a = 2.f * st.x - 1.f, b = 2.f * st.y - 1.f;
+    switch (face)
+    {
+    case Face_PosX: return float3{1.f, -b, -a};
+    case Face_NegX: return float3{-1.f, -b, a};
+    case Face_PosY: return float3{a, 1.f, b};
+    case Face_NegY: return float3{a, -1.f, -b};
+    case Face_PosZ: return float3{a, -b, 1.f};
+    default: return float3{a, b, -1.f};
+    }
+}
+
+/// Which face \p d falls on: the axis it points most steeply along, ties going to x and then y.
+int cube_face_of(float3 d)
+{
+    const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
+    if (ax >= ay && ax >= az)
+        return d.x >= 0.f ? Face_PosX : Face_NegX;
+    if (ay >= az)
+        return d.y >= 0.f ? Face_PosY : Face_NegY;
+    return d.z >= 0.f ? Face_PosZ : Face_NegZ;
+}
+
+/// Where \p d falls on \p face's plane, in that face's own [0,1]^2; the inverse of cube_face_vector().
+/**
+    \p face need not be the one \p d is really on: a direction off to the side lands outside [0,1]^2, so a
+    footprint reaching past an edge is still described in one face's coordinates.
+*/
+float2 cube_face_st(int face, float3 d)
+{
+    float axis;
+    switch (face)
+    {
+    case Face_PosX: axis = d.x; break;
+    case Face_NegX: axis = -d.x; break;
+    case Face_PosY: axis = d.y; break;
+    case Face_NegY: axis = -d.y; break;
+    case Face_PosZ: axis = d.z; break;
+    default: axis = -d.z; break;
+    }
+
+    // a direction at or behind this face's horizon has no place on its plane; the floor on the divisor
+    // puts it far outside the face instead of at infinity
+    const float3 t = d / std::max(axis, 1e-6f);
+
+    float a, b;
+    switch (face)
+    {
+    case Face_PosX:
+        a = -t.z;
+        b = -t.y;
+        break;
+    case Face_NegX:
+        a = t.z;
+        b = -t.y;
+        break;
+    case Face_PosY:
+        a = t.x;
+        b = t.z;
+        break;
+    case Face_NegY:
+        a = t.x;
+        b = -t.z;
+        break;
+    case Face_PosZ:
+        a = t.x;
+        b = -t.y;
+        break;
+    default:
+        a = t.x;
+        b = t.y;
+        break;
+    }
+
+    return float2{0.5f * (a + 1.f), 0.5f * (b + 1.f)};
+}
+
+/// Cell of the cross's 3-by-4 grid holding each face, as (column, row).
+constexpr int2 k_cross_cell[Face_COUNT] = {int2{2, 1}, int2{0, 1}, int2{1, 0}, int2{1, 2}, int2{1, 1}, int2{1, 3}};
+
+/// The face in the cross's (\p col, \p row) cell; the inverse of k_cross_cell.
+int cross_face(int col, int row)
+{
+    switch (col)
+    {
+    case 0: return Face_NegX;
+    case 2: return Face_PosX;
+    default: return row == 0 ? Face_PosY : row == 1 ? Face_PosZ : row == 2 ? Face_NegY : Face_NegZ;
+    }
+}
+
+/// Which of a face's two axes the single-column layout turns to match OpenEXR; the other it keeps.
+constexpr bool k_column_flips_s[Face_COUNT] = {true, true, false, false, true, false};
+
+/// \p st turned as the column layout turns \p face, which being a single flip is its own inverse.
+float2 column_st(int face, float2 st)
+{
+    return k_column_flips_s[face] ? float2{1.f - st.x, st.y} : float2{st.x, 1.f - st.y};
+}
 
 // -------------------------------------------------------------------------------------------------
 // image point -> direction
@@ -84,46 +206,16 @@ float3 cube_map_face_vector(float2 uv)
 {
     // This is assuming that the Cubemap is a vertical cross: the upright column of four down the middle
     // third, and the two side faces either side of it
-    float3 xyz{0.f};
+    const bool middle = uv.x >= 1.f / 3.f && uv.x <= 2.f / 3.f;
+    const int  col    = middle ? 1 : (uv.x < 1.f / 3.f ? 0 : 2);
+    const int  row    = middle ? (uv.y <= 0.25f ? 0 : uv.y <= 0.5f ? 1 : uv.y <= 0.75f ? 2 : 3) : 1;
 
-    if (uv.x >= 1.f / 3.f && uv.x <= 2.f / 3.f)
-    {
-        xyz.x = (uv.x - 0.5f) * 6.f;
-        if (uv.y <= 0.25f)
-        {
-            xyz.y = 1.f;
-            xyz.z = (uv.y - 0.125f) * 8.f;
-        }
-        else if (uv.y <= 0.5f)
-        {
-            xyz.y = (0.375f - uv.y) * 8.f;
-            xyz.z = 1.f;
-        }
-        else if (uv.y <= 0.75f)
-        {
-            xyz.y = -1.f;
-            xyz.z = (0.625f - uv.y) * 8.f;
-        }
-        else
-        {
-            xyz.y = (uv.y - 0.875f) * 8.f;
-            xyz.z = -1.f;
-        }
-    }
-    else if (uv.x < 1.f / 3.f)
-    {
-        xyz.x = -1.f;
-        xyz.y = (0.375f - std::clamp(uv.y, 0.25f, 0.5f)) * 8.f;
-        xyz.z = (std::clamp(uv.x, 0.f, 1.f / 3.f) - 1.f / 6.f) * 6.f;
-    }
-    else
-    {
-        xyz.x = 1.f;
-        xyz.y = (0.375f - std::clamp(uv.y, 0.25f, 0.5f)) * 8.f;
-        xyz.z = (5.f / 6.f - std::clamp(uv.x, 2.f / 3.f, 1.f)) * 6.f;
-    }
+    // a uv in one of the four corner cells stands for no direction; clamping it into the side face beside
+    // it gives that face's edge
+    const float u = middle ? uv.x : std::clamp(uv.x, float(col) / 3.f, float(col + 1) / 3.f);
+    const float v = middle ? uv.y : std::clamp(uv.y, 0.25f, 0.5f);
 
-    return xyz;
+    return cube_face_vector(cross_face(col, row), float2{u * 3.f - float(col), v * 4.f - float(row)});
 }
 
 float3 cube_map_to_xyz(float2 uv) { return la::normalize(cube_map_face_vector(uv)); }
@@ -131,25 +223,14 @@ float3 cube_map_to_xyz(float2 uv) { return la::normalize(cube_map_face_vector(uv
 /**
     The cube face vector for \p uv in the single-column layout, before normalizing.
 
-    Six faces stacked top to bottom as +X, -X, +Y, -Y, +Z, -Z, each turned the way OpenEXR turns it.
-    OpenEXR puts its outermost samples exactly on the face edges, where this puts them half a texel inside
-    as a GPU does; see CubeLevel. Same layout, sample grid offset by half a texel.
+    Six faces stacked top to bottom in the CubeFace order, each turned the way OpenEXR turns it. OpenEXR
+    puts its outermost samples exactly on the face edges, where this puts them half a texel inside as a GPU
+    does; see CubeLevel. Same layout, sample grid offset by half a texel.
 */
 float3 cube_column_face_vector(float2 uv)
 {
-    const int   face = std::clamp(int(uv.y * 6.f), 0, 5);
-    const float a    = 2.f * uv.x - 1.f;
-    const float b    = 2.f * (uv.y * 6.f - float(face)) - 1.f;
-
-    switch (face)
-    {
-    case 0: return float3{1.f, -b, a};   // +X
-    case 1: return float3{-1.f, -b, -a}; // -X
-    case 2: return float3{a, 1.f, -b};   // +Y
-    case 3: return float3{a, -1.f, b};   // -Y
-    case 4: return float3{-a, -b, 1.f};  // +Z
-    default: return float3{a, -b, -1.f}; // -Z
-    }
+    const int face = std::clamp(int(uv.y * 6.f), 0, 5);
+    return cube_face_vector(face, column_st(face, float2{uv.x, uv.y * 6.f - float(face)}));
 }
 
 float3 cube_column_to_xyz(float2 uv) { return la::normalize(cube_column_face_vector(uv)); }
@@ -157,33 +238,9 @@ float3 cube_column_to_xyz(float2 uv) { return la::normalize(cube_column_face_vec
 /// Where \p xyz falls in the single-column layout; the inverse of cube_column_face_vector().
 float2 xyz_to_cube_column(float3 xyz)
 {
-    const float ax = std::abs(xyz.x), ay = std::abs(xyz.y), az = std::abs(xyz.z);
-
-    int   face;
-    float l, a, b;
-    if (ax >= ay && ax >= az)
-    {
-        l    = ax;
-        face = xyz.x >= 0.f ? 0 : 1;
-        a    = (xyz.z / l) * (face == 0 ? 1.f : -1.f);
-        b    = -xyz.y / l;
-    }
-    else if (ay >= az)
-    {
-        l    = ay;
-        face = xyz.y >= 0.f ? 2 : 3;
-        a    = xyz.x / l;
-        b    = (xyz.z / l) * (face == 2 ? -1.f : 1.f);
-    }
-    else
-    {
-        l    = az;
-        face = xyz.z >= 0.f ? 4 : 5;
-        a    = (xyz.x / l) * (face == 4 ? -1.f : 1.f);
-        b    = -xyz.y / l;
-    }
-
-    return float2{0.5f * (a + 1.f), (float(face) + 0.5f * (b + 1.f)) / 6.f};
+    const int    face = cube_face_of(xyz);
+    const float2 st   = column_st(face, cube_face_st(face, xyz));
+    return float2{st.x, (float(face) + st.y) / 6.f};
 }
 
 //
@@ -248,33 +305,13 @@ float2 xyz_to_cylindrical(float3 xyz)
 
 float2 xyz_to_cube_map(float3 xyz)
 {
-    // Again, the CubeMap is a vertical cross.
-    // Make sure that the infinite norm of xyz == 1; the face tells us which side we're looking at.
-    float l    = std::abs(xyz.x);
-    int   face = int(sign(xyz.x));
-    if (std::abs(xyz.y) > l)
-    {
-        l    = std::abs(xyz.y);
-        face = int(sign(xyz.y)) * 2;
-    }
-    if (std::abs(xyz.z) > l)
-    {
-        l    = std::abs(xyz.z);
-        face = int(sign(xyz.z)) * 3;
-    }
+    // Again, the CubeMap is a vertical cross: the face tells us which side we're looking at, and its cell
+    // where that side sits in the 3-by-4 grid.
+    const int    face = cube_face_of(xyz);
+    const float2 st   = cube_face_st(face, xyz);
+    const int2   cell = k_cross_cell[face];
 
-    // Projected onto that face's plane, so one component is now +-1.
-    const float3 t = xyz / l;
-
-    switch (face)
-    {
-    case 3: return float2{t.x / 6.f + 0.5f, -t.y / 8.f + 0.375f};
-    case -1: return float2{t.z / 6.f + 1.f / 6.f, -t.y / 8.f + 0.375f};
-    case 1: return float2{-t.z / 6.f + 5.f / 6.f, -t.y / 8.f + 0.375f};
-    case 2: return float2{t.x / 6.f + 0.5f, t.z / 8.f + 0.125f};
-    case -2: return float2{t.x / 6.f + 0.5f, -t.z / 8.f + 0.625f};
-    default: return float2{t.x / 6.f + 0.5f, t.y / 8.f + 0.875f};
-    }
+    return float2{(float(cell.x) + st.x) / 3.f, (float(cell.y) + st.y) / 4.f};
 }
 
 template <typename Float, typename C>
@@ -415,19 +452,22 @@ float texel(const Array2Df &a, int x, int y, EnvMapping mapping)
     return a(std::clamp(x, 0, a.width() - 1), std::clamp(y, 0, a.height() - 1));
 }
 
-/// Bilinear read in [0,1]^2 image coordinates, reading past the edges as \p mapping says.
-float sample_bilinear(const Array2Df &a, float2 uv, EnvMapping mapping)
+/// Blend of the four texels around continuous coordinate (\p x, \p y), each supplied by \p at.
+template <typename At>
+float bilinear(float x, float y, At &&at)
 {
-    const float x = uv.x * float(a.width()) - 0.5f;
-    const float y = uv.y * float(a.height()) - 0.5f;
-
     const int   x0 = int(std::floor(x)), y0 = int(std::floor(y));
     const float tx = x - float(x0), ty = y - float(y0);
 
-    auto at = [&a, mapping](int i, int j) { return texel(a, i, j, mapping); };
-
     return (1.f - ty) * ((1.f - tx) * at(x0, y0) + tx * at(x0 + 1, y0)) +
            ty * ((1.f - tx) * at(x0, y0 + 1) + tx * at(x0 + 1, y0 + 1));
+}
+
+/// Bilinear read in [0,1]^2 image coordinates, reading past the edges as \p mapping says.
+float sample_bilinear(const Array2Df &a, float2 uv, EnvMapping mapping)
+{
+    return bilinear(uv.x * float(a.width()) - 0.5f, uv.y * float(a.height()) - 0.5f,
+                    [&a, mapping](int i, int j) { return texel(a, i, j, mapping); });
 }
 
 } // namespace
@@ -446,7 +486,7 @@ float envmap_jacobian(EnvMapping mapping, float2 uv)
         return 2.f * k_pi * k_pi * std::sin(k_pi * uv.y);
 
     case EnvMapping_Cylindrical:
-        // Archimedes: v is the height rather than the angle, so every row covers the same solid angle.
+        // Archimedes: v is the height and not the angle, so every row covers the same solid angle.
         return k_four_pi;
 
     case EnvMapping_EqualArea:
@@ -462,13 +502,13 @@ float envmap_jacobian(EnvMapping mapping, float2 uv)
     {
         // Here the polar angle itself grows linearly with the radius, so the sky compresses towards the rim.
         const float r = la::length(2.f * uv - float2{1.f});
-        // sin(pi*r)/r tends to pi at the center rather than dividing by zero.
+        // sin(pi*r)/r tends to pi at the center, where the ratio itself would divide by zero.
         return r < 1e-6f ? k_four_pi * k_pi : k_four_pi * std::sin(k_pi * r) / r;
     }
 
     case EnvMapping_CubeMapColumn:
     {
-        // As below, but the column gives each face a sixth of the image rather than a twelfth of it.
+        // As below, but the column gives each face a sixth of the image where the cross gives a twelfth.
         const float3 v = cube_column_face_vector(uv);
         const float  l = la::length(v);
         return 24.f / (l * l * l);
@@ -570,103 +610,6 @@ std::vector<Array2Df> build_mip_pyramid(const Array2Df &src)
 // A cube map's six faces, each in its own coordinates
 // -------------------------------------------------------------------------------------------------
 
-/// The six faces of the cube, in the order everything below indexes them.
-enum CubeFace : int
-{
-    Face_PosX = 0,
-    Face_NegX,
-    Face_PosY,
-    Face_NegY,
-    Face_PosZ,
-    Face_NegZ,
-
-    Face_COUNT
-};
-
-/// Direction for \p st on \p face, in that face's own [0,1]^2; not normalized.
-/**
-    Not clamped: an \p st outside [0,1]^2 names a direction past that edge of the cube, which is how a face
-    reaches its neighbors.
-*/
-float3 cube_face_vector(int face, float2 st)
-{
-    const float a = 2.f * st.x - 1.f, b = 2.f * st.y - 1.f;
-    switch (face)
-    {
-    case Face_PosX: return float3{1.f, -b, -a};
-    case Face_NegX: return float3{-1.f, -b, a};
-    case Face_PosY: return float3{a, 1.f, b};
-    case Face_NegY: return float3{a, -1.f, -b};
-    case Face_PosZ: return float3{a, -b, 1.f};
-    default: return float3{a, b, -1.f};
-    }
-}
-
-/// Which face \p d falls on: the axis it points most steeply along, ties going to x and then y.
-int cube_face_of(float3 d)
-{
-    const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
-    if (ax >= ay && ax >= az)
-        return d.x >= 0.f ? Face_PosX : Face_NegX;
-    if (ay >= az)
-        return d.y >= 0.f ? Face_PosY : Face_NegY;
-    return d.z >= 0.f ? Face_PosZ : Face_NegZ;
-}
-
-/// Where \p d falls on \p face's plane, in that face's own [0,1]^2; the inverse of cube_face_vector().
-/**
-    \p face need not be the one \p d is really on: a direction off to the side lands outside [0,1]^2, so a
-    footprint reaching past an edge is still described in one face's coordinates.
-*/
-float2 cube_face_st(int face, float3 d)
-{
-    float axis;
-    switch (face)
-    {
-    case Face_PosX: axis = d.x; break;
-    case Face_NegX: axis = -d.x; break;
-    case Face_PosY: axis = d.y; break;
-    case Face_NegY: axis = -d.y; break;
-    case Face_PosZ: axis = d.z; break;
-    default: axis = -d.z; break;
-    }
-
-    // a direction at or behind this face's horizon has no place on its plane; the floor on the divisor
-    // puts it far outside the face rather than at infinity
-    const float3 t = d / std::max(axis, 1e-6f);
-
-    float a, b;
-    switch (face)
-    {
-    case Face_PosX:
-        a = -t.z;
-        b = -t.y;
-        break;
-    case Face_NegX:
-        a = t.z;
-        b = -t.y;
-        break;
-    case Face_PosY:
-        a = t.x;
-        b = t.z;
-        break;
-    case Face_NegY:
-        a = t.x;
-        b = -t.z;
-        break;
-    case Face_PosZ:
-        a = t.x;
-        b = -t.y;
-        break;
-    default:
-        a = t.x;
-        b = t.y;
-        break;
-    }
-
-    return float2{0.5f * (a + 1.f), 0.5f * (b + 1.f)};
-}
-
 /// One mip level of a cube map: six faces, each ringed by a texel of whatever lies past its edges.
 /**
     These faces are cell-centered, as a GPU's are, so the outermost sample sits half a texel inside the
@@ -688,37 +631,17 @@ int face_size_for(EnvMapping mapping, int2 size)
                                                : std::max(1, std::min(size.x / 3, size.y / 4));
 }
 
-/// Bilinear read of \p face at \p st in face coordinates, over its interior alone.
-/**
-    This is what the ring is filled from, so it must not look at the ring itself.
-*/
-float sample_face_interior(const Array2Df &face, float2 st)
-{
-    const int   n = face.width() - 2;
-    const float x = st.x * float(n) + 0.5f, y = st.y * float(n) + 0.5f;
-
-    const int   x0 = int(std::floor(x)), y0 = int(std::floor(y));
-    const float tx = x - float(x0), ty = y - float(y0);
-
-    auto at = [&face, n](int i, int j) { return face(std::clamp(i, 1, n), std::clamp(j, 1, n)); };
-
-    return (1.f - ty) * ((1.f - tx) * at(x0, y0) + tx * at(x0 + 1, y0)) +
-           ty * ((1.f - tx) * at(x0, y0 + 1) + tx * at(x0 + 1, y0 + 1));
-}
-
 /// Bilinear read of \p face at \p st in face coordinates, the ring standing in past its edges.
-float sample_face(const Array2Df &face, float2 st)
+/**
+    An \p interior read stops at the edge of the face proper, which is what filling the ring must do.
+*/
+float sample_face(const Array2Df &face, float2 st, bool interior = false)
 {
-    const int   n = face.width() - 2;
-    const float x = st.x * float(n) + 0.5f, y = st.y * float(n) + 0.5f;
+    const int n  = face.width() - 2;
+    const int lo = interior ? 1 : 0, hi = interior ? n : n + 1;
 
-    const int   x0 = int(std::floor(x)), y0 = int(std::floor(y));
-    const float tx = x - float(x0), ty = y - float(y0);
-
-    auto at = [&face, n](int i, int j) { return face(std::clamp(i, 0, n + 1), std::clamp(j, 0, n + 1)); };
-
-    return (1.f - ty) * ((1.f - tx) * at(x0, y0) + tx * at(x0 + 1, y0)) +
-           ty * ((1.f - tx) * at(x0, y0 + 1) + tx * at(x0 + 1, y0 + 1));
+    return bilinear(st.x * float(n) + 0.5f, st.y * float(n) + 0.5f,
+                    [&face, lo, hi](int i, int j) { return face(std::clamp(i, lo, hi), std::clamp(j, lo, hi)); });
 }
 
 /// Fill every face's ring from whichever face the direction just past that edge belongs to.
@@ -736,7 +659,7 @@ void fill_face_padding(CubeLevel &level)
         const float3 d = cube_face_vector(f, st);
         const int    g = cube_face_of(d);
 
-        level[size_t(f)](i + 1, j + 1) = sample_face_interior(level[size_t(g)], cube_face_st(g, d));
+        level[size_t(f)](i + 1, j + 1) = sample_face(level[size_t(g)], cube_face_st(g, d), true);
     };
 
     for (int f = 0; f < Face_COUNT; ++f)
@@ -780,8 +703,8 @@ CubeLevel faces_from_source(const Array2Df &src, int n, EnvMapping mapping)
 
 /// \p prev at half its resolution, averaged 2x2 over the interiors alone and ringed afresh.
 /**
-    The ring is rebuilt rather than decimated because a coarser level's reads want a ring of what its own
-    neighbors hold at that level.
+    The ring is rebuilt, not decimated: a coarser level's reads want a ring of what its own neighbors hold
+    at that level.
 */
 CubeLevel decimated(const CubeLevel &prev)
 {
@@ -894,7 +817,7 @@ struct EWAFootprint
 
     Follows PBRT's `MIPMap::Filter`.
 */
-EWAFootprint choose_ewa_levels(float2 du, float2 dv, float2 base, int num_levels, int max_aniso, float mip_bias)
+EWAFootprint choose_ewa_levels(float2 du, float2 dv, float2 base, int num_levels, int max_aniso)
 {
     EWAFootprint fp;
 
@@ -927,7 +850,7 @@ EWAFootprint choose_ewa_levels(float2 du, float2 dv, float2 base, int num_levels
     // blend across the two levels either side, since a snapped level aliases in bands wherever the scale
     // crosses a power of two. Clamp the lod before splitting it into level and fraction, or a lod just
     // below 0 blends toward level 1.
-    const float lod = std::clamp(std::log2(shorter) + mip_bias, 0.f, float(num_levels - 1));
+    const float lod = std::clamp(std::log2(shorter), 0.f, float(num_levels - 1));
     fp.lo           = int(std::floor(lod));
     fp.hi           = std::min(fp.lo + 1, num_levels - 1);
     fp.blend        = lod - float(fp.lo);
@@ -935,7 +858,7 @@ EWAFootprint choose_ewa_levels(float2 du, float2 dv, float2 base, int num_levels
 }
 
 /**
-    A source image prepared to be read by direction rather than by image coordinate.
+    A source image prepared to be read by direction instead of by image coordinate.
 
     A cube map's layout is six charts in one image: texels either side of a face join are not neighboring
     directions, some cells stand for no direction, and a pyramid over the whole picture averages both into
@@ -971,12 +894,12 @@ public:
         \p uv is that pixel's center in \p dst's parameterization, \p delta_u and \p delta_v the step to
         the next pixel.
     */
-    float ewa(EnvMapping dst, float2 uv, float2 delta_u, float2 delta_v, int max_aniso, float mip_bias) const
+    float ewa(EnvMapping dst, float2 uv, float2 delta_u, float2 delta_v, int max_aniso) const
     {
         const float3 d = envmap_uv_to_xyz(dst, uv);
 
         if (!m_faces.empty())
-            return ewa_on_face(dst, uv, d, delta_u, delta_v, max_aniso, mip_bias);
+            return ewa_on_face(dst, uv, d, delta_u, delta_v, max_aniso);
 
         // footprint = source-space step to the neighboring destination pixel, which composes both
         // mappings at once. Use the smaller of the forward and backward differences so a seam (lat-long
@@ -990,8 +913,7 @@ public:
         };
 
         const float2       base{float(level(0).width()), float(level(0).height())};
-        const EWAFootprint fp =
-            choose_ewa_levels(step(delta_u), step(delta_v), base, num_levels(), max_aniso, mip_bias);
+        const EWAFootprint fp = choose_ewa_levels(step(delta_u), step(delta_v), base, num_levels(), max_aniso);
 
         if (fp.degenerate)
             return sample_bilinear(level(0), c, m_mapping);
@@ -1051,8 +973,7 @@ private:
         return sample_face(f, st);
     }
 
-    float ewa_on_face(EnvMapping dst, float2 uv, float3 d, float2 delta_u, float2 delta_v, int max_aniso,
-                      float mip_bias) const
+    float ewa_on_face(EnvMapping dst, float2 uv, float3 d, float2 delta_u, float2 delta_v, int max_aniso) const
     {
         const int    face = cube_face_of(d);
         const float2 st   = cube_face_st(face, d);
@@ -1067,8 +988,7 @@ private:
         };
 
         const float2       base{float(face_size(m_faces[0]))};
-        const EWAFootprint fp =
-            choose_ewa_levels(step(delta_u), step(delta_v), base, int(m_faces.size()), max_aniso, mip_bias);
+        const EWAFootprint fp = choose_ewa_levels(step(delta_u), step(delta_v), base, int(m_faces.size()), max_aniso);
 
         if (fp.degenerate)
             return sample_face_at(0, d);
@@ -1087,7 +1007,7 @@ private:
 } // namespace
 
 Array2Df remapped_envmap(const Array2Df &src, int2 size, EnvMapping dst_mapping, EnvMapping src_mapping,
-                         EnvMapSampling sampling, int supersample, float mip_bias, AtomicProgress progress)
+                         EnvMapSampling sampling, int supersample, AtomicProgress progress)
 {
     Array2Df out{size};
 
@@ -1120,7 +1040,7 @@ Array2Df remapped_envmap(const Array2Df &src, int2 size, EnvMapping dst_mapping,
                     if (sampling == EnvMapSampling_EWA)
                     {
                         out(x, y) = source.ewa(dst_mapping, uv, float2{1.f / float(size.x), 0.f},
-                                               float2{0.f, 1.f / float(size.y)}, ss, mip_bias);
+                                               float2{0.f, 1.f / float(size.y)}, ss);
                         continue;
                     }
 

--- a/src/edit/envmap.cpp
+++ b/src/edit/envmap.cpp
@@ -59,12 +59,9 @@ float3 cube_face_vector(int face, float2 st)
 /// Which face \p d falls on: the axis it points most steeply along, ties going to x and then y.
 int cube_face_of(float3 d)
 {
-    const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
-    if (ax >= ay && ax >= az)
-        return d.x >= 0.f ? Face_PosX : Face_NegX;
-    if (ay >= az)
-        return d.y >= 0.f ? Face_PosY : Face_NegY;
-    return d.z >= 0.f ? Face_PosZ : Face_NegZ;
+    // argmax breaks ties toward the lower index, which is the x-then-y order the faces are declared in
+    const int axis = la::argmax(la::abs(d));
+    return 2 * axis + (d[axis] < 0.f);
 }
 
 /// Where \p d falls on \p face's plane, in that face's own [0,1]^2; the inverse of cube_face_vector().
@@ -485,9 +482,7 @@ float envmap_jacobian(EnvMapping mapping, float2 uv)
         // dw = sin(phi) dtheta dphi, with theta spanning 2*pi across u and phi spanning pi down v.
         return 2.f * k_pi * k_pi * std::sin(k_pi * uv.y);
 
-    case EnvMapping_Cylindrical:
-        // Archimedes: v is the height and not the angle, so every row covers the same solid angle.
-        return k_four_pi;
+    case EnvMapping_Cylindrical: return k_four_pi;
 
     case EnvMapping_EqualArea:
         // equal-area by construction
@@ -502,7 +497,6 @@ float envmap_jacobian(EnvMapping mapping, float2 uv)
     {
         // Here the polar angle itself grows linearly with the radius, so the sky compresses towards the rim.
         const float r = la::length(2.f * uv - float2{1.f});
-        // sin(pi*r)/r tends to pi at the center, where the ratio itself would divide by zero.
         return r < 1e-6f ? k_four_pi * k_pi : k_four_pi * std::sin(k_pi * r) / r;
     }
 
@@ -703,8 +697,8 @@ CubeLevel faces_from_source(const Array2Df &src, int n, EnvMapping mapping)
 
 /// \p prev at half its resolution, averaged 2x2 over the interiors alone and ringed afresh.
 /**
-    The ring is rebuilt, not decimated: a coarser level's reads want a ring of what its own neighbors hold
-    at that level.
+    The ring is built afresh from the neighboring faces at the new size, since a read at this level wants
+    what its neighbors hold here.
 */
 CubeLevel decimated(const CubeLevel &prev)
 {

--- a/src/edit/envmap.h
+++ b/src/edit/envmap.h
@@ -76,10 +76,10 @@ enum EnvMapSampling : int
 
     Point sampling averages \p supersample^2 samples per output pixel. EWA reads a mip pyramid through an
     ellipse fitted to the pixel's footprint in the source (PBRT's MIPMap::EWA); there \p supersample is the
-    maximum anisotropy, and \p mip_bias shifts the level it computes (negative sharper, positive blurrier).
+    maximum anisotropy.
 */
 Array2Df remapped_envmap(const Array2Df &src, int2 size, EnvMapping dst_mapping, EnvMapping src_mapping,
-                         EnvMapSampling sampling = EnvMapSampling_Point, int supersample = 2, float mip_bias = 0.f,
+                         EnvMapSampling sampling = EnvMapSampling_Point, int supersample = 2,
                          AtomicProgress progress = {});
 
 /// Convolve \p src, a \p mapping of incident radiance, with a clamped cosine, giving irradiance per direction.

--- a/src/edit/filters.cpp
+++ b/src/edit/filters.cpp
@@ -15,17 +15,6 @@
 #include <smallthreadpool.h>
 #include <vector>
 
-namespace
-{
-
-/// Sample \p a at \p x, \p y with the border clamped to the nearest sample inside it.
-inline float clamped(const Array2Df &a, int x, int y)
-{
-    return a(std::clamp(x, 0, a.width() - 1), std::clamp(y, 0, a.height() - 1));
-}
-
-} // namespace
-
 int wrap_coord(int p, int extent, int mode)
 {
     if (p >= 0 && p < extent)

--- a/src/edit/filters.cpp
+++ b/src/edit/filters.cpp
@@ -152,12 +152,11 @@ Array2Df convolve_separable(const Array2Df &src, const Box2i &region, const std:
                                   const int x = region.min.x + i;
                                   if (taps_x.empty())
                                   {
-                                      horizontal(i, j) = clamped(src, x, y);
+                                      horizontal(i, j) = src.clamped(x, y);
                                       continue;
                                   }
                                   float sum = 0.f;
-                                  for (int k = -rx; k <= rx; ++k)
-                                      sum += taps_x[size_t(k + rx)] * clamped(src, x + k, y);
+                                  for (int k = -rx; k <= rx; ++k) sum += taps_x[size_t(k + rx)] * src.clamped(x + k, y);
                                   horizontal(i, j) = sum;
                               }
                               ++h_progress;
@@ -208,7 +207,7 @@ Array2Df box_pass(const Array2Df &src, int2 src_origin, const Box2i &region, int
     const int2 extent = region.size();
     const int  rows   = extent.y + 2 * ry;
 
-    auto at = [&src, src_origin](int x, int y) { return clamped(src, x - src_origin.x, y - src_origin.y); };
+    auto at = [&src, src_origin](int x, int y) { return src.clamped(x - src_origin.x, y - src_origin.y); };
 
     Array2Df    horizontal{int2{extent.x, rows}};
     const float inv_x = 1.f / float(2 * rx + 1);
@@ -462,7 +461,7 @@ Array2Df unsharp_masked(const Array2Df &src, const Box2i &region, float sigma, f
                           for (int y = y0; y < y1; ++y)
                               for (int x = 0; x < extent.x; ++x)
                               {
-                                  const float v = clamped(src, region.min.x + x, region.min.y + y);
+                                  const float v = src.clamped(region.min.x + x, region.min.y + y);
                                   out(x, y)     = v + amount * (v - blurred(x, y));
                               }
                       });
@@ -480,7 +479,7 @@ Array2Df median_filtered(const Array2Df &src, const Box2i &region, float radius,
     if (r == 0)
     {
         for (int y = 0; y < extent.y; ++y)
-            for (int x = 0; x < extent.x; ++x) out(x, y) = clamped(src, region.min.x + x, region.min.y + y);
+            for (int x = 0; x < extent.x; ++x) out(x, y) = src.clamped(region.min.x + x, region.min.y + y);
         return out;
     }
 
@@ -505,7 +504,7 @@ Array2Df median_filtered(const Array2Df &src, const Box2i &region, float radius,
                                       for (int dx = -r; dx <= r; ++dx)
                                           if (!disc || float(dx * dx + dy * dy) <= r2)
                                               window.push_back(
-                                                  clamped(src, region.min.x + x + dx, region.min.y + y + dy));
+                                                  src.clamped(region.min.x + x + dx, region.min.y + y + dy));
 
                                   // nth_element is linear, and only the middle value is wanted
                                   const size_t mid = window.size() / 2;
@@ -533,7 +532,7 @@ Array2Df zapped_gremlins(const Array2Df &src, const Box2i &region, float replace
                               for (int x = 0; x < extent.x; ++x)
                               {
                                   const int   sx = region.min.x + x, sy = region.min.y + y;
-                                  const float v = clamped(src, sx, sy);
+                                  const float v = src.clamped(sx, sy);
                                   if (std::isfinite(v))
                                   {
                                       out(x, y) = v;
@@ -548,7 +547,7 @@ Array2Df zapped_gremlins(const Array2Df &src, const Box2i &region, float replace
                                       {
                                           if (dx == 0 && dy == 0)
                                               continue;
-                                          const float nv = clamped(src, sx + dx, sy + dy);
+                                          const float nv = src.clamped(sx + dx, sy + dy);
                                           if (std::isfinite(nv))
                                               ring[size_t(n++)] = nv;
                                       }

--- a/src/edit/poisson.cpp
+++ b/src/edit/poisson.cpp
@@ -39,10 +39,10 @@ Array2Df laplacian(const Array2Df &src)
                       {
                           for (int y = y0; y < y1; ++y)
                               for (int x = 0; x < src.width(); ++x)
-                                  out(x, y) = clamped(src, x - 1, y) + clamped(src, x + 1, y) + clamped(src, x, y - 1) +
-                                              clamped(src, x, y + 1) + clamped(src, x - 1, y - 1) +
-                                              clamped(src, x + 1, y + 1) + clamped(src, x + 1, y - 1) +
-                                              clamped(src, x - 1, y + 1) - 8.f * clamped(src, x, y);
+                                  out(x, y) = src.clamped(x - 1, y) + src.clamped(x + 1, y) + src.clamped(x, y - 1) +
+                                              src.clamped(x, y + 1) + src.clamped(x - 1, y - 1) +
+                                              src.clamped(x + 1, y + 1) + src.clamped(x + 1, y - 1) +
+                                              src.clamped(x - 1, y + 1) - 8.f * src.clamped(x, y);
                       });
 
     return out;

--- a/src/edit/poisson.cpp
+++ b/src/edit/poisson.cpp
@@ -15,11 +15,6 @@
 namespace
 {
 
-inline float clamped(const Array2Df &a, int x, int y)
-{
-    return a(std::clamp(x, 0, a.width() - 1), std::clamp(y, 0, a.height() - 1));
-}
-
 /// Inner product of \p a and \p b.
 /**
     In double: the step lengths are ratios of two of these, and a float sum over a large region loses enough

--- a/tests/test_envmap.cpp
+++ b/tests/test_envmap.cpp
@@ -9,7 +9,6 @@
 #include "edit/envmap.h"
 
 #include <cmath>
-#include <functional>
 #include <string>
 #include <vector>
 
@@ -96,24 +95,6 @@ TEST_CASE("An image point lands inside the image it came from")
             CHECK(uv.y <= 1.f + 1e-4f);
         }
     }
-}
-
-TEST_CASE("Converting between two mappings is the same as going through a direction")
-{
-    // convert_envmap_uv() is an unprojection through one followed by a projection through the other
-    for (int src = 0; src < EnvMapping_COUNT; ++src)
-        for (int dst = 0; dst < EnvMapping_COUNT; ++dst)
-        {
-            CAPTURE(std::string(name_of(src)));
-            CAPTURE(std::string(name_of(dst)));
-
-            const float2 uv      = float2{0.37f, 0.61f};
-            const float2 direct  = convert_envmap_uv(EnvMapping(dst), EnvMapping(src), uv);
-            const float2 by_hand = envmap_xyz_to_uv(EnvMapping(dst), envmap_uv_to_xyz(EnvMapping(src), uv));
-
-            CHECK(direct.x == doctest::Approx(by_hand.x));
-            CHECK(direct.y == doctest::Approx(by_hand.y));
-        }
 }
 
 TEST_CASE("Converting a mapping to itself leaves the point where it was")
@@ -317,19 +298,32 @@ TEST_CASE("A cube map's faces join up, so a read at a face edge continues onto t
 {
     // Two texels either side of a face join are neighboring directions but nowhere near each other in the
     // cross, and for eight of the twelve joins what lies beside the edge in the image is an empty cell. So a
-    // read half a texel past an edge has to find the next face, checked against a function of direction alone.
-    auto f = [](float3 d) { return 0.5f + 0.2f * d.x + 0.15f * d.y - 0.1f * d.z; };
+    // read half a texel past an edge has to find the next face.
+    auto face_of = [](float3 d)
+    {
+        const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
+        const int   axis = ax >= ay && ax >= az ? 0 : (ay >= az ? 1 : 2);
+        return 2 * axis + ((axis == 0 ? d.x : axis == 1 ? d.y : d.z) >= 0.f ? 0 : 1);
+    };
 
+    // a smooth function of direction, which the result has to reproduce wherever a sample lands, joins
+    // included, with the cross's empty cells given a value nothing else could be confused with
+    auto       f = [](float3 d) { return 0.5f + 0.2f * d.x + 0.15f * d.y - 0.1f * d.z; };
     const int2 src_size{96, 128};
-    Array2Df   src = make_envmap(src_size, EnvMapping_CubeMap, f);
-
+    Array2Df   smooth = make_envmap(src_size, EnvMapping_CubeMap, f);
     for (int y = 0; y < src_size.y; ++y)
         for (int x = 0; x < src_size.x; ++x)
         {
             const float2 uv{(float(x) + 0.5f) / float(src_size.x), (float(y) + 0.5f) / float(src_size.y)};
             if (!envmap_uv_is_valid(EnvMapping_CubeMap, uv))
-                src(x, y) = 1000.f;
+                smooth(x, y) = 1000.f;
         }
+
+    // and a second source, constant on each face and jumping between them, so a disagreement about where a
+    // face ends shows at full contrast instead of as a fraction of a gradient
+    auto           face_value = [](int face) { return 0.1f + 0.16f * float(face); };
+    const Array2Df stepped =
+        make_envmap(src_size, EnvMapping_CubeMap, [&](float3 d) { return face_value(face_of(d)); });
 
     for (int sampler : {EnvMapSampling_Point, EnvMapSampling_EWA})
     {
@@ -338,7 +332,7 @@ TEST_CASE("A cube map's faces join up, so a read at a face edge continues onto t
         // magnified, so each destination sample reads a texel or two instead of averaging a face's worth
         const int2     size{192, 96};
         const Array2Df out =
-            remapped_envmap(src, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling(sampler), 2);
+            remapped_envmap(smooth, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling(sampler), 2);
 
         for (int y = 0; y < size.y; ++y)
             for (int x = 0; x < size.x; ++x)
@@ -348,107 +342,30 @@ TEST_CASE("A cube map's faces join up, so a read at a face edge continues onto t
                 const float2 uv{(float(x) + 0.5f) / float(size.x), (float(y) + 0.5f) / float(size.y)};
                 CHECK(out(x, y) == doctest::Approx(f(envmap_uv_to_xyz(EnvMapping_LatLong, uv))).epsilon(0.03));
             }
-    }
-}
 
-TEST_CASE("Crossing a cube map's face join is as smooth as staying on one face")
-{
-    // The visible failure is a discontinuity, not an error against the truth: a bright or dark line along a
-    // face's edge. The source is a smooth function of direction, so the largest step between samples on one
-    // face and the largest between samples on two are measured separately and compared, which depends on
-    // neither the resolution nor how steep the function is.
-    auto f = [](float3 d) { return 0.5f + 0.2f * d.x + 0.15f * d.y - 0.1f * d.z; };
-
-    const Array2Df src = make_envmap(int2{96, 128}, EnvMapping_CubeMap, f);
-
-    // which face a direction is on: the axis it points most steeply along
-    auto face_of = [](float3 d)
-    {
-        const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
-        const int   axis = ax >= ay && ax >= az ? 0 : (ay >= az ? 1 : 2);
-        return 2 * axis + ((axis == 0 ? d.x : axis == 1 ? d.y : d.z) >= 0.f ? 0 : 1);
-    };
-
-    for (int sampler : {EnvMapSampling_Point, EnvMapSampling_EWA})
-    {
-        CAPTURE(sampler);
-
-        const int2     size{256, 128};
-        const Array2Df out =
-            remapped_envmap(src, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling(sampler), 2);
-
-        // every row, so all twelve joins are covered and not only the four a ring around the equator meets
-        float within = 0.f, across = 0.f;
-        int   crossings = 0;
-        for (int y = 0; y < size.y; ++y)
-            for (int x = 1; x < size.x; ++x)
-            {
-                auto dir = [&](int i)
-                {
-                    return envmap_uv_to_xyz(EnvMapping_LatLong, float2{(float(i) + 0.5f) / float(size.x),
-                                                                       (float(y) + 0.5f) / float(size.y)});
-                };
-
-                const float step = std::abs(out(x, y) - out(x - 1, y));
-                if (face_of(dir(x)) == face_of(dir(x - 1)))
-                    within = std::max(within, step);
-                else
-                {
-                    across = std::max(across, step);
-                    ++crossings;
-                }
-            }
-
-        // the comparison is worth nothing unless the sweep met some joins
-        CHECK(crossings > 100);
-
-        CAPTURE(within);
-        CAPTURE(across);
-        CHECK(across < 2.f * within);
-    }
-}
-
-TEST_CASE("A face's ring carries its neighbors, so a read at an edge blends across the join")
-{
-    // Each face is stored with a one-texel ring of what lies past its edges, taken from whichever face that
-    // is. Given every face a value of its own, a join reconstructed with the ring spreads the step over about
-    // a texel, with samples in between on neither face; clamped at the edge, every sample holds one face's
-    // value.
-    auto face_of = [](float3 d)
-    {
-        const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
-        const int   axis = ax >= ay && ax >= az ? 0 : (ay >= az ? 1 : 2);
-        return 2 * axis + ((axis == 0 ? d.x : axis == 1 ? d.y : d.z) >= 0.f ? 0 : 1);
-    };
-    auto face_value = [](int face) { return 0.1f + 0.16f * float(face); };
-
-    const Array2Df src =
-        make_envmap(int2{96, 128}, EnvMapping_CubeMap, [&](float3 d) { return face_value(face_of(d)); });
-
-    for (int sampler : {EnvMapSampling_Point, EnvMapSampling_EWA})
-    {
-        CAPTURE(sampler);
-
+        // Each face is stored with a one-texel ring of what lies past its edges, taken from whichever face
+        // that is: a join reconstructed with the ring spreads the step over about a texel, with samples in
+        // between on neither face, where clamping at the edge leaves every sample holding one face's value.
         // Four destination samples per source texel around the equator, so a step spread over one texel is
-        // several samples wide. One sample per pixel, since averaging several within it would soften the
-        // step by itself.
-        const int2     size{512, 256};
-        const Array2Df out =
-            remapped_envmap(src, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling(sampler), 1);
+        // several samples wide, and one sample per pixel, since averaging several within it would soften
+        // the step by itself.
+        const int2     ring_size{512, 256};
+        const Array2Df ring =
+            remapped_envmap(stepped, ring_size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling(sampler), 1);
 
-        const int y = size.y / 2; // the equator, which crosses four faces and so four joins
+        const int y = ring_size.y / 2; // the equator, which crosses four faces and so four joins
 
         auto face_at = [&](int x)
         {
-            return face_of(envmap_uv_to_xyz(
-                EnvMapping_LatLong, float2{(float(x) + 0.5f) / float(size.x), (float(y) + 0.5f) / float(size.y)}));
+            return face_of(envmap_uv_to_xyz(EnvMapping_LatLong, float2{(float(x) + 0.5f) / float(ring_size.x),
+                                                                       (float(y) + 0.5f) / float(ring_size.y)}));
         };
 
         int   joins = 0, blended = 0;
         float largest = 0.f;
-        for (int x = 1; x < size.x; ++x)
+        for (int x = 1; x < ring_size.x; ++x)
         {
-            largest = std::max(largest, std::abs(out(x, y) - out(x - 1, y)));
+            largest = std::max(largest, std::abs(ring(x, y) - ring(x - 1, y)));
 
             if (face_at(x) == face_at(x - 1))
                 continue;
@@ -460,8 +377,8 @@ TEST_CASE("A face's ring carries its neighbors, so a read at an edge blends acro
             const float lo = std::min(a, b) + 0.15f * std::abs(a - b);
             const float hi = std::max(a, b) - 0.15f * std::abs(a - b);
 
-            for (int i = std::max(0, x - 3); i < std::min(size.x, x + 3); ++i)
-                if (out(i, y) > lo && out(i, y) < hi)
+            for (int i = std::max(0, x - 3); i < std::min(ring_size.x, x + 3); ++i)
+                if (ring(i, y) > lo && ring(i, y) < hi)
                 {
                     ++blended;
                     break;
@@ -476,33 +393,20 @@ TEST_CASE("A face's ring carries its neighbors, so a read at an edge blends acro
         CAPTURE(largest);
         CHECK(largest < 0.5f);
     }
-}
 
-TEST_CASE("Filtering a cube map elliptically agrees with averaging it by brute force")
-{
-    // The two samplers reach a cube map's faces by different routes: a bilinear tap per sub-sample, or an
-    // ellipse over a level of the pyramid. With enough sub-samples, point sampling is the average over the
-    // destination pixel, which is what EWA approximates, so it stands as a reference. The source is constant
-    // on each face and jumps between them, so every disagreement about where a face ends shows at full contrast.
-    auto face_of = [](float3 d)
-    {
-        const float ax = std::abs(d.x), ay = std::abs(d.y), az = std::abs(d.z);
-        const int   axis = ax >= ay && ax >= az ? 0 : (ay >= az ? 1 : 2);
-        return 2 * axis + ((axis == 0 ? d.x : axis == 1 ? d.y : d.z) >= 0.f ? 0 : 1);
-    };
-    const Array2Df src =
-        make_envmap(int2{96, 128}, EnvMapping_CubeMap, [&](float3 d) { return 0.1f + 0.16f * float(face_of(d)); });
-
-    // nearly isotropic, and lopsided each way: the anisotropic ones send the ellipse along a face and off
-    // the end of it
+    // The two samplers reach the faces by different routes: a bilinear tap per sub-sample, or an ellipse
+    // over a level of the pyramid. With enough sub-samples point sampling is the average over the
+    // destination pixel, which is what EWA approximates, so it stands as a reference. Nearly isotropic and
+    // lopsided each way: the anisotropic shapes send the ellipse along a face and off the end of it.
     for (int2 size : {int2{16, 8}, int2{64, 32}, int2{128, 8}, int2{8, 64}})
     {
         CAPTURE(size.x);
         CAPTURE(size.y);
 
         const Array2Df brute =
-            remapped_envmap(src, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling_Point, 24);
-        const Array2Df ewa = remapped_envmap(src, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling_EWA, 16);
+            remapped_envmap(stepped, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling_Point, 24);
+        const Array2Df ewa =
+            remapped_envmap(stepped, size, EnvMapping_LatLong, EnvMapping_CubeMap, EnvMapSampling_EWA, 16);
 
         double mean = 0.0, worst = 0.0;
         for (int i = 0; i < ewa.num_elements(); ++i)
@@ -624,19 +528,24 @@ TEST_CASE("EWA lands on the mean whatever shape the reduction is")
     {
         const char *what;
         int2        size;
+        int         max_aniso;
     };
     // only shapes that reduce along x, the axis the pattern varies on: a destination keeping x at full
-    // resolution covers one source column per pixel and shows the stripes, not their mean
-    const Shape shapes[] = {{"isotropic", int2{32, 32}},
-                            {"reduced in x only", int2{32, 512}},
-                            {"reduced further in x than in y", int2{16, 128}}};
+    // resolution covers one source column per pixel and shows the stripes, not their mean. The last is
+    // capped below the eccentricity it needs, so the ellipse is widened until round and the level rises with
+    // it: exceeding the cap gives a soft result and not a broken one, where keeping the level and gathering
+    // part of the footprint would alias.
+    const Shape shapes[] = {{"isotropic", int2{32, 32}, 16},
+                            {"reduced in x only", int2{32, 512}, 16},
+                            {"reduced further in x than in y", int2{16, 128}, 16},
+                            {"too eccentric for its anisotropy cap", int2{32, 512}, 1}};
 
     for (const Shape &shape : shapes)
     {
         CAPTURE(std::string(shape.what));
 
-        const Array2Df ewa =
-            remapped_envmap(src, shape.size, EnvMapping_LatLong, EnvMapping_LatLong, EnvMapSampling_EWA, 16);
+        const Array2Df ewa = remapped_envmap(src, shape.size, EnvMapping_LatLong, EnvMapping_LatLong,
+                                             EnvMapSampling_EWA, shape.max_aniso);
 
         double err = 0.0;
         for (int i = 0; i < ewa.num_elements(); ++i) err += std::abs(double(ewa(i)) - true_mean);
@@ -845,46 +754,26 @@ TEST_CASE("Magnifying reconstructs rather than repeating source texels")
     }
 }
 
-TEST_CASE("A footprint too eccentric to afford blurs rather than aliases")
-{
-    // At an anisotropy cap of one the ellipse is widened until round, which raises the level, so exceeding
-    // the cap gives a soft result and not a broken one. Keeping the level and gathering only part of the
-    // footprint is what aliases.
-    Array2Df src{int2{512, 64}};
-    for (int y = 0; y < 64; ++y)
-        for (int x = 0; x < 512; ++x) src(x, y) = (x % 8 < 2) ? 1.f : 0.f;
-
-    const Array2Df few =
-        remapped_envmap(src, int2{32, 64}, EnvMapping_LatLong, EnvMapping_LatLong, EnvMapSampling_EWA, 1);
-
-    // still near the mean, not swinging between the stripe's extremes
-    for (int i = 0; i < few.num_elements(); ++i)
-    {
-        CHECK(few(i) > 0.05f);
-        CHECK(few(i) < 0.6f);
-    }
-}
-
-TEST_CASE("Each parameterization asks for the proportions it can fill")
-{
-    // a remap to a size that ignores these stretches the result or throws away resolution along one axis
-    CHECK(envmapping_aspect(EnvMapping_LatLong) == doctest::Approx(2.f));
-    CHECK(envmapping_aspect(EnvMapping_Cylindrical) == doctest::Approx(2.f));
-    CHECK(envmapping_aspect(EnvMapping_CubeMap) == doctest::Approx(0.75f));
-    CHECK(envmapping_aspect(EnvMapping_Angular) == doctest::Approx(1.f));
-    CHECK(envmapping_aspect(EnvMapping_MirrorBall) == doctest::Approx(1.f));
-    CHECK(envmapping_aspect(EnvMapping_EqualArea) == doctest::Approx(1.f));
-}
-
 TEST_CASE("A mapping's aspect matches the area its image actually covers")
 {
-    // the proportion each wants is the one under which its valid region fills the image, measured here from
-    // the mapping itself rather than repeating the numbers above
+    // A remap to a size that ignores the proportions a parameterization asks for stretches the result or
+    // throws away resolution along one axis. Those proportions are what its layout packs into the image, so
+    // the fraction of the image that stands for a direction is measured from the mapping itself and checked
+    // against the same layout.
     for (int m = 0; m < EnvMapping_COUNT; ++m)
     {
         CAPTURE(std::string(name_of(m)));
 
-        // a tall, thin sampling grid so both axes are resolved; count where the mapping has a direction
+        // a full turn across by half a turn down, three faces across by four down, one across by six down,
+        // or a square
+        const bool   is_disc = m == EnvMapping_Angular || m == EnvMapping_MirrorBall;
+        const double aspect  = m == EnvMapping_LatLong || m == EnvMapping_Cylindrical ? 2.0
+                               : m == EnvMapping_CubeMap                              ? 3.0 / 4.0
+                               : m == EnvMapping_CubeMapColumn                        ? 1.0 / 6.0
+                                                                                      : 1.0;
+        CHECK(double(envmapping_aspect(m)) == doctest::Approx(aspect));
+
+        // a fine sampling grid so both axes are resolved; count where the mapping has a direction
         const int n       = 240;
         int       covered = 0;
         for (int y = 0; y < n; ++y)
@@ -895,7 +784,6 @@ TEST_CASE("A mapping's aspect matches the area its image actually covers")
         // the discs cover pi/4 of their square; the cross uses six of the twelve cells of its 3-by-4 grid,
         // the column of four plus the two side faces, and the rest fill their image
         const double fraction = double(covered) / double(n) * (1.0 / double(n));
-        const bool   is_disc  = m == EnvMapping_Angular || m == EnvMapping_MirrorBall;
         if (is_disc)
             CHECK(fraction == doctest::Approx(3.14159265358979 / 4.0).epsilon(0.01));
         else if (m == EnvMapping_CubeMap)
@@ -905,88 +793,49 @@ TEST_CASE("A mapping's aspect matches the area its image actually covers")
     }
 }
 
-TEST_CASE("The mip level is reached, moves with the bias, and is blended across")
+TEST_CASE("The mip level is blended continuously across the finest one")
 {
-    // the quality tests only show the result is close to the mean, which a sharp enough filter over the top
-    // level would also be
+    // A remap at the source's own size sits on the boundary between magnifying and minifying, where the lod
+    // crosses zero. Clamping the level while taking the fraction from the unclamped lod puts a whole level's
+    // worth of blur on one side of that boundary, which in a remap is a curve across the image.
+    //
+    // Alternating columns, which the finest level holds and the next one averages flat, so how much of the
+    // output's variation survives says which level was read.
     Array2Df src{int2{256, 256}};
     for (int y = 0; y < 256; ++y)
-        for (int x = 0; x < 256; ++x) src(x, y) = (x % 16 < 4) ? 1.f : 0.f;
+        for (int x = 0; x < 256; ++x) src(x, y) = float(x % 2);
 
-    auto remap = [&](float bias)
-    { return remapped_envmap(src, int2{32, 32}, EnvMapping_LatLong, EnvMapping_LatLong, EnvMapSampling_EWA, 8, bias); };
-
-    // spread of the output, as a stand-in for how much detail survives
-    auto spread = [](const Array2Df &a)
+    // spread about the mean, which compares across destinations of different sizes
+    auto variation = [&](int n)
     {
-        float lo = a(0), hi = a(0);
-        for (int i = 1; i < a.num_elements(); ++i)
-        {
-            lo = std::min(lo, a(i));
-            hi = std::max(hi, a(i));
-        }
-        return hi - lo;
+        const Array2Df out =
+            remapped_envmap(src, int2{n, n}, EnvMapping_LatLong, EnvMapping_LatLong, EnvMapSampling_EWA, 8);
+
+        double mean = 0.0;
+        for (int i = 0; i < out.num_elements(); ++i) mean += double(out(i));
+        mean /= double(out.num_elements());
+
+        double var = 0.0;
+        for (int i = 0; i < out.num_elements(); ++i) var += (double(out(i)) - mean) * (double(out(i)) - mean);
+        return std::sqrt(var / double(out.num_elements()));
     };
 
-    const float sharp   = spread(remap(-4.f));
-    const float neutral = spread(remap(0.f));
-    const float soft    = spread(remap(+4.f));
+    // a hundredth of a level either side of the boundary, and a whole level past it
+    const double just_over = variation(255), at = variation(256), just_under = variation(257);
+    const double one_level = variation(128);
 
-    // biasing down reaches levels that still hold the stripes and biasing up ones that do not; if the level
-    // were ignored, all three would be identical
-    CHECK(sharp > neutral);
-    CHECK(soft <= neutral);
+    CAPTURE(just_over);
+    CAPTURE(at);
+    CAPTURE(just_under);
+    CAPTURE(one_level);
 
-    // A continuous response to the level says the two levels either side are blended rather than one snapped
-    // to: a snapped level puts a whole level's worth of difference into the step crossing an integer and
-    // almost nothing into the others, which shows as bands wherever the scale crosses a power of two.
-    //
-    // Swept at two scales, since the two ends of the pyramid are reached differently: the reduction above
-    // lands in the middle, and a remap at its own size sits at level zero, where the lod goes negative as
-    // soon as the bias does.
-    auto sweep = [](const std::function<Array2Df(float)> &at_bias)
-    {
-        Array2Df prev  = at_bias(-1.f);
-        double   worst = 0.0, total = 0.0;
-        int      n = 0;
-        for (float bias = -0.9f; bias <= 1.01f; bias += 0.1f)
-        {
-            const Array2Df cur = at_bias(bias);
+    // the level is reached at all: the finest holds the columns and the next has averaged them away, or
+    // the comparison below says nothing
+    REQUIRE(at > 0.05);
+    REQUIRE(one_level < 0.25 * at);
 
-            double d = 0.0;
-            for (int i = 0; i < cur.num_elements(); ++i) d += std::abs(double(cur(i)) - double(prev(i)));
-            d /= double(cur.num_elements());
-
-            worst = std::max(worst, d);
-            total += d;
-            ++n;
-            prev = cur;
-        }
-
-        // no step much larger than the steps either side of it
-        CHECK(worst < 4.0 * (total / double(n)));
-    };
-
-    sweep(remap);
-
-    // The boundary between magnifying and minifying, too fine for the sweep above to see: a step either side
-    // is a fortieth of a level and must change the result by far less than a whole level does. A remap at the
-    // source's own size sits on it, one destination pixel per source pixel, so the lod is the bias.
-    auto at_own_size = [&](float bias) {
-        return remapped_envmap(src, int2{256, 256}, EnvMapping_LatLong, EnvMapping_LatLong, EnvMapSampling_EWA, 8,
-                               bias);
-    };
-
-    auto mean_difference = [](const Array2Df &a, const Array2Df &b)
-    {
-        double d = 0.0;
-        for (int i = 0; i < a.num_elements(); ++i) d += std::abs(double(a(i)) - double(b(i)));
-        return d / double(a.num_elements());
-    };
-
-    const double across = mean_difference(at_own_size(-0.02f), at_own_size(0.02f));
-    const double level  = mean_difference(at_own_size(0.f), at_own_size(1.f));
-
-    REQUIRE(level > 0.0); // the two levels differ at all, or the comparison says nothing
-    CHECK(across < 0.25 * level);
+    // and the two sides of the boundary agree far more closely than a level's worth of difference. Only
+    // these two are compared: at the source's own size the samples land on the columns instead of drifting
+    // across them, which changes the spread by itself.
+    CHECK(std::abs(just_under - just_over) < 0.2 * (just_over - one_level));
 }

--- a/tests/test_filters.cpp
+++ b/tests/test_filters.cpp
@@ -42,13 +42,37 @@ Array2Df constant(int2 size, float v)
 
 } // namespace
 
-TEST_CASE("A blur leaves a constant image constant")
+TEST_CASE("Every filter leaves a constant image alone")
 {
-    // clamping at the border makes this hold at the edges too, which blurring against black would not
+    // Clamping at the border makes this hold at the edges too, which filtering against black would not. A
+    // filter whose weights do not sum to one drifts off the constant, and a resampling one that reconstructs
+    // between samples has to keep it there as well.
     const Array2Df flat = constant(int2{16, 12}, 0.37f);
+    const Box2i    all  = whole(flat);
 
-    for (const Array2Df &out : {gaussian_blurred(flat, whole(flat), 3.f, 3.f), box_blurred(flat, whole(flat), 2, 2)})
+    auto is_flat = [](const char *what, const Array2Df &out)
+    {
+        CAPTURE(what);
         for (int i = 0; i < out.num_elements(); ++i) CHECK(out(i) == doctest::Approx(0.37f).epsilon(1e-5));
+    };
+
+    is_flat("gaussian", gaussian_blurred(flat, all, 3.f, 3.f));
+    is_flat("fast gaussian", fast_gaussian_blurred(flat, all, 3.f, 3.f));
+    is_flat("box", box_blurred(flat, all, 2, 2));
+    is_flat("iterated box", box_blurred(flat, all, 2, 2, 4));
+    is_flat("unsharp masked", unsharp_masked(flat, all, 2.f, 1.5f));
+    is_flat("median over a disc", median_filtered(flat, all, 3.f, true));
+    is_flat("median over a square", median_filtered(flat, all, 3.f, false));
+    is_flat("zapped", zapped_gremlins(flat, all));
+
+    // a fractional shift, so every sampler reconstructs between samples instead of picking one
+    for (int sampler = 0; sampler < Sampler_COUNT; ++sampler)
+        for (int border : {BorderMode_Edge, BorderMode_Repeat, BorderMode_Mirror})
+        {
+            CAPTURE(sampler);
+            CAPTURE(border);
+            is_flat("shifted", shifted(flat, all, 0.5f, -0.25f, sampler, border, border));
+        }
 }
 
 TEST_CASE("A blur conserves what it spreads")
@@ -408,21 +432,16 @@ TEST_CASE("Wrapping makes a shift reversible, and a shift by the whole image not
     }
 }
 
-TEST_CASE("A fractional shift reconstructs, rather than snapping to a sample")
+TEST_CASE("A fractional shift reconstructs instead of snapping to a sample")
 {
-    // Two things every sampler owes: a constant image survives, or the taps do not sum to one and the result
-    // drifts as it moves; and an offset landing between two samples does not round to one of them.
-    const Array2Df flat = constant(int2{12, 10}, 0.375f);
-    const Array2Df src  = noise(int2{24, 18});
+    // an offset landing between two samples must not round to one of them
+    const Array2Df src = noise(int2{24, 18});
 
     for (int sampler = 0; sampler < Sampler_COUNT; ++sampler)
         for (int border : {BorderMode_Edge, BorderMode_Repeat, BorderMode_Mirror})
         {
             CAPTURE(sampler);
             CAPTURE(border);
-
-            const Array2Df c = shifted(flat, whole(flat), 0.5f, -0.25f, sampler, border, border);
-            for (int i = 0; i < c.num_elements(); ++i) REQUIRE(c(i) == doctest::Approx(0.375f));
 
             // bracketing is bilinear's promise alone: bicubic's negative lobes overshoot to keep an edge
             // sharp, and its accuracy is measured on a ramp below
@@ -534,15 +553,6 @@ TEST_CASE("A median removes a lone outlier where a mean only spreads it")
     // whereas the blur has pushed it outwards
     CHECK(avg(4, 4) > 0.6f);
     CHECK(avg(5, 4) > 0.6f);
-}
-
-TEST_CASE("A median leaves a constant image alone")
-{
-    Array2Df flat{int2{12, 10}};
-    for (int i = 0; i < flat.num_elements(); ++i) flat(i) = 0.25f;
-
-    const Array2Df out = median_filtered(flat, whole(flat), 3.f);
-    for (int i = 0; i < out.num_elements(); ++i) CHECK(out(i) == doctest::Approx(0.25f));
 }
 
 TEST_CASE("A median keeps an edge that a blur would soften")


### PR DESCRIPTION
**Based on #216.** Review that first; this diff shows only its own change.

**The EWA filter, its mip pyramid, and the point supersampler all stay.** An earlier plan proposed replacing EWA and deleting the point sampler; both were reversed. This is trimming around them, and **no expected value in any test moved.**

## One cube-face convention instead of three

There were three sign tables for the same six faces: the 1.8 cross, the column, and the per-face pair. The column's +X read `{1,-b,a}` and the per-face one `{1,-b,-a}`, so telling OpenEXR's mirror apart from a typo meant deriving it.

The per-face pair is now the convention. The cross is a six-entry table of cells; the column is `face = floor(6v)` plus one boolean flip per face, which is its own inverse and so serves both directions. All twelve correspondences were derived by hand, and the cross's out-of-range clamping asymmetry is reproduced exactly.

## Smaller

- Two of the three bilinear readers differed in two integers; there is one now, taking the texel accessor.
- `sqr()` shadowed the one in `common.h` that the file already includes. `clamped()` was written out identically in `filters.cpp` and `poisson.cpp`, and now lives in `array2d.h`.
- **`mip_bias` is gone.** No caller outside its own test passed anything but zero, and the dialog passed zero with a comment saying its control had been removed. What that test was really checking — that the lod blend is continuous across level zero — is now checked by remapping to 255, 256 and 257 wide and asserting the two sides of zero agree far more closely than a level apart.

| | |
|---|---|
| `envmap.cpp` | −79 lines |
| tests | −141 net |
| doctest | 319 cases, 359,225 assertions |
| GUI tests | 101 / 101 |

The case count drops from 326 because five cube-map cases became two, and three constant-image cases became one sweep over eight filters × nine sampler/border combinations.

## Three things I decided, all reversible

**I did not delete the aspect-ratio pin**, though the plan said to. The test said to replace it with does not measure the same thing — it measures valid *area*, and never calls `envmapping_aspect`. Deleting it would have left that function untested. The two are merged into one sweep over all seven mappings, which also closes the gap the plan noticed: the old pin forgot `CubeMapColumn`, and the merged test now catches that.

**I did not delete the face-ring case either.** The plan said the 3%-agreement block implies it. It does not: on a smooth source a broken ring costs about half a texel of gradient, comfortably inside 3%. Breaking `fill_face_padding` fails 6 assertions in the ring block and none in the 3% block, so it was folded in rather than dropped.

**One mutation now goes undetected.** Flipping a single entry of the column's flip table passes the whole suite, because both directions read the same table and a wrong entry rotates a face consistently. The old two-table version could be mutated consistently too, so no coverage was lost, but the failure mode of a typo changed from "the round trip breaks" to "it silently disagrees with OpenEXR". Pinning it in-suite would just re-encode the same six booleans as literals; the honest fix is a fixture written by OpenEXR itself. **Your call whether that is worth doing.**

Separately, and pre-existing: nothing in the suite catches `ewa_face` clamping an out-of-ring tap instead of resolving the neighbouring face. This change neither created nor widened that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
