### PR TITLE
Draw the tone curve through free functions

### DIFF
--- a/src/edit/commands/color.cpp
+++ b/src/edit/commands/color.cpp
@@ -504,7 +504,7 @@ private:
             curved[i]     = brightness_contrast_nonlinear(x, slope, bias);
         }
 
-        if (!ImGui::BeginToneCurvePlot("##Curve"))
+        if (!ImGui::BeginToneCurvePlot("##Curve", true))
             return;
 
         const ImVec4 active{1.f, 1.f, 1.f, 0.85f};

--- a/src/edit/commands/color.cpp
+++ b/src/edit/commands/color.cpp
@@ -496,28 +496,28 @@ private:
         const float midpoint = (1.f - m_brightness) / 2.f;
         const float bias     = (m_brightness + 1.f) / 2.f;
 
-        float linear[ImGui::ToneCurvePlot::N], curved[ImGui::ToneCurvePlot::N];
-        for (int i = 0; i < ImGui::ToneCurvePlot::N; ++i)
+        float linear[ImGui::ToneCurveSamples], curved[ImGui::ToneCurveSamples];
+        for (int i = 0; i < ImGui::ToneCurveSamples; ++i)
         {
-            const float x = ImGui::ToneCurvePlot::x(i);
+            const float x = ImGui::ToneCurveX(i);
             linear[i]     = brightness_contrast_linear(x, slope, midpoint);
             curved[i]     = brightness_contrast_nonlinear(x, slope, bias);
         }
 
-        if (!m_plot.begin("##Curve"))
+        if (!ImGui::BeginToneCurvePlot("##Curve"))
             return;
 
         const ImVec4 active{1.f, 1.f, 1.f, 0.85f};
         const ImVec4 faint{1.f, 1.f, 1.f, 0.18f};
 
         // both are drawn whichever is in force, the inactive one faint
-        m_plot.curve("s-curve", curved, m_linear ? faint : active);
-        m_plot.curve("line", linear, m_linear ? active : faint);
+        ImGui::ToneCurve("s-curve", curved, m_linear ? faint : active);
+        ImGui::ToneCurve("line", linear, m_linear ? active : faint);
 
         // the pivot: the one input both curves send to the middle, whatever the contrast. Drawn as a
         // handle because it is also what the drag below grabs.
-        m_plot.marker_x("pivot", midpoint, ImVec4(1.f, 1.f, 1.f, 0.35f));
-        m_plot.handle(float2{midpoint, 0.5f}, ImVec4(1.f, 1.f, 1.f, 0.55f));
+        ImGui::ToneCurveMarkerX("pivot", midpoint, ImVec4(1.f, 1.f, 1.f, 0.35f));
+        ImGui::ToneCurveHandle(float2{midpoint, 0.5f}, ImVec4(1.f, 1.f, 1.f, 0.55f));
 
         /*
             Dragging does one of two things, decided by what was under the cursor when it went down. Near
@@ -527,7 +527,7 @@ private:
             The two cannot be combined: the pivot's output is one half at every contrast, so both requests
             agree only when the cursor is at one half.
         */
-        if (float2 p, from; m_plot.drag(p, &from))
+        if (float2 p, from; ImGui::ToneCurveDrag(p, &from))
         {
             if (m_dragging_pivot.value_or(std::fabs(from.x - midpoint) < 0.06f))
             {
@@ -550,7 +550,7 @@ private:
         else
             m_dragging_pivot.reset();
 
-        m_plot.end();
+        ImGui::EndToneCurvePlot();
     }
 
     /// Which of the image's qualities the curve is applied to.
@@ -563,10 +563,9 @@ private:
         Channel_COUNT
     };
 
-    float                m_brightness = 0.f, m_contrast = 0.f;
-    bool                 m_linear  = false;
-    int                  m_channel = Channel_RGB;
-    ImGui::ToneCurvePlot m_plot;
+    float m_brightness = 0.f, m_contrast = 0.f;
+    bool  m_linear  = false;
+    int   m_channel = Channel_RGB;
     /// Which of the two things the drag in progress is doing; unset between drags.
     std::optional<bool> m_dragging_pivot;
 };

--- a/src/edit/commands/tonal.cpp
+++ b/src/edit/commands/tonal.cpp
@@ -77,19 +77,18 @@ public:
         const float scale = std::pow(2.f, m_exposure);
         const float inv_g = 1.f / std::max(MIN_GAMMA, m_gamma);
 
-        float ys[ImGui::ToneCurvePlot::N];
-        for (int i = 0; i < ImGui::ToneCurvePlot::N; ++i)
-            ys[i] = spow(scale * ImGui::ToneCurvePlot::x(i) + m_offset, inv_g);
+        float ys[ImGui::ToneCurveSamples];
+        for (int i = 0; i < ImGui::ToneCurveSamples; ++i) ys[i] = spow(scale * ImGui::ToneCurveX(i) + m_offset, inv_g);
 
-        if (!m_plot.begin("##Curve"))
+        if (!ImGui::BeginToneCurvePlot("##Curve"))
             return;
 
-        m_plot.curve("exposure/gamma", ys, ImVec4(1.f, 1.f, 1.f, 0.85f));
+        ImGui::ToneCurve("exposure/gamma", ys, ImVec4(1.f, 1.f, 1.f, 0.85f));
 
         // where a mid-gray input lands
-        m_plot.marker_x("mid", 0.5f, ImVec4(1.f, 1.f, 1.f, 0.25f));
+        ImGui::ToneCurveMarkerX("mid", 0.5f, ImVec4(1.f, 1.f, 1.f, 0.25f));
 
-        m_plot.end();
+        ImGui::EndToneCurvePlot();
     }
 
     void apply(const EditContext &ctx) override
@@ -108,8 +107,7 @@ public:
     }
 
 private:
-    float                m_exposure = 0.f, m_offset = 0.f, m_gamma = 1.f;
-    ImGui::ToneCurvePlot m_plot;
+    float m_exposure = 0.f, m_offset = 0.f, m_gamma = 1.f;
 };
 
 class Fill final : public EditCommand

--- a/src/image-gui.cpp
+++ b/src/image-gui.cpp
@@ -502,20 +502,22 @@ void Image::draw_info()
             // same as filling in one nothing ever did.
             const string from_file = fmt::format("{}{}", transparency_type_name(transparency_from_file),
                                                  transparency_assumed ? " (assumed)" : "");
-            filtered_property("Alpha",
-                              transparency_override ? fmt::format("{} (override; was {})",
-                                                                  transparency_type_name(transparency), from_file)
-                                                    : from_file,
-                              "How this image's alpha is being read: whether the color channels are multiplied "
-                              "by it, and in what space. \"Assumed\" means nothing in the file stated it and the "
-                              "loader picked a default, which is where the override below is most likely wanted.");
+            filtered_property(
+                "Transparency",
+                transparency_override
+                    ? fmt::format("{} (override; was {})", transparency_type_name(transparency), from_file)
+                    : from_file,
+                "How this image's alpha channel is read: whether it means transparency, and if so in what "
+                "space. \"Assumed\" means nothing in the file stated it and the "
+                "loader picked a default, which is where the override below is most likely wanted.");
 
-            if (filter.PassFilter("Alpha override"))
+            if (filter.PassFilter("Transparency override"))
             {
                 // draw_info() is only ever drawn for the current image (see the Info window)
                 const bool reloadable = hdrview()->can_reload(hdrview()->current_image());
                 string     tooltip =
-                    "Read the alpha as something other than what the file says. \"None\" treats a fourth channel "
+                    "Read the alpha channel as something other than what the file says. \"None\" treats a fourth "
+                    "channel "
                     "as ordinary data rather than transparency, so nothing is multiplied by it.\n\nThe two "
                     "premultiplied kinds differ in where the multiply happened; pick the other one for an image "
                     "whose semi-transparent areas read too dark or too bright.\n\nChanging this re-reads the "
@@ -525,13 +527,13 @@ void Image::draw_info()
 
                 ImGui::BeginDisabled(!reloadable);
                 ImGui::PE::Entry(
-                    "Alpha override",
+                    "Transparency override",
                     [this]
                     {
                         static constexpr const char *k_not_overridden = "Not overridden";
 
                         bool changed = false;
-                        if (ImGui::BeginCombo("##Alpha override",
+                        if (ImGui::BeginCombo("##Transparency override",
                                               transparency_override ? transparency_override_name(*transparency_override)
                                                                     : k_not_overridden))
                         {

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -902,7 +902,7 @@ void draw_load_image_options_dialog(bool &open)
                        "only load layers which contain either of these two words, and \"-.A\" would exclude channels "
                        "named \"A\". Leave empty to load all parts.");
 
-        ImGui::Checkbox("Override file's alpha", &s_opts.override_transparency);
+        ImGui::Checkbox("Override file's transparency type", &s_opts.override_transparency);
         ImGui::Tooltip("By default HDRView follows what the file says about its alpha channel. Enable this to state "
                        "the interpretation yourself, for a file whose semi-transparent areas read too dark or too "
                        "bright, or whose fourth channel is really a mask rather than transparency.");
@@ -911,7 +911,7 @@ void draw_load_image_options_dialog(bool &open)
         {
             ImGui::Indent();
             ImGui::PushItemWidth(ImGui::CalcItemWidth() - ImGui::GetStyle().IndentSpacing);
-            if (ImGui::BeginCombo("Alpha", transparency_override_name(s_opts.transparency_override)))
+            if (ImGui::BeginCombo("Transparency", transparency_override_name(s_opts.transparency_override)))
             {
                 for (TransparencyType_ a = 0; a < TransparencyType_Count; ++a)
                 {

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -1387,13 +1387,31 @@ void PE::WrappedText(const string &property_name, const string &value, const str
 namespace ImGui
 {
 
-bool ToneCurvePlot::begin(const char *id)
+namespace
 {
-    // as wide as the sliders beneath it. The tick labels take more width at the left than height at
-    // the bottom, so the height carries a correction measured from the last frame; see end().
-    m_width = ImGui::CalcItemWidth();
+/// The plot's width this frame, and what its height needs on top of that for the area to come out square.
+/**
+    The correction is a property of the style rather than of any one plot, so both dialogs share it; it is
+    measured once and then holds. Between BeginToneCurvePlot() and EndToneCurvePlot() only one plot is open,
+    the same as ImPlot itself.
+*/
+float s_tone_width = 0.f;
+float s_tone_extra = 0.f;
 
-    if (!ImPlot::BeginPlot(id, ImVec2(m_width, m_width + m_extra_height),
+/// \p screen in the plot's own coordinates, clamped to the unit square the axes are locked to.
+float2 tone_plot_pos(ImVec2 screen)
+{
+    const ImPlotPoint p = ImPlot::PixelsToPlot(screen);
+    return float2{std::clamp(float(p.x), 0.f, 1.f), std::clamp(float(p.y), 0.f, 1.f)};
+}
+} // namespace
+
+bool BeginToneCurvePlot(const char *id)
+{
+    // as wide as the sliders beneath it, and as tall as it needs to be for the plot area to be square
+    s_tone_width = ImGui::CalcItemWidth();
+
+    if (!ImPlot::BeginPlot(id, ImVec2(s_tone_width, s_tone_width + s_tone_extra),
                            ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect))
         return false;
 
@@ -1409,18 +1427,18 @@ bool ToneCurvePlot::begin(const char *id)
     return true;
 }
 
-void ToneCurvePlot::curve(const char *name, const float *ys, ImVec4 color, float weight)
+void ToneCurve(const char *name, const float *ys, ImVec4 color, float weight)
 {
-    float xs[N];
-    for (int i = 0; i < N; ++i) xs[i] = x(i);
+    float xs[ToneCurveSamples];
+    for (int i = 0; i < ToneCurveSamples; ++i) xs[i] = ToneCurveX(i);
 
     ImPlotSpec spec;
     spec.LineWeight = weight;
     spec.LineColor  = color;
-    ImPlot::PlotLine(name, xs, ys, N, spec);
+    ImPlot::PlotLine(name, xs, ys, ToneCurveSamples, spec);
 }
 
-void ToneCurvePlot::marker_x(const char *name, float value, ImVec4 color)
+void ToneCurveMarkerX(const char *name, float value, ImVec4 color)
 {
     const float xs[2] = {value, value};
     const float ys[2] = {0.f, 1.f};
@@ -1431,7 +1449,7 @@ void ToneCurvePlot::marker_x(const char *name, float value, ImVec4 color)
     ImPlot::PlotLine(name, xs, ys, 2, spec);
 }
 
-void ToneCurvePlot::handle(float2 at, ImVec4 color)
+void ToneCurveHandle(float2 at, ImVec4 color)
 {
     const float xs[1] = {at.x};
     const float ys[1] = {at.y};
@@ -1444,43 +1462,31 @@ void ToneCurvePlot::handle(float2 at, ImVec4 color)
     ImPlot::PlotScatter("handle", xs, ys, 1, spec);
 }
 
-bool ToneCurvePlot::drag(float2 &position, float2 *pressed_at)
+bool ToneCurveDrag(float2 &position, float2 *pressed_at)
 {
-    auto here = []
-    {
-        const ImPlotPoint p = ImPlot::GetPlotMousePos();
-        return float2{std::clamp(float(p.x), 0.f, 1.f), std::clamp(float(p.y), 0.f, 1.f)};
-    };
-
-    if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
-    {
-        m_dragging = true;
-        m_press    = here();
-    }
-
-    if (!m_dragging)
-        return false;
-
     if (!ImGui::IsMouseDown(ImGuiMouseButton_Left))
-    {
-        m_dragging = false;
         return false;
-    }
 
-    position = here();
+    // ImGui already records where each button went down, so whether this drag belongs to the plot is a
+    // question about that point rather than something to remember from frame to frame
+    const ImVec2 began = ImGui::GetIO().MouseClickedPos[ImGuiMouseButton_Left];
+    const ImVec2 pos = ImPlot::GetPlotPos(), size = ImPlot::GetPlotSize();
+    if (began.x < pos.x || began.x > pos.x + size.x || began.y < pos.y || began.y > pos.y + size.y)
+        return false;
+
+    position = tone_plot_pos(ImGui::GetIO().MousePos);
     if (pressed_at)
-        *pressed_at = m_press;
+        *pressed_at = tone_plot_pos(began);
     return true;
 }
 
-void ToneCurvePlot::end()
+void EndToneCurvePlot()
 {
-    // measured before the plot closes, and applied to the next frame's height; see begin()
     // Squaring the plot area usually means taking height away, since the tick labels are wider at the left
     // than they are tall at the bottom, so this has to be free to go negative.
     const ImVec2 area = ImPlot::GetPlotSize();
     if (area.x > 0.f && area.y > 0.f)
-        m_extra_height = std::clamp(m_extra_height + (area.x - area.y), -0.5f * m_width, m_width);
+        s_tone_extra = std::clamp(s_tone_extra + (area.x - area.y), -0.5f * s_tone_width, s_tone_width);
 
     ImPlot::EndPlot();
 }

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -1411,8 +1411,12 @@ bool BeginToneCurvePlot(const char *id)
     // as wide as the sliders beneath it, and as tall as it needs to be for the plot area to be square
     s_tone_width = ImGui::CalcItemWidth();
 
+    // NoInputs because the curve is dragged through ToneCurveDrag(), which reads the mouse itself. Without
+    // it ImPlot reads the same drag as an attempt to pan, finds both axes locked, and shows the cursor that
+    // says the drag is not allowed.
     if (!ImPlot::BeginPlot(id, ImVec2(s_tone_width, s_tone_width + s_tone_extra),
-                           ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect))
+                           ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect |
+                               ImPlotFlags_NoInputs))
         return false;
 
     const ImPlotAxisFlags axes = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoMenus | ImPlotAxisFlags_Lock;

--- a/src/imgui_ext.cpp
+++ b/src/imgui_ext.cpp
@@ -1398,6 +1398,13 @@ namespace
 float s_tone_width = 0.f;
 float s_tone_extra = 0.f;
 
+/// Whether \p p is inside the open plot's area.
+bool in_tone_plot(ImVec2 p)
+{
+    const ImVec2 pos = ImPlot::GetPlotPos(), size = ImPlot::GetPlotSize();
+    return p.x >= pos.x && p.x <= pos.x + size.x && p.y >= pos.y && p.y <= pos.y + size.y;
+}
+
 /// \p screen in the plot's own coordinates, clamped to the unit square the axes are locked to.
 float2 tone_plot_pos(ImVec2 screen)
 {
@@ -1406,7 +1413,7 @@ float2 tone_plot_pos(ImVec2 screen)
 }
 } // namespace
 
-bool BeginToneCurvePlot(const char *id)
+bool BeginToneCurvePlot(const char *id, bool draggable)
 {
     // as wide as the sliders beneath it, and as tall as it needs to be for the plot area to be square
     s_tone_width = ImGui::CalcItemWidth();
@@ -1428,6 +1435,14 @@ bool BeginToneCurvePlot(const char *id)
 
     // fixed, so a steep curve is seen leaving the top and bottom instead of the frame following it
     ImPlot::SetupAxesLimits(0.0, 1.0, 0.0, 1.0, ImPlotCond_Always);
+
+    // say the curve can be taken hold of, and keep saying it while it is being held and the cursor has
+    // wandered off the plot
+    if (draggable && (ImGui::IsWindowHovered() ? in_tone_plot(ImGui::GetIO().MousePos)
+                                               : ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
+                                                     in_tone_plot(ImGui::GetIO().MouseClickedPos[0])))
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+
     return true;
 }
 
@@ -1474,8 +1489,7 @@ bool ToneCurveDrag(float2 &position, float2 *pressed_at)
     // ImGui already records where each button went down, so whether this drag belongs to the plot is a
     // question about that point rather than something to remember from frame to frame
     const ImVec2 began = ImGui::GetIO().MouseClickedPos[ImGuiMouseButton_Left];
-    const ImVec2 pos = ImPlot::GetPlotPos(), size = ImPlot::GetPlotSize();
-    if (began.x < pos.x || began.x > pos.x + size.x || began.y < pos.y || began.y > pos.y + size.y)
+    if (!in_tone_plot(began))
         return false;
 
     position = tone_plot_pos(ImGui::GetIO().MousePos);

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -315,47 +315,35 @@ void Tooltip(const char *description, bool questionMark = false, float wrap_widt
 */
 /**
     The square plot of a tone curve that the tonal dialogs draw above their sliders: what a level goes in
-    as against what it comes out as, over [0,1]. Keeps state between frames, so it is a member of the
-    command. Used between begin() and end(), like ImPlot itself:
+    as against what it comes out as, over [0,1]. Used like ImPlot itself:
 
-        if (m_plot.begin("##Curve"))
+        if (ImGui::BeginToneCurvePlot("##Curve"))
         {
-            m_plot.curve("gamma", ys, ImVec4(1, 1, 1, 0.85f));
-            m_plot.end();
+            ImGui::ToneCurve("gamma", ys, ImVec4(1, 1, 1, 0.85f));
+            ImGui::EndToneCurvePlot();
         }
 */
-class ToneCurvePlot
-{
-public:
-    /// Samples along the horizontal axis.
-    static constexpr int N = 129;
 
-    /// The input level at sample \p i, where every curve drawn here is evaluated.
-    static float x(int i) { return float(i) / float(N - 1); }
+/// Samples along the horizontal axis.
+constexpr int ToneCurveSamples = 129;
+/// The input level at sample \p i, where every curve drawn here is evaluated.
+inline float ToneCurveX(int i) { return float(i) / float(ToneCurveSamples - 1); }
 
-    /// Open the plot. False when ImPlot declined it, in which case nothing else may be called.
-    bool begin(const char *id);
-    /// One curve, \p ys being N outputs for the inputs x(0)..x(N-1).
-    void curve(const char *name, const float *ys, ImVec4 color, float weight = 2.f);
-    /// A vertical line, for marking the input level a curve pivots about.
-    void marker_x(const char *name, float value, ImVec4 color);
-    /// A small marker at \p at, for a point of the curve that can be taken hold of.
-    void handle(float2 at, ImVec4 color);
-    /// While the left button is dragging inside the plot, where it is, in plot coordinates.
-    /**
-        Not the widget's coordinates, which include the frame and tick labels. A drag that began inside is
-        followed after it leaves, and \p pressed_at receives where it began, which says what is being
-        dragged.
-    */
-    bool drag(float2 &position, float2 *pressed_at = nullptr);
-    void end();
-
-private:
-    float  m_width        = 0.f;
-    float  m_extra_height = 0.f; ///< Added to the widget's height to square the plot area; usually negative
-    bool   m_dragging     = false;
-    float2 m_press{0.f, 0.f}; ///< Where the drag began
-};
+/// Open the plot. False when ImPlot declined it, in which case nothing else may be called.
+bool BeginToneCurvePlot(const char *id);
+/// One curve, \p ys being ToneCurveSamples outputs for the inputs ToneCurveX(0)...
+void ToneCurve(const char *name, const float *ys, ImVec4 color, float weight = 2.f);
+/// A vertical line, for marking the input level a curve pivots about.
+void ToneCurveMarkerX(const char *name, float value, ImVec4 color);
+/// A small marker at \p at, for a point of the curve that can be taken hold of.
+void ToneCurveHandle(float2 at, ImVec4 color);
+/// While the left button is dragging inside the plot, where it is, in plot coordinates.
+/**
+    Not the widget's coordinates, which include the frame and tick labels. A drag that began inside is
+    followed after it leaves, and \p pressed_at receives where it began, which says what is being dragged.
+*/
+bool ToneCurveDrag(float2 &position, float2 *pressed_at = nullptr);
+void EndToneCurvePlot();
 
 struct RowSpan
 {

--- a/src/imgui_ext.h
+++ b/src/imgui_ext.h
@@ -330,7 +330,11 @@ constexpr int ToneCurveSamples = 129;
 inline float ToneCurveX(int i) { return float(i) / float(ToneCurveSamples - 1); }
 
 /// Open the plot. False when ImPlot declined it, in which case nothing else may be called.
-bool BeginToneCurvePlot(const char *id);
+/**
+    \p draggable says the curve answers ToneCurveDrag(), which is what the cursor over the plot then
+    advertises. A plot that only draws leaves the cursor alone.
+*/
+bool BeginToneCurvePlot(const char *id, bool draggable = false);
 /// One curve, \p ys being ToneCurveSamples outputs for the inputs ToneCurveX(0)...
 void ToneCurve(const char *name, const float *ys, ImVec4 color, float weight = 2.f);
 /// A vertical line, for marking the input level a curve pivots about.


### PR DESCRIPTION
**This one is not covered by a test. Please drive the curve by hand before merging.** What to try, in Edit > Brightness/contrast on any image:

- Drag the curve **away from the midpoint** — contrast should follow, and the S-curve should bend under the cursor.
- Drag **at the midpoint handle** — brightness should follow instead, sliding the pivot horizontally.
- Drag from inside the plot and keep going **outside** it — the curve should keep following until you release.
- Press **inside the sliders below** and drag up into the plot — the curve must *not* grab.
- Exposure/gamma's plot should look and behave as before; it draws a curve and a marker but has no drag.

## What changed

`ToneCurvePlot` was a class because it had four members. Three of them were not really its own:

| member | what it was | now |
|---|---|---|
| `m_dragging` | is a drag in progress | `ImGui::IsMouseDown` |
| `m_press` | where the drag began | `ImGui::GetIO().MouseClickedPos`, which ImGui already records |
| `m_extra_height` | the squaring correction | a property of the **style**, not of a plot, so both dialogs share one |
| `m_width` | width between begin and end | only meaningful while one plot is open, as in ImPlot |

So it is `BeginToneCurvePlot` / `EndToneCurvePlot` now, matching `ImPlot::BeginPlot` / `EndPlot` and `imgui_ext`'s own `BeginModalDialog` and `PE::Begin`/`End`. Neither dialog holds a member for it any more.

**The drag also stopped depending on hover.** It used to require `ImPlot::IsPlotHovered()` at the moment the button went down, then remember that it was dragging. It now asks whether the recorded click position falls inside the plot rect. Same behaviour, one less piece of state, and it does not depend on the flakier of the two signals — which matters, because hover is exactly what defeated my attempt to test this.

## Why there is no test

Nothing in the suite drives an ImPlot drag. I wrote one, and **it passed with dragging disabled entirely** — `EditCommand` instances outlive their dialogs, so the sliders held values an earlier test had set, and my assertion was reading those. I mutation-checked it, found the tautology, and discarded it rather than let it stand as the safety net for this change.

I got as far as proving each step individually: the drag starts, reports sensible plot coordinates, computes a contrast value, and Apply creates the right undo entry — yet the pixel never moved, and I could not close that last gap at reasonable cost. The slider path changes the same pixel fine, so the observation method was sound.

| | |
|---|---|
| doctest | 300 cases, 361,742 assertions |
| GUI tests | 89 / 89 |

Neither suite touches the drag, so those numbers say the conversion compiles and breaks nothing else. They say nothing about whether dragging still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
