### PR TITLE
Add JPEG 2000 support, and fix the CMYK and ICC handling it uncovered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,9 +262,10 @@ stats), separate from `image.cpp`'s data-model logic.
 `src/imageio/image_loader.h` declares `BackgroundImageLoader`, which loads images asynchronously (off the
 main thread, tile-uploaded to the GPU across frames to avoid stalling), watches directories for changed
 files, and manages recent files. Format decoding lives in `src/imageio/<format>.cpp`, one file per codec
-(`exr.cpp`, `png.cpp`, `jpg.cpp`, `jxl.cpp`, `heif.cpp` — also handles AVIF/HEIC/AVCI/J2K/HTJ2K, all
-libheif plugin codecs gated by their own `HDRVIEW_ENABLE_*` options — `uhdr.cpp` (Ultra HDR), `webp.cpp`,
-`tiff.cpp`, `raw.cpp`, `dds.cpp`, `qoi.cpp`, `pfm.cpp`, `stb.cpp` for the stb_image-covered formats, plus
+(`exr.cpp`, `png.cpp`, `jpg.cpp`, `jxl.cpp`, `j2k.cpp` for JPEG 2000 and HTJ2K, `heif.cpp` — also handles
+AVIF/HEIC/AVCI/J2K/HTJ2K, all libheif plugin codecs gated by their own `HDRVIEW_ENABLE_*` options —
+`uhdr.cpp` (Ultra HDR), `webp.cpp`, `tiff.cpp`, `raw.cpp`, `dds.cpp`, `qoi.cpp`, `pfm.cpp`, `stb.cpp` for
+the stb_image-covered formats, plus
 `exif.cpp`/`icc.cpp`/`xmp.cpp` for metadata (`psd.cpp` similarly only parses PSD metadata — color mode, ICC
 profile, etc. — consumed by `stb.cpp`, since stb_image itself decodes PSD pixel data). `image_loader.cpp`
 holds a `default_loaders()` table of `{name, try_load}` entries, each guarded by an `is_<format>_image()`
@@ -273,8 +274,9 @@ CMake options above. To add a new format: implement `is_X_image()` + `load_X_ima
 `imageio/x.{h,cpp}`, add a CMake option/target wiring, and register it in `default_loaders()`.
 
 libheif is the one dependency that finds its own codecs, with `find_package()` calls that only ever turn up
-an installed library, of which Emscripten has none. So the web build builds libaom (AVIF) and OpenJPEG (J2K)
-itself, in `CMakeLists.txt` just above the libheif block, and reaches libheif through the `<pkg>-extra.cmake`
+an installed library, of which Emscripten and a bare Windows runner have none. So the build fetches libaom
+(AVIF) itself under Emscripten, and OpenJPEG whenever no installed copy answers — `imageio/j2k.cpp` needs it
+too — in `CMakeLists.txt` just above the libheif block, reaching libheif through the `<pkg>-extra.cmake`
 files it writes into `CMAKE_FIND_PACKAGE_REDIRECTS_DIR`: CPM already leaves a redirect config there for every
 package it adds, and the `-extra.cmake` fills in the `AOM_*`/`OPENJPEG_*` variables libheif's own find
 modules would otherwise have set. Both packages also write their own preferences into the CMake cache, which

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1924,6 +1924,34 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
     )
   endif()
 
+  # The CMYK conversions cannot be exercised without a CMYK ICC profile, and the smallest real one is half a
+  # megabyte, too large to vendor. libjxl carries lcms in-tree and lcms's testbed carries two, so a build
+  # that fetched libjxl already has one on disk and the cases can run in CI like the OpenEXR ones.
+  set(HDRVIEW_TEST_LCMS_TESTBED_DIR
+      ""
+      CACHE PATH "lcms2's testbed directory, whose test1.icc is a CMYK printer profile"
+  )
+  if(HDRVIEW_TEST_LCMS_TESTBED_DIR)
+    set(_hdrview_lcms_testbed "${HDRVIEW_TEST_LCMS_TESTBED_DIR}")
+    set(_hdrview_lcms_explicit TRUE)
+  elseif(DEFINED JXL_SOURCE_DIR)
+    set(_hdrview_lcms_testbed "${JXL_SOURCE_DIR}/third_party/lcms/testbed")
+    set(_hdrview_lcms_explicit FALSE)
+  endif()
+
+  if(DEFINED _hdrview_lcms_testbed AND EXISTS "${_hdrview_lcms_testbed}/test1.icc")
+    target_compile_definitions(hdrview_tests PRIVATE HDRVIEW_TEST_LCMS_TESTBED_DIR="${_hdrview_lcms_testbed}")
+  elseif(_hdrview_lcms_explicit)
+    message(FATAL_ERROR "HDRVIEW_TEST_LCMS_TESTBED_DIR is set to '${_hdrview_lcms_testbed}', which holds no "
+                        "test1.icc"
+    )
+  else()
+    message(STATUS "lcms2's test profiles not available (no fetched libjxl source; set "
+                   "HDRVIEW_TEST_LCMS_TESTBED_DIR to use a checkout); skipping the CMYK cases in "
+                   "tests/test_j2k_io.cpp"
+    )
+  endif()
+
   # No JPEG 2000 corpus is vendored by anything the build fetches, so this one is opt-in: point it at a
   # directory of real .jp2/.j2k/.jph files and tests/test_j2k_io.cpp sweeps it.
   set(HDRVIEW_TEST_J2K_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1219,14 +1219,18 @@ if(EMSCRIPTEN AND HDRVIEW_ENABLE_AVIF)
   )
 endif()
 
-# OpenJPEG decodes the J2K- and HTJ2K-compressed HEIF images, and under Emscripten there is no installed
-# copy for libheif's find_package(OpenJPEG) to turn up, so build it here as with libaom above.
-if(EMSCRIPTEN AND HDRVIEW_ENABLE_J2K)
+# OpenJPEG serves two consumers: imageio/j2k.cpp, which reads and writes standalone JPEG 2000 files, and
+# libheif's J2K/HTJ2K plugins, which handle the same codestreams wrapped in a HEIF item. libheif finds it
+# only through find_package(OpenJPEG), which turns up nothing under Emscripten and nothing on a bare Windows
+# runner, so build it here when no installed copy answers and hand libheif the result via the redirect file.
+# Both paths leave the same `openjp2` target name.
+if(HDRVIEW_ENABLE_J2K)
   CPMAddPackage(
     NAME OpenJPEG
-    VERSION 2.5.4
+    VERSION 2.5.0 # 2.5.0 is the first release whose decoder handles HTJ2K codestreams
     GITHUB_REPOSITORY uclouvain/openjpeg
     GIT_TAG v2.5.4
+    FIND_PACKAGE_ARGUMENTS "QUIET"
     OPTIONS "BUILD_SHARED_LIBS OFF"
             "BUILD_CODEC OFF"
             "BUILD_TESTING OFF"
@@ -1234,23 +1238,33 @@ if(EMSCRIPTEN AND HDRVIEW_ENABLE_J2K)
     SYSTEM YES
     EXCLUDE_FROM_ALL YES
   )
-  if(NOT OpenJPEG_ADDED)
-    message(FATAL_ERROR "Failed to fetch OpenJPEG, which the Emscripten build needs for J2K support.")
-  endif()
-  # OpenJPEG puts the legacy EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH into the cache, which is global,
-  # so left there every target in the build lands in OpenJPEG's bin directory. Nothing else sets them.
-  unset(EXECUTABLE_OUTPUT_PATH CACHE)
-  unset(LIBRARY_OUTPUT_PATH CACHE)
+  if(OpenJPEG_ADDED)
+    # OpenJPEG puts the legacy EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH into the cache, which is
+    # global, so left there every target in the build lands in OpenJPEG's bin directory. Nothing else sets
+    # them.
+    unset(EXECUTABLE_OUTPUT_PATH CACHE)
+    unset(LIBRARY_OUTPUT_PATH CACHE)
 
-  message(STATUS "Will build OpenJPEG library")
-  mark_as_system_library(openjp2)
-  disable_target_warnings(openjp2)
-  # openjpeg.h lives beside the sources, and the opj_config.h it includes is generated into the build tree
-  file(
-    WRITE "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/openjpeg-extra.cmake"
-    "set(OPENJPEG_FOUND TRUE)\n" "set(OPENJPEG_LIBRARIES openjp2)\n"
-    "set(OPENJPEG_INCLUDE_DIRS \"${OpenJPEG_SOURCE_DIR}/src/lib/openjp2;${OpenJPEG_BINARY_DIR}/src/lib/openjp2\")\n"
-  )
+    message(STATUS "Will build OpenJPEG library")
+    mark_as_system_library(openjp2)
+    disable_target_warnings(openjp2)
+    # openjpeg.h lives beside the sources, and the opj_config.h it includes is generated into the build tree.
+    # OpenJPEG publishes both only to an install tree, so state them for the build tree: on the target for
+    # our own use, and in the redirect file for libheif's find module.
+    target_include_directories(openjp2 INTERFACE $<BUILD_INTERFACE:${OpenJPEG_SOURCE_DIR}/src/lib/openjp2>
+                                                 $<BUILD_INTERFACE:${OpenJPEG_BINARY_DIR}/src/lib/openjp2>
+    )
+    file(
+      WRITE "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/openjpeg-extra.cmake"
+      "set(OPENJPEG_FOUND TRUE)\n" "set(OPENJPEG_LIBRARIES openjp2)\n"
+      "set(OPENJPEG_INCLUDE_DIRS \"${OpenJPEG_SOURCE_DIR}/src/lib/openjp2;${OpenJPEG_BINARY_DIR}/src/lib/openjp2\")\n"
+    )
+  elseif(TARGET openjp2)
+    message(STATUS "Using system-installed OpenJPEG library")
+  else()
+    message(FATAL_ERROR "OpenJPEG not found. Please install it or turn off HDRVIEW_ENABLE_J2K.")
+  endif()
+  list(APPEND HDRVIEW_DEPENDENCIES "openjp2")
 endif()
 
 # dav1d decodes the AV1 in an AVIF about twice as fast as libaom's decoder, to the same pixels, so libheif
@@ -1694,6 +1708,7 @@ set(HDRVIEW_SOURCES
     src/imageio/gainmap.cpp
     src/imageio/heif.cpp
     src/imageio/icc.cpp
+    src/imageio/j2k.cpp
     src/imageio/jpg.cpp
     src/imageio/jxl.cpp
     src/imageio/pfm.cpp
@@ -1834,7 +1849,7 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
                                 tests/test_exr_io.cpp tests/test_png_io.cpp tests/test_tiff_io.cpp tests/test_gainmap.cpp
                                 tests/test_alpha.cpp tests/test_image_groups.cpp tests/test_assets.cpp tests/test_long_paths.cpp tests/test_loader_limits.cpp
                                 tests/test_short_names.cpp tests/test_path_helpers.cpp tests/test_index_helpers.cpp tests/test_psd_metadata.cpp tests/test_endian_utils.cpp
-                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_orientation_windows.cpp tests/test_undo.cpp tests/test_edit_commands.cpp tests/test_filters.cpp tests/test_envmap.cpp tests/test_poisson.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_xmp.cpp tests/test_exif.cpp
+                                tests/test_icc_gray_alpha.cpp tests/test_qoi_io.cpp tests/test_icc_cicp.cpp tests/test_dds_io.cpp tests/test_line_helpers.cpp tests/test_orientation_windows.cpp tests/test_undo.cpp tests/test_edit_commands.cpp tests/test_filters.cpp tests/test_envmap.cpp tests/test_poisson.cpp tests/test_export_roundtrip.cpp tests/test_heif_io.cpp tests/test_j2k_io.cpp tests/test_xmp.cpp tests/test_exif.cpp
                                 ${HDRVIEW_IPC_TESTS}
   )
   hdrview_setup_target(hdrview_tests)
@@ -1907,6 +1922,19 @@ if(HDRVIEW_BUILD_TESTS AND NOT EMSCRIPTEN)
     message(STATUS "libpng test images not available (no fetched source; set HDRVIEW_TEST_PNG_CONTRIB_DIR to "
                     "use a checkout); skipping tests/test_png_io.cpp's vendored-data tests"
     )
+  endif()
+
+  # No JPEG 2000 corpus is vendored by anything the build fetches, so this one is opt-in: point it at a
+  # directory of real .jp2/.j2k/.jph files and tests/test_j2k_io.cpp sweeps it.
+  set(HDRVIEW_TEST_J2K_DIR
+      ""
+      CACHE PATH "A directory of real JPEG 2000 files for tests/test_j2k_io.cpp to sweep"
+  )
+  if(HDRVIEW_TEST_J2K_DIR)
+    if(NOT EXISTS "${HDRVIEW_TEST_J2K_DIR}")
+      message(FATAL_ERROR "HDRVIEW_TEST_J2K_DIR is set to '${HDRVIEW_TEST_J2K_DIR}', which does not exist")
+    endif()
+    target_compile_definitions(hdrview_tests PRIVATE HDRVIEW_TEST_J2K_DIR="${HDRVIEW_TEST_J2K_DIR}")
   endif()
 
   include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2217,6 +2217,11 @@ elseif(UNIX AND NOT EMSCRIPTEN)
   list(APPEND CPACK_GENERATOR External)
   set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/cmake/create-appimage.cmake")
   set(CPACK_EXTERNAL_ENABLE_STAGING YES)
+  # CPack reads the global COMPONENTS property, so one dependency's install(... COMPONENT ...) is enough to
+  # put it in component mode, and staging then lands each component in a subdirectory of its own:
+  # `Unspecified/usr/bin/HDRView` rather than `usr/bin/HDRView`, which linuxdeploy cannot find. Nothing here
+  # names a component, so ask for the single-pass install the AppDir layout needs.
+  set(CPACK_MONOLITHIC_INSTALL ON)
   # When packaging, instruct CPack to set DESTDIR so install uses a staging dir
   set(CPACK_SET_DESTDIR ON)
   # Place generated packages in the build directory instead of the source root

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ HDRView picks a decoder by inspecting a file's contents rather than by trusting 
 | PNG (.png) | Including animated PNGs and HDR PNGs with CICP (via [libpng](https://github.com/pnggroup/libpng)) | ✓ | ✓ |
 | TIFF (.tif, .tiff) | Including SGI LogLuv and Pixar Log HDR formats (via [libtiff](https://gitlab.com/libtiff/libtiff)) | ✓ | ✓ |
 | JPEG-XL (.jxl) | Including lossless, lossy, animation/burst, HDR, and gain maps (via [libjxl](https://github.com/libjxl/libjxl)) | ✓ | ✓ |
+| JPEG 2000 (.jp2, .j2k, .jph, .jhc) | Both the boxed JP2 file format and bare codestreams, at any precision up to 31 bits, including high-throughput HTJ2K (via [OpenJPEG](https://github.com/uclouvain/openjpeg)) | ✓ | ✓ |
 | HEIF, AVIF (.heif, .heic, .avif, .avci) | Including lossless, lossy, animation/burst, HDR, and the gain maps in HDR photos from iPhones (via [libheif](https://github.com/strukturag/libheif) and various codec libraries). Output is HEIF or AVIF | ✓ | ✓ |
 | WebP (.webp) | Google's format supporting lossy/lossless and animation (via [libwebp](https://chromium.googlesource.com/webm/libwebp)) | ✓ | ✓ |
 | QOI (.qoi) | Quite OK Image — simple, fast, lossless (via [qoi](https://github.com/phoboslab/qoi)) | ✓ | ✓ |
@@ -96,7 +97,7 @@ HDRView picks a decoder by inspecting a file's contents rather than by trusting 
 | PNM (.pnm, .pgm, .ppm) | Netpbm portable bitmaps (via [stb_image](https://github.com/nothings/stb)) | ✓ | |
 | PIC (.pic) | Softimage PIC (via [stb_image](https://github.com/nothings/stb)) | ✓ | |
 
-JPEG 2000 and HTJ2K are supported as codecs *inside* HEIF containers, not as standalone `.jp2` files.
+JPEG 2000 and HTJ2K are also readable as codecs *inside* a HEIF container (`.hej2`).
 
 Which formats a particular build actually has depends on its `HDRVIEW_ENABLE_*` options; the About dialog's Build info tab lists what was compiled in.
 

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -122,8 +122,7 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             Format_JPEG_STB,
             Format_JPEG_UHDR,
             Format_JPEG_XL,
-            Format_JPEG2000_JP2,
-            Format_JPEG2000_J2K,
+            Format_JPEG2000,
             Format_WEBP,
             Format_EXR,
             Format_PFM,
@@ -159,9 +158,9 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
                                                        false,
 #endif
 #if HDRVIEW_ENABLE_J2K
-                                                       true, true,
+                                                       true,
 #else
-                                                       false, false,
+                                                       false,
 #endif
 #if HDRVIEW_ENABLE_LIBWEBP
                                                        true,
@@ -193,8 +192,7 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             "JPEG (stb)",
             "JPEG (UltraHDR)",
             "JPEG-XL",
-            "JPEG 2000 (JP2)",
-            "JPEG 2000 (codestream)",
+            "JPEG 2000",
             "WebP",
             "OpenEXR",
             "PFM",
@@ -218,7 +216,6 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             ".jpg",
             ".jxl",
             ".jp2",
-            ".j2k",
             ".webp",
             ".exr",
             ".pfm",
@@ -271,6 +268,8 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
         ImGui::PopFont();
 
         std::function<void(const Image &, std::ostream &, const std::string_view)> save_func;
+        // what the format writes unless one of its options says otherwise
+        std::string save_extension = save_format_extensions[save_format];
 
         switch (save_format)
         {
@@ -309,13 +308,12 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
         }
         break;
 
-        // Two entries, since the file's extension fixes which of the two syntaxes goes in it: a .jp2 carries
-        // the boxes that record the color space, a .j2k is the bare codestream.
-        case Format_JPEG2000_JP2:
-        case Format_JPEG2000_J2K:
+        case Format_JPEG2000:
         {
-            auto opts = j2k_parameters_gui(save_format == Format_JPEG2000_J2K ? J2KContainer::J2K : J2KContainer::JP2);
-            save_func = [opts](const Image &img, std::ostream &os, const std::string_view filename)
+            auto opts = j2k_parameters_gui();
+            // the container is one of its options, so the extension follows what was chosen there
+            save_extension = j2k_extension(opts);
+            save_func      = [opts](const Image &img, std::ostream &os, const std::string_view filename)
             { save_j2k_image(img, os, filename, opts); };
         }
         break;
@@ -426,11 +424,10 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
         save_as_name = fmt::format("Save as {}...", save_format_names[save_format]).c_str();
         if (ImGui::Button(save_as_name.c_str()))
         {
-            filename = current_image()->path.stem().u8string() + string(save_format_extensions[save_format]);
+            filename = current_image()->path.stem().u8string() + save_extension;
 #if !defined(__EMSCRIPTEN__)
-            filename = pfd::save_file(
-                           save_as_name.c_str(), filename,
-                           {string(save_format_names[save_format]) + " images", save_format_extensions[save_format]})
+            filename = pfd::save_file(save_as_name.c_str(), filename,
+                                      {string(save_format_names[save_format]) + " images", save_extension})
                            .result();
 #endif
         }

--- a/src/app-file-io.cpp
+++ b/src/app-file-io.cpp
@@ -12,6 +12,7 @@
 
 #include "imageio/exr.h"
 #include "imageio/heif.h"
+#include "imageio/j2k.h"
 #include "imageio/jpg.h"
 #include "imageio/jxl.h"
 #include "imageio/pfm.h"
@@ -121,6 +122,8 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             Format_JPEG_STB,
             Format_JPEG_UHDR,
             Format_JPEG_XL,
+            Format_JPEG2000_JP2,
+            Format_JPEG2000_J2K,
             Format_WEBP,
             Format_EXR,
             Format_PFM,
@@ -155,6 +158,11 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
 #else
                                                        false,
 #endif
+#if HDRVIEW_ENABLE_J2K
+                                                       true, true,
+#else
+                                                       false, false,
+#endif
 #if HDRVIEW_ENABLE_LIBWEBP
                                                        true,
 #else
@@ -185,6 +193,8 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             "JPEG (stb)",
             "JPEG (UltraHDR)",
             "JPEG-XL",
+            "JPEG 2000 (JP2)",
+            "JPEG 2000 (codestream)",
             "WebP",
             "OpenEXR",
             "PFM",
@@ -207,6 +217,8 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             ".jpg",
             ".jpg",
             ".jxl",
+            ".jp2",
+            ".j2k",
             ".webp",
             ".exr",
             ".pfm",
@@ -294,6 +306,17 @@ void HDRViewApp::draw_save_as_dialog(bool &open)
             auto opts = jxl_parameters_gui();
             save_func = [opts](const Image &img, std::ostream &os, const std::string_view filename)
             { save_jxl_image(img, os, filename, opts); };
+        }
+        break;
+
+        // Two entries, since the file's extension fixes which of the two syntaxes goes in it: a .jp2 carries
+        // the boxes that record the color space, a .j2k is the bare codestream.
+        case Format_JPEG2000_JP2:
+        case Format_JPEG2000_J2K:
+        {
+            auto opts = j2k_parameters_gui(save_format == Format_JPEG2000_J2K ? J2KContainer::J2K : J2KContainer::JP2);
+            save_func = [opts](const Image &img, std::ostream &os, const std::string_view filename)
+            { save_j2k_image(img, os, filename, opts); };
         }
         break;
 

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -18,6 +18,7 @@
 #include <OpenEXRConfig.h>
 
 #include "imageio/heif.h"
+#include "imageio/j2k.h"
 #include "imageio/jpg.h"
 #include "imageio/jxl.h"
 #include "imageio/png.h"
@@ -1471,7 +1472,9 @@ void HDRViewApp::draw_about_dialog(bool &open)
                         ImGui::PE::Hyperlink("OpenH264", "For decoding AVC/AVCI/AVCS/H264 files.",
                                              "https://github.com/cisco/openh264");
                     if (HDRVIEW_ENABLE_J2K)
-                        ImGui::PE::Hyperlink("OpenJPEG", "For encoding/decoding J2K- and HTJ2K-compressed HEIF images.",
+                        ImGui::PE::Hyperlink("OpenJPEG",
+                                             "For loading & saving JPEG 2000 images, in their own file formats and "
+                                             "as J2K- and HTJ2K-compressed HEIF items.",
                                              "https://github.com/uclouvain/openjpeg");
                     if (HDRVIEW_ENABLE_HTJ2K)
                         ImGui::PE::Hyperlink("OpenJPH", "For encoding HTJ2K-compressed HEIF images.",
@@ -1512,6 +1515,7 @@ void HDRViewApp::draw_about_dialog(bool &open)
                 auto build_info_text = [&]()
                 {
                     auto heif_info = get_heif_info();
+                    auto j2k_info  = get_j2k_info();
                     auto jpg_info  = get_jpg_info();
                     auto png_info  = get_png_info();
                     auto jxl_info  = get_jxl_info();
@@ -1603,6 +1607,7 @@ void HDRViewApp::draw_about_dialog(bool &open)
                     info += fmt::format("{:<8} {:<15}\n", "libtiff", tiff_info.value("version", "not enabled"));
                     info += fmt::format("{:<8} {:<15}\n", "libuhdr", uhdr_info.value("version", "not enabled"));
                     info += fmt::format("{:<8} {:<15}\n", "libwebp", webp_info.value("version", "not enabled"));
+                    info += fmt::format("{:<8} {:<15}\n", "openjpeg", j2k_info.value("version", "not enabled"));
 
                     if (png_info.value("enabled", false))
                     {

--- a/src/app-gui.cpp
+++ b/src/app-gui.cpp
@@ -1473,8 +1473,8 @@ void HDRViewApp::draw_about_dialog(bool &open)
                                              "https://github.com/cisco/openh264");
                     if (HDRVIEW_ENABLE_J2K)
                         ImGui::PE::Hyperlink("OpenJPEG",
-                                             "For loading & saving JPEG 2000 images, in their own file formats and "
-                                             "as J2K- and HTJ2K-compressed HEIF items.",
+                                             "For encoding/decoding J2K and HTJ2K codestreams, in native JPEG 2000 "
+                                             "files and HEIF containers.",
                                              "https://github.com/uclouvain/openjpeg");
                     if (HDRVIEW_ENABLE_HTJ2K)
                         ImGui::PE::Hyperlink("OpenJPH", "For encoding HTJ2K-compressed HEIF images.",

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -174,9 +174,21 @@ const std::set<std::string> &Image::loadable_formats()
 #if HDRVIEW_ENABLE_LIBJXL
         "jxl",
 #endif
+#if HDRVIEW_ENABLE_J2K
+        "jp2",
+        "j2k",
+        "j2c",
+        "jpc",
+        "jpf",
+        "jpx",
+        "jpm",
+        "jph",
+        "jhc",
+#endif
 #if HDRVIEW_ENABLE_LIBHEIF
         "heif",
         "heifs",
+        "hej2",
 #endif
 #if HDRVIEW_ENABLE_HEIC
         "heic",

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -140,7 +140,6 @@ struct Exif::Impl
     std::unique_ptr<ExifLog, decltype(&exif_log_unref)>   exif_log{nullptr, &exif_log_unref};
 
     /// libexif's log callback keeps firing after the constructor (e.g. from to_json()), so this can't be local.
-    bool load_error = false;
 };
 
 Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<Impl>())
@@ -177,8 +176,7 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
             [](ExifLog * /*log*/, ExifLogCode kind, const char *domain, const char *format, va_list args,
                void *user_data)
             {
-                bool *error = static_cast<bool *>(user_data);
-                char  msg[1024];
+                char msg[1024];
                 vsnprintf(msg, sizeof(msg), format, args);
 
                 switch (kind)
@@ -188,21 +186,15 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
                 // libexif carries on past a tag it cannot follow and the readable tags still arrive, so
                 // this says what was skipped rather than announcing a failure that did not happen
                 case EXIF_LOG_CODE_CORRUPT_DATA: spdlog::warn("{}: {}", domain, msg); break;
-                case EXIF_LOG_CODE_NO_MEMORY:
-                    *error = true;
-                    spdlog::error("{}: {}", domain, msg);
-                    break;
+                case EXIF_LOG_CODE_NO_MEMORY: spdlog::error("{}: {}", domain, msg); break;
                 }
             },
-            &m_impl->load_error);
+            nullptr);
 
         exif_data_log(m_impl->exif_data.get(), m_impl->exif_log.get());
 
         // 3) Load the EXIF data from memory buffer
         exif_data_load_data(m_impl->exif_data.get(), m_impl->data.data(), (unsigned)m_impl->data.size());
-
-        if (m_impl->load_error)
-            spdlog::error("Ran out of memory while loading EXIF data; keeping what was read.");
 
         if (!m_impl->exif_data)
             throw std::invalid_argument{"Failed to decode EXIF data."};

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -185,10 +185,13 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
                 {
                 case EXIF_LOG_CODE_NONE: spdlog::info("{}: {}", domain, msg); break;
                 case EXIF_LOG_CODE_DEBUG: spdlog::debug("{}: {}", domain, msg); break;
+                // libexif carries on past a tag it cannot follow, and the tags it can read still arrive, so
+                // this says what was skipped rather than announcing a failure that did not happen. A writer
+                // trimming an EXIF block without trimming the offsets into it is enough to reach here.
+                case EXIF_LOG_CODE_CORRUPT_DATA: spdlog::warn("{}: {}", domain, msg); break;
                 case EXIF_LOG_CODE_NO_MEMORY:
-                case EXIF_LOG_CODE_CORRUPT_DATA:
                     *error = true;
-                    spdlog::error("log: {}: {}", domain, msg);
+                    spdlog::error("{}: {}", domain, msg);
                     break;
                 }
             },
@@ -200,7 +203,7 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
         exif_data_load_data(m_impl->exif_data.get(), m_impl->data.data(), (unsigned)m_impl->data.size());
 
         if (m_impl->load_error)
-            spdlog::warn("There were errors while loading EXIF data, but trying to continue.");
+            spdlog::error("Ran out of memory while loading EXIF data; keeping what was read.");
 
         if (!m_impl->exif_data)
             throw std::invalid_argument{"Failed to decode EXIF data."};

--- a/src/imageio/exif.cpp
+++ b/src/imageio/exif.cpp
@@ -185,9 +185,8 @@ Exif::Exif(const uint8_t *data_ptr, size_t data_size) : m_impl(std::make_unique<
                 {
                 case EXIF_LOG_CODE_NONE: spdlog::info("{}: {}", domain, msg); break;
                 case EXIF_LOG_CODE_DEBUG: spdlog::debug("{}: {}", domain, msg); break;
-                // libexif carries on past a tag it cannot follow, and the tags it can read still arrive, so
-                // this says what was skipped rather than announcing a failure that did not happen. A writer
-                // trimming an EXIF block without trimming the offsets into it is enough to reach here.
+                // libexif carries on past a tag it cannot follow and the readable tags still arrive, so
+                // this says what was skipped rather than announcing a failure that did not happen
                 case EXIF_LOG_CODE_CORRUPT_DATA: spdlog::warn("{}: {}", domain, msg); break;
                 case EXIF_LOG_CODE_NO_MEMORY:
                     *error = true;

--- a/src/imageio/icc.cpp
+++ b/src/imageio/icc.cpp
@@ -338,7 +338,8 @@ ICCProfile ICCProfile::linearized_profile(Chromaticities *c) const
         return ICCProfile::linear_RGB(chr);
 }
 
-bool ICCProfile::transform_pixels(float *pixels, int3 size, const ICCProfile &profile_in, const ICCProfile &profile_out)
+bool ICCProfile::transform_pixels(float *pixels, int3 size, const ICCProfile &profile_in, const ICCProfile &profile_out,
+                                  bool cmyk_is_inverted)
 {
     if (!profile_in || !profile_out)
         return false;
@@ -388,9 +389,11 @@ bool ICCProfile::transform_pixels(float *pixels, int3 size, const ICCProfile &pr
         }
     }
 
-    // If CMYK, lcms expects floating-point values in the range [0, 100]
+    // lcms expects CMYK in [0, 100], where 100 is full ink. Adobe's JPEGs store the inverse of that and
+    // JPEG 2000 stores it directly, and nothing in the profile says which, so the caller has to.
     if (is_cmyk)
-        for (size_t i = 0, n = (size_t)size.x * size.y * size.z; i < n; ++i) pixels[i] = (1.0f - pixels[i]) * 100.0f;
+        for (size_t i = 0, n = (size_t)size.x * size.y * size.z; i < n; ++i)
+            pixels[i] = (cmyk_is_inverted ? 1.0f - pixels[i] : pixels[i]) * 100.0f;
 
     auto flags = (((size.z == 4 || size.z == 2) && !is_cmyk) ? cmsFLAGS_COPY_ALPHA : 0) | cmsFLAGS_HIGHRESPRECALC |
                  cmsFLAGS_NOCACHE;
@@ -416,7 +419,7 @@ bool ICCProfile::transform_pixels(float *pixels, int3 size, const ICCProfile &pr
 }
 
 bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries, string *tf_description,
-                                  Chromaticities *c) const
+                                  Chromaticities *c, bool cmyk_is_inverted) const
 {
     // a `cicp` tag states the profile's encoding in CICP's own terms (ICC.1:2022) and is authoritative. For
     // HDR it is also the only part of the profile that can describe the encoding: the ICC PCS is normalized
@@ -425,8 +428,10 @@ bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries,
         return codes.linearize_pixels(pixels, size, keep_primaries, tf_description, c);
 
     ICCProfile profile_out = nullptr;
-    // create the output profile and store either the input or output primaries in c
-    if (keep_primaries)
+    // create the output profile and store either the input or output primaries in c. CMYK is the exception:
+    // it has no primaries of its own to keep, so linearized_profile() would find no colorants to read and
+    // give up, and transform_pixels() needs an RGB output profile to recognize the conversion at all.
+    if (keep_primaries && !is_CMYK())
         profile_out = linearized_profile(c);
     else
     {
@@ -435,7 +440,7 @@ bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries,
             *c = Chromaticities();
     }
 
-    if (transform_pixels(pixels, size, *this, profile_out))
+    if (transform_pixels(pixels, size, *this, profile_out, cmyk_is_inverted))
     {
         if (tf_description)
             *tf_description = description();
@@ -481,12 +486,13 @@ bool                 ICCProfile::is_RGB() const { return false; }
 bool                 ICCProfile::is_Gray() const { return false; }
 
 bool ICCProfile::transform_pixels(float * /*pixels*/, int3 /*size*/, const ICCProfile & /*profile_in*/,
-                                  const ICCProfile & /*profile_out*/)
+                                  const ICCProfile & /*profile_out*/, bool /*cmyk_is_inverted*/)
 {
     return false;
 }
 bool ICCProfile::linearize_pixels(float * /*pixels*/, int3 /*size*/, bool /*keep_primaries*/,
-                                  std::string * /*tf_description*/, Chromaticities * /*c*/) const
+                                  std::string * /*tf_description*/, Chromaticities * /*c*/,
+                                  bool /*cmyk_is_inverted*/) const
 {
     return false;
 }

--- a/src/imageio/icc.cpp
+++ b/src/imageio/icc.cpp
@@ -428,9 +428,8 @@ bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries,
         return codes.linearize_pixels(pixels, size, keep_primaries, tf_description, c);
 
     ICCProfile profile_out = nullptr;
-    // create the output profile and store either the input or output primaries in c. CMYK is the exception:
-    // it has no primaries of its own to keep, so linearized_profile() would find no colorants to read and
-    // give up, and transform_pixels() needs an RGB output profile to recognize the conversion at all.
+    // create the output profile and store either the input or output primaries in c. CMYK has no primaries
+    // of its own to keep, and transform_pixels() needs an RGB output profile to recognize the conversion.
     if (keep_primaries && !is_CMYK())
         profile_out = linearized_profile(c);
     else

--- a/src/imageio/icc.h
+++ b/src/imageio/icc.h
@@ -124,7 +124,8 @@ public:
             True if the pixel values were successfully linearized.
     */
     bool linearize_pixels(float *pixels, int3 size, bool keep_primaries = true,
-                          std::string *profile_description = nullptr, Chromaticities *c = nullptr) const;
+                          std::string *profile_description = nullptr, Chromaticities *c = nullptr,
+                          bool cmyk_is_inverted = true) const;
 
     /**
        \brief Transform an array of floating-point pixels between two ICC profiles in-place.
@@ -134,8 +135,8 @@ public:
        interleaved row-major with `size.z` channels per pixel.
 
        Supported conversions (when built with LCMS2) include RGB↔RGB, CMYK→RGBA, and Gray↔Gray.
-       For CMYK inputs this function internally converts values to the range expected by LCMS
-       (LCMS commonly expects CMYK in [0,100] for float formats).
+       For CMYK inputs this function internally converts values to the [0,100] range LCMS expects of a float
+       format, inverting them on the way when `cmyk_is_inverted` says the file stores ink that way.
 
        \param[in,out] pixels  Pointer to the pixel buffer. On success the buffer contains transformed
                               pixel values. For RGB/Gray values are typically in [0,1]. For CMYK
@@ -144,12 +145,16 @@ public:
                               `size.z` = number of channels (e.g., 3 for RGB, 4 for RGBA/CMYK).
        \param[in] profile_in  Source ICC profile (must be valid).
        \param[in] profile_out Destination ICC profile (must be valid).
+       \param[in] cmyk_is_inverted
+                              Whether a CMYK input stores its samples inverted, 0 meaning full ink, as Adobe's
+                              JPEGs do. JPEG 2000 stores ink directly and passes false.
        \returns               True if the transform was created and applied successfully; false otherwise.
 
        \note The function uses LCMS2 when `HDRVIEW_ENABLE_LCMS2` is enabled; without LCMS2 it just returns false.
              The function sets alpha to 1.0 for outputs produced by CMYK→RGBA conversions.
      */
-    static bool transform_pixels(float *pixels, int3 size, const ICCProfile &profile_in, const ICCProfile &profile_out);
+    static bool transform_pixels(float *pixels, int3 size, const ICCProfile &profile_in, const ICCProfile &profile_out,
+                                 bool cmyk_is_inverted = true);
 
 private:
     /// Internal constructor from raw profile pointer.

--- a/src/imageio/image_loader.cpp
+++ b/src/imageio/image_loader.cpp
@@ -22,6 +22,7 @@
 #include "imageio/dds.h"
 #include "imageio/exr.h"
 #include "imageio/heif.h"
+#include "imageio/j2k.h"
 #include "imageio/jpg.h"
 #include "imageio/jxl.h"
 #include "imageio/pfm.h"
@@ -105,6 +106,19 @@ static std::vector<LoaderEntry> default_loaders()
              {
                  spdlog::info("Loading '{}' using libjxl loader...", filename);
                  out = load_jxl_image(is, filename, opts);
+                 return true;
+             }
+             return false;
+         }},
+#endif
+#if HDRVIEW_ENABLE_J2K
+        {"openjpeg",
+         [](std::istream &is, std::string_view filename, const ImageLoadOptions &opts, std::vector<ImagePtr> &out)
+         {
+             if (is_j2k_image(is))
+             {
+                 spdlog::info("Loading '{}' using OpenJPEG loader...", filename);
+                 out = load_j2k_image(is, filename, opts);
                  return true;
              }
              return false;

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -62,13 +62,18 @@ bool zip_entry_size_is_plausible(uint64_t uncompressed_size, uint64_t compressed
 const ImageLoadOptions &load_image_options();
 void                    draw_load_image_options_dialog(bool &open);
 
+/// Load an image from the input stream, reporting failure by returning nothing rather than by throwing.
 /**
-    Load the an image from the input stream.
+    Every `load_<format>_image()` throws on error; this one catches, logs, and returns an empty vector, so
+    the caller sees the same thing whether nothing recognized the file, a loader refused it, or the stream
+    was unreadable. It can also return fewer images than the file holds: a part that fails to finalize is
+    logged and dropped, and the channel selector discards the parts it does not name.
 
     \param [] is       The input stream to read from
     \param [] filename The corresponding filename if `is` was opened from a file
     \param [] opts     Options for loading the image
-    \return            A vector of possibly multiple images (e.g. from multi-part EXR files)
+    \return            The images loaded, possibly several (e.g. from multi-part EXR files), and empty on
+                       failure. Check before dereferencing.
 */
 vector<ImagePtr> load_image(std::istream &is, std::string_view filename, const ImageLoadOptions &opts = {});
 

--- a/src/imageio/image_loader.h
+++ b/src/imageio/image_loader.h
@@ -62,18 +62,13 @@ bool zip_entry_size_is_plausible(uint64_t uncompressed_size, uint64_t compressed
 const ImageLoadOptions &load_image_options();
 void                    draw_load_image_options_dialog(bool &open);
 
-/// Load an image from the input stream, reporting failure by returning nothing rather than by throwing.
+/// Load an image from the input stream, reporting failure by returning an empty vector.
 /**
-    Every `load_<format>_image()` throws on error; this one catches, logs, and returns an empty vector, so
-    the caller sees the same thing whether nothing recognized the file, a loader refused it, or the stream
-    was unreadable. It can also return fewer images than the file holds: a part that fails to finalize is
-    logged and dropped, and the channel selector discards the parts it does not name.
-
     \param [] is       The input stream to read from
     \param [] filename The corresponding filename if `is` was opened from a file
     \param [] opts     Options for loading the image
-    \return            The images loaded, possibly several (e.g. from multi-part EXR files), and empty on
-                       failure. Check before dereferencing.
+    \return            A vector of possibly multiple images (e.g. from multi-part EXR files), empty if
+                       nothing could be loaded
 */
 vector<ImagePtr> load_image(std::istream &is, std::string_view filename, const ImageLoadOptions &opts = {});
 

--- a/src/imageio/j2k.cpp
+++ b/src/imageio/j2k.cpp
@@ -410,12 +410,8 @@ namespace
 {
 
 /// Decodes one codestream into an Image, applying the color pipeline `opts` asks for.
-/**
-    `cs` is what the decoder reads, which for the JP2 syntax is the whole file rather than the codestream
-    alone, so `syntax` names the bytes the codestream markers actually start at.
-*/
-ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, const Jp2Boxes &boxes, string_view filename,
-                           const ImageLoadOptions &opts)
+ImagePtr decode_codestream(Bytes cs, bool high_throughput, OPJ_CODEC_FORMAT format, const Jp2Boxes &boxes,
+                           string_view filename, const ImageLoadOptions &opts)
 {
     CodecPtr codec{opj_create_decompress(format), opj_destroy_codec};
     if (!codec)
@@ -477,8 +473,8 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
 
     const bool cmyk = cs_enum == OPJ_CLRSPC_CMYK && img->numcomps >= 4;
     const bool gray = cs_enum == OPJ_CLRSPC_GRAY || img->numcomps < 3;
-    // ICCProfile turns four ink channels into RGB through the file's own profile, the way the JPEG XL loader
-    // does. Without one there is nothing to convert them with, so they keep their own names and their values.
+    // ICCProfile turns four ink channels into RGB through the file's own profile. Without one there is
+    // nothing to convert them with, so they keep their own names and their values.
     const bool cmyk_to_rgb = cmyk && img->numcomps == 4 && !icc.empty() && ICCProfile(icc).is_CMYK();
     if (cmyk && !cmyk_to_rgb)
         spdlog::warn("No CMYK ICC profile to convert this image's ink channels with; leaving them as they are.");
@@ -500,17 +496,13 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
 
     vector<string> names;
     if (cmyk && !cmyk_to_rgb)
-        names.insert(names.end(), {"C", "M", "Y", "K"});
+        names = {"C", "M", "Y", "K"};
     else if (num_color == 1)
-        names.push_back("Y");
+        names = {"Y"};
     else
-    {
-        names.insert(names.end(), {"R", "G", "B"});
-        // the conversion writes RGB over the four ink channels and a fourth that is opaque everywhere
-        if (cmyk_to_rgb)
-            names.push_back("A");
-    }
-    if (has_alpha)
+        names = {"R", "G", "B"};
+    // the ink conversion writes RGB over the four channels it reads, leaving the fourth opaque
+    if (has_alpha || cmyk_to_rgb)
         names.push_back("A");
     for (uint32_t c = 0; c < num_extra; ++c) names.push_back(fmt::format("extra.{}", c));
 
@@ -541,7 +533,6 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
     auto &header = image->metadata["header"];
     header["Color space"] =
         header_entry(color_space_name(cs_enum), color_space_name(cs_enum), "string", "Color space of the codestream");
-    const bool high_throughput = codestream_is_high_throughput(syntax);
     header["Block coder"] =
         header_entry(high_throughput ? "HTJ2K" : "JPEG 2000", high_throughput ? "high-throughput (Part 15)" : "Part 1",
                      "string", "Block coder the codestream needs");
@@ -696,8 +687,11 @@ vector<ImagePtr> load_j2k_image(istream &is, string_view filename, const ImageLo
         // extracted codestreams are the fallback for the family members it does not parse, such as JPM
         try
         {
+            // the JP2 codec reads the whole file, so the markers naming the block coder are in the first
+            // codestream box rather than at the front
             const Bytes first = boxes.codestreams.empty() ? all : boxes.codestreams.front();
-            images.push_back(decode_codestream(all, first, OPJ_CODEC_JP2, boxes, filename, opts));
+            images.push_back(
+                decode_codestream(all, codestream_is_high_throughput(first), OPJ_CODEC_JP2, boxes, filename, opts));
         }
         catch (const exception &e)
         {
@@ -717,7 +711,8 @@ vector<ImagePtr> load_j2k_image(istream &is, string_view filename, const ImageLo
             if (!partname.empty() && !filter.PassFilter(partname.c_str()))
                 continue;
 
-            auto image      = decode_codestream(streams[i], streams[i], OPJ_CODEC_J2K, boxes, filename, opts);
+            auto image = decode_codestream(streams[i], codestream_is_high_throughput(streams[i]), OPJ_CODEC_J2K, boxes,
+                                           filename, opts);
             image->partname = partname;
             images.push_back(image);
         }
@@ -848,8 +843,10 @@ void save_j2k_image(const Image &img, ostream &os, string_view filename, float g
     opts.dither     = dither;
     opts.reversible = lossless;
     opts.container  = container;
-    opts.bit_depth_index =
-        (int)(std::find(k_bit_depths, k_bit_depths + k_num_bit_depths, bit_depth) - k_bit_depths) % k_num_bit_depths;
+    const auto *at  = std::find(k_bit_depths, k_bit_depths + k_num_bit_depths, bit_depth);
+    if (at == k_bit_depths + k_num_bit_depths)
+        throw invalid_argument{fmt::format("JPEG 2000: cannot write {}-bit samples", bit_depth)};
+    opts.bit_depth_index = (int)(at - k_bit_depths);
     save_j2k_image(img, os, filename, &opts);
 }
 

--- a/src/imageio/j2k.cpp
+++ b/src/imageio/j2k.cpp
@@ -17,7 +17,7 @@ struct J2KSaveOptions
     float            gain            = 1.f;
     TransferFunction tf              = TransferFunction::sRGB;
     bool             dither          = true;
-    int              bit_depth_index = 2;
+    int              bit_depth_index = 3; ///< index into k_bit_depths, defaulting to 16-bit
     bool             reversible      = true;
     float            ratio           = 20.f; ///< target compression ratio, ignored when reversible
     int              num_resolutions = 6;
@@ -40,7 +40,12 @@ vector<ImagePtr> load_j2k_image(istream &, string_view, const ImageLoadOptions &
     throw runtime_error("JPEG 2000 support not enabled in this build.");
 }
 
-J2KSaveOptions *j2k_parameters_gui(J2KContainer) { return &s_opts; }
+J2KSaveOptions *j2k_parameters_gui() { return &s_opts; }
+
+const char *j2k_extension(const J2KSaveOptions *params)
+{
+    return params && params->container == J2KContainer::J2K ? ".j2k" : ".jp2";
+}
 
 void save_j2k_image(const Image &, ostream &, string_view, const J2KSaveOptions *)
 {
@@ -76,7 +81,7 @@ using namespace std;
 namespace
 {
 
-constexpr int k_bit_depths[]   = {8, 12, 16};
+constexpr int k_bit_depths[]   = {8, 10, 12, 16};
 constexpr int k_num_bit_depths = (int)(sizeof(k_bit_depths) / sizeof(k_bit_depths[0]));
 /// The most components a codestream may declare, per ISO/IEC 15444-1.
 constexpr uint32_t k_max_components = 16384;
@@ -850,10 +855,13 @@ void save_j2k_image(const Image &img, ostream &os, string_view filename, float g
     save_j2k_image(img, os, filename, &opts);
 }
 
-J2KSaveOptions *j2k_parameters_gui(J2KContainer container)
+const char *j2k_extension(const J2KSaveOptions *params)
 {
-    s_opts.container = container;
+    return params && params->container == J2KContainer::J2K ? ".j2k" : ".jp2";
+}
 
+J2KSaveOptions *j2k_parameters_gui()
+{
     if (ImGui::PE::Begin("JPEG 2000 Save Options",
                          ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize))
     {
@@ -904,8 +912,20 @@ J2KSaveOptions *j2k_parameters_gui(J2KContainer container)
             ImGui::PE::SliderFloat("Gamma", &s_opts.tf.gamma, 0.1f, 5.f, "%.3f", 0,
                                    "When using a gamma transfer function, this is the gamma value to use.");
 
+        {
+            int container = (int)s_opts.container;
+            ImGui::PE::Combo("Container", &container,
+                             "JP2 file (.jp2)\0"
+                             "Raw codestream (.j2k)\0",
+                             -1,
+                             "A JP2 wraps the codestream in boxes, which is where the color space, an ICC "
+                             "profile and any metadata go. A raw codestream carries none of that, and is what "
+                             "a container of its own holds, such as a HEIF item or an MJ2 track.");
+            s_opts.container = (J2KContainer)container;
+        }
         ImGui::PE::Combo("Bit depth", &s_opts.bit_depth_index,
                          "8-bit\0"
+                         "10-bit\0"
                          "12-bit\0"
                          "16-bit\0");
         ImGui::PE::Checkbox("Dither", &s_opts.dither);

--- a/src/imageio/j2k.cpp
+++ b/src/imageio/j2k.cpp
@@ -463,15 +463,28 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
 
     const int2 size{(int)(img->x1 - img->x0), (int)(img->y1 - img->y0)};
 
+    // OpenJPEG hands over the profile it read from the 'colr' box, but only for the syntaxes whose boxes it
+    // parses, and it also parks CIELab parameters in the same field under a length of zero
+    vector<uint8_t> icc;
+    if (img->icc_profile_buf && img->icc_profile_len > 0)
+        icc.assign(img->icc_profile_buf, img->icc_profile_buf + img->icc_profile_len);
+    else if (!boxes.icc.empty())
+        icc.assign(boxes.icc.data, boxes.icc.data + boxes.icc.size);
+
     OPJ_COLOR_SPACE cs_enum = img->color_space;
     if (cs_enum == OPJ_CLRSPC_UNSPECIFIED || cs_enum == OPJ_CLRSPC_UNKNOWN)
         cs_enum = img->numcomps <= 2 ? OPJ_CLRSPC_GRAY : OPJ_CLRSPC_SRGB;
 
     const bool cmyk = cs_enum == OPJ_CLRSPC_CMYK && img->numcomps >= 4;
     const bool gray = cs_enum == OPJ_CLRSPC_GRAY || img->numcomps < 3;
+    // ICCProfile turns four ink channels into RGB through the file's own profile, the way the JPEG XL loader
+    // does. Without one there is nothing to convert them with, so they keep their own names and their values.
+    const bool cmyk_to_rgb = cmyk && img->numcomps == 4 && !icc.empty() && ICCProfile(icc).is_CMYK();
+    if (cmyk && !cmyk_to_rgb)
+        spdlog::warn("No CMYK ICC profile to convert this image's ink channels with; leaving them as they are.");
 
     // the cdef box names the alpha component, which OpenJPEG reports per component and orders last; with no
-    // cdef, a second or fourth component is alpha by convention
+    // cdef, a second or fourth component is alpha by convention. CMYK's fourth is ink, not opacity.
     uint32_t num_color = cmyk ? 4u : (gray ? 1u : 3u);
     bool     has_alpha = false;
     for (uint32_t c = 0; c < img->numcomps; ++c)
@@ -483,14 +496,20 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
     if (num_color + (has_alpha ? 1u : 0u) > img->numcomps)
         has_alpha = false;
 
-    const uint32_t num_out_color = cmyk ? 3u : num_color;
-    const uint32_t num_extra     = img->numcomps - num_color - (has_alpha ? 1u : 0u);
+    const uint32_t num_extra = img->numcomps - num_color - (has_alpha ? 1u : 0u);
 
     vector<string> names;
-    if (num_out_color == 1)
+    if (cmyk && !cmyk_to_rgb)
+        names.insert(names.end(), {"C", "M", "Y", "K"});
+    else if (num_color == 1)
         names.push_back("Y");
     else
+    {
         names.insert(names.end(), {"R", "G", "B"});
+        // the conversion writes RGB over the four ink channels and a fourth that is opaque everywhere
+        if (cmyk_to_rgb)
+            names.push_back("A");
+    }
     if (has_alpha)
         names.push_back("A");
     for (uint32_t c = 0; c < num_extra; ++c) names.push_back(fmt::format("extra.{}", c));
@@ -578,10 +597,10 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
     // an 'xml ' box is where several encoders put XMP, there being no XMP box in Part 1
     image->xmp_data = !boxes.xmp.empty() ? boxes.xmp : boxes.xml;
 
-    Timer         timer;
-    const size_t  num_pixels = (size_t)size.x * size.y;
-    const int     n_src      = (int)img->numcomps;
-    vector<float> samples(num_pixels * n_src);
+    Timer        timer;
+    const size_t num_pixels = (size_t)size.x * size.y;
+    // every component is its own channel, so this gather is already the layout the image wants
+    vector<float> pixels(num_pixels * nc);
 
     const int block_size = std::max(1, 1024 * 1024 / std::max(1, size.x));
     parallel_for(blocked_range<int>(0, size.y, block_size),
@@ -590,41 +609,18 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
                      for (int y = begin_y; y < end_y; ++y)
                          for (int x = 0; x < size.x; ++x)
                          {
-                             float *p = samples.data() + ((size_t)y * size.x + x) * n_src;
-                             for (int c = 0; c < n_src; ++c) p[c] = component_value(img.get(), (uint32_t)c, x, y);
+                             float *p = pixels.data() + ((size_t)y * size.x + x) * nc;
+                             for (int c = 0; c < nc; ++c) p[c] = component_value(img.get(), (uint32_t)c, x, y);
                          }
                  });
 
-    if ((cs_enum == OPJ_CLRSPC_SYCC || cs_enum == OPJ_CLRSPC_EYCC) && num_out_color == 3)
-        sycc_to_rgb(samples.data(), num_pixels, n_src, img->comps[1].sgnd != 0);
-
-    vector<float> pixels;
-    if (!cmyk)
-        // every component is its own channel, so the gather already has the layout the image wants
-        pixels = std::move(samples);
-    else
-    {
-        // CMYK stores ink coverage, and its four components become three, shifting everything after them
-        pixels.resize(num_pixels * nc);
-        for (size_t i = 0; i < num_pixels; ++i)
-        {
-            const float *src = samples.data() + i * n_src;
-            float       *out = pixels.data() + i * nc;
-            const float  k   = 1.f - src[3];
-            for (int c = 0; c < 3; ++c) out[c] = (1.f - src[c]) * k;
-            for (int c = 3; c < nc; ++c) out[c] = src[c + 1];
-        }
-    }
+    if ((cs_enum == OPJ_CLRSPC_SYCC || cs_enum == OPJ_CLRSPC_EYCC) && !gray && !cmyk)
+        sycc_to_rgb(pixels.data(), num_pixels, nc, img->comps[1].sgnd != 0);
 
     const int3 buffer_size{size.x, size.y, nc};
     string     profile_desc;
     unpremultiply_before_transfer(pixels.data(), buffer_size, image->transparency);
-    // OpenJPEG hands over the profile it read from the 'colr' box, but only for the syntaxes whose boxes it
-    // parses, and it also parks CIELab parameters in the same field under a length of zero
-    if (img->icc_profile_buf && img->icc_profile_len > 0)
-        image->icc_data.assign(img->icc_profile_buf, img->icc_profile_buf + img->icc_profile_len);
-    else if (!boxes.icc.empty())
-        image->icc_data.assign(boxes.icc.data, boxes.icc.data + boxes.icc.size);
+    image->icc_data = icc;
 
     Chromaticities chr;
     if (opts.override_profile)

--- a/src/imageio/j2k.cpp
+++ b/src/imageio/j2k.cpp
@@ -634,11 +634,15 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
     }
     else if (!image->icc_data.empty() &&
              ICCProfile(image->icc_data)
-                 .linearize_pixels(pixels.data(), buffer_size, opts.keep_primaries, &profile_desc, &chr))
+                 .linearize_pixels(pixels.data(), buffer_size, opts.keep_primaries, &profile_desc, &chr,
+                                   /* cmyk_is_inverted */ false))
     {
         spdlog::info("Linearizing colors using ICC profile.");
         image->chromaticities = chr;
     }
+    else if (cmyk_to_rgb)
+        // the ink has no reading as color without its profile, and an sRGB curve over it is not one
+        throw runtime_error{"Failed to convert this image's ink channels through its CMYK profile."};
     else if (linearize_pixels(pixels.data(), buffer_size, Chromaticities(), TransferFunction::sRGB, opts.keep_primaries,
                               &profile_desc, &chr))
     {

--- a/src/imageio/j2k.cpp
+++ b/src/imageio/j2k.cpp
@@ -1,0 +1,935 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include "imageio/j2k.h"
+
+#include "app.h"
+#include "fonts.h"
+#include "imgui.h"
+#include "imgui_ext.h"
+
+/// Options for writing a JPEG 2000 file. \see j2k_parameters_gui()
+struct J2KSaveOptions
+{
+    float            gain            = 1.f;
+    TransferFunction tf              = TransferFunction::sRGB;
+    bool             dither          = true;
+    int              bit_depth_index = 2;
+    bool             reversible      = true;
+    float            ratio           = 20.f; ///< target compression ratio, ignored when reversible
+    int              num_resolutions = 6;
+    bool             mct             = true;
+    J2KContainer     container       = J2KContainer::JP2;
+};
+
+static J2KSaveOptions s_opts;
+
+#if !HDRVIEW_ENABLE_J2K
+
+using namespace std;
+
+json get_j2k_info() { return json{{"name", "OpenJPEG"}}; }
+
+bool is_j2k_image(istream &) noexcept { return false; }
+
+vector<ImagePtr> load_j2k_image(istream &, string_view, const ImageLoadOptions &)
+{
+    throw runtime_error("JPEG 2000 support not enabled in this build.");
+}
+
+J2KSaveOptions *j2k_parameters_gui(J2KContainer) { return &s_opts; }
+
+void save_j2k_image(const Image &, ostream &, string_view, const J2KSaveOptions *)
+{
+    throw runtime_error("JPEG 2000 support not enabled in this build.");
+}
+
+void save_j2k_image(const Image &, ostream &, string_view, float, bool, int, J2KContainer, TransferFunction, bool)
+{
+    throw runtime_error("JPEG 2000 support not enabled in this build.");
+}
+
+#else
+
+#include "colorspace.h"
+#include "common.h"
+#include "image.h"
+#include "imageio/alpha.h"
+#include "imageio/exif.h"
+#include "imageio/icc.h"
+#include "imageio/image_loader.h"
+#include "timer.h"
+
+#include <openjpeg.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <algorithm>
+#include <cstring>
+#include <optional>
+#include <set>
+#include <thread>
+
+using namespace std;
+
+namespace
+{
+
+constexpr int k_bit_depths[]   = {8, 12, 16};
+constexpr int k_num_bit_depths = (int)(sizeof(k_bit_depths) / sizeof(k_bit_depths[0]));
+/// The most components a codestream may declare, per ISO/IEC 15444-1.
+constexpr uint32_t k_max_components = 16384;
+
+/// The 12-byte JP2 signature box that opens every file in the JP2 family.
+constexpr uint8_t k_jp2_signature[12] = {0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50, 0x20, 0x20, 0x0D, 0x0A, 0x87, 0x0A};
+
+// UUIDs under which the JP2 family stores EXIF and XMP in a 'uuid' box
+constexpr uint8_t k_exif_uuid[16]       = {0x4A, 0x70, 0x67, 0x54, 0x69, 0x66, 0x66, 0x45,
+                                           0x78, 0x69, 0x66, 0x2D, 0x3E, 0x4A, 0x50, 0x32};
+constexpr uint8_t k_exif_uuid_adobe[16] = {0x05, 0x37, 0xCD, 0xAB, 0x9D, 0x0C, 0x44, 0x31,
+                                           0xA7, 0x2A, 0xFA, 0x56, 0x1F, 0x2A, 0x11, 0x3E};
+constexpr uint8_t k_xmp_uuid[16]        = {0xBE, 0x7A, 0xCF, 0xCB, 0x97, 0xA9, 0x42, 0xE8,
+                                           0x9C, 0x71, 0x99, 0x94, 0x91, 0xE3, 0xAF, 0xAC};
+
+uint16_t read_u16(const uint8_t *p) { return uint16_t((uint16_t(p[0]) << 8) | p[1]); }
+uint32_t read_u32(const uint8_t *p)
+{
+    return (uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) | (uint32_t(p[2]) << 8) | uint32_t(p[3]);
+}
+uint64_t read_u64(const uint8_t *p) { return (uint64_t(read_u32(p)) << 32) | read_u32(p + 4); }
+
+struct Bytes
+{
+    const uint8_t *data = nullptr;
+    size_t         size = 0;
+
+    bool  empty() const { return !data || size == 0; }
+    Bytes subspan(size_t offset, size_t count) const { return {data + offset, count}; }
+};
+
+struct Box
+{
+    string_view type;
+    Bytes       payload;
+};
+
+/// Reads the box starting at `in`, storing its full length (header included) in `total`.
+/**
+    Returns false at the end of a box sequence and on any malformed length, in which case `total` covers
+    what is left so a caller stepping by it terminates.
+*/
+bool read_box(Bytes in, Box &box, size_t &total)
+{
+    total = in.size;
+    if (in.size < 8)
+        return false;
+
+    size_t length = read_u32(in.data);
+    size_t header = 8;
+    if (length == 1)
+    {
+        if (in.size < 16)
+            return false;
+        length = (size_t)read_u64(in.data + 8);
+        header = 16;
+    }
+    else if (length == 0)
+        length = in.size;
+
+    if (length < header || length > in.size)
+        return false;
+
+    box.type    = string_view{reinterpret_cast<const char *>(in.data) + 4, 4};
+    box.payload = in.subspan(header, length - header);
+    total       = length;
+    return true;
+}
+
+/// What the JP2 boxes around a codestream say, for the parts OpenJPEG does not report itself.
+struct Jp2Boxes
+{
+    string             brand;
+    Bytes              icc;
+    vector<uint8_t>    exif;
+    vector<uint8_t>    xmp;
+    vector<uint8_t>    xml;
+    vector<Bytes>      codestreams;
+    optional<uint32_t> enum_cs;
+};
+
+/// Reads the 'colr' box body: an enumerated color space or a restricted ICC profile.
+void parse_colr(Bytes box, Jp2Boxes &out)
+{
+    if (box.size < 3)
+        return;
+
+    const uint8_t meth = box.data[0];
+    if (meth == 1 && box.size >= 7)
+    {
+        if (!out.enum_cs)
+            out.enum_cs = read_u32(box.data + 3);
+    }
+    else if ((meth == 2 || meth == 3) && box.size > 3 && out.icc.empty())
+        out.icc = box.subspan(3, box.size - 3);
+}
+
+/// Walks the top-level boxes, descending only into 'jp2h', where the color specification lives.
+void parse_jp2_boxes(Bytes in, Jp2Boxes &out, int depth = 0)
+{
+    Box    box;
+    size_t total = 0;
+    for (Bytes rest = in; !rest.empty(); rest = rest.subspan(total, rest.size - total))
+    {
+        if (!read_box(rest, box, total))
+            break;
+
+        if (box.type == "ftyp" && box.payload.size >= 4)
+            out.brand.assign(reinterpret_cast<const char *>(box.payload.data), 4);
+        else if (box.type == "jp2c")
+            out.codestreams.push_back(box.payload);
+        else if (box.type == "colr")
+            parse_colr(box.payload, out);
+        else if (box.type == "xml " && out.xml.empty())
+            out.xml.assign(box.payload.data, box.payload.data + box.payload.size);
+        else if (box.type == "uuid" && box.payload.size > 16)
+        {
+            const Bytes body = box.payload.subspan(16, box.payload.size - 16);
+            if (memcmp(box.payload.data, k_xmp_uuid, 16) == 0)
+                out.xmp.assign(body.data, body.data + body.size);
+            else if (memcmp(box.payload.data, k_exif_uuid, 16) == 0 ||
+                     memcmp(box.payload.data, k_exif_uuid_adobe, 16) == 0)
+                out.exif.assign(body.data, body.data + body.size);
+        }
+        else if (box.type == "jp2h" && depth < 4)
+            parse_jp2_boxes(box.payload, out, depth + 1);
+    }
+}
+
+/// Rsiz bit 14 marks a codestream that needs a Part-15 (high-throughput) decoder.
+bool codestream_is_high_throughput(Bytes cs)
+{
+    return cs.size >= 8 && cs.data[0] == 0xFF && cs.data[1] == 0x4F && cs.data[2] == 0xFF && cs.data[3] == 0x51 &&
+           (read_u16(cs.data + 6) & 0x4000) != 0;
+}
+
+struct MemStream
+{
+    Bytes  bytes;
+    size_t pos = 0;
+};
+
+OPJ_SIZE_T mem_read(void *buffer, OPJ_SIZE_T count, void *user_data)
+{
+    auto *m = static_cast<MemStream *>(user_data);
+    if (m->pos >= m->bytes.size)
+        return (OPJ_SIZE_T)-1;
+
+    OPJ_SIZE_T n = std::min(count, (OPJ_SIZE_T)(m->bytes.size - m->pos));
+    memcpy(buffer, m->bytes.data + m->pos, n);
+    m->pos += n;
+    return n;
+}
+
+OPJ_OFF_T mem_skip(OPJ_OFF_T count, void *user_data)
+{
+    auto *m = static_cast<MemStream *>(user_data);
+    if (count < 0)
+        return -1;
+
+    m->pos = std::min(m->pos + (size_t)count, m->bytes.size);
+    return (OPJ_OFF_T)m->pos;
+}
+
+OPJ_BOOL mem_seek(OPJ_OFF_T offset, void *user_data)
+{
+    auto *m = static_cast<MemStream *>(user_data);
+    if (offset < 0 || (size_t)offset > m->bytes.size)
+        return OPJ_FALSE;
+
+    m->pos = (size_t)offset;
+    return OPJ_TRUE;
+}
+
+struct OutStream
+{
+    vector<uint8_t> bytes;
+    size_t          pos = 0;
+};
+
+OPJ_SIZE_T out_write(void *buffer, OPJ_SIZE_T count, void *user_data)
+{
+    auto *o = static_cast<OutStream *>(user_data);
+    if (o->pos + count > o->bytes.size())
+        o->bytes.resize(o->pos + count);
+    memcpy(o->bytes.data() + o->pos, buffer, count);
+    o->pos += count;
+    return count;
+}
+
+OPJ_OFF_T out_skip(OPJ_OFF_T count, void *user_data)
+{
+    auto *o = static_cast<OutStream *>(user_data);
+    if (count < 0)
+        return -1;
+
+    o->pos += (size_t)count;
+    if (o->pos > o->bytes.size())
+        o->bytes.resize(o->pos);
+    return count;
+}
+
+OPJ_BOOL out_seek(OPJ_OFF_T offset, void *user_data)
+{
+    auto *o = static_cast<OutStream *>(user_data);
+    if (offset < 0)
+        return OPJ_FALSE;
+
+    o->pos = (size_t)offset;
+    if (o->pos > o->bytes.size())
+        o->bytes.resize(o->pos);
+    return OPJ_TRUE;
+}
+
+void log_opj_message(const char *msg, spdlog::level::level_enum level)
+{
+    if (!msg)
+        return;
+    string_view text{msg};
+    while (!text.empty() && (text.back() == '\n' || text.back() == '\r')) text.remove_suffix(1);
+    if (!text.empty())
+        spdlog::log(level, "OpenJPEG: {}", text);
+}
+
+void install_handlers(opj_codec_t *codec)
+{
+    opj_set_error_handler(codec, [](const char *msg, void *) { log_opj_message(msg, spdlog::level::debug); }, nullptr);
+    opj_set_warning_handler(codec, [](const char *msg, void *) { log_opj_message(msg, spdlog::level::warn); }, nullptr);
+    opj_set_info_handler(codec, [](const char *msg, void *) { log_opj_message(msg, spdlog::level::trace); }, nullptr);
+}
+
+using CodecPtr  = unique_ptr<opj_codec_t, void (*)(opj_codec_t *)>;
+using StreamPtr = unique_ptr<opj_stream_t, void (*)(opj_stream_t *)>;
+using OpjImgPtr = unique_ptr<opj_image_t, void (*)(opj_image_t *)>;
+
+const char *color_space_name(OPJ_COLOR_SPACE cs)
+{
+    switch (cs)
+    {
+    case OPJ_CLRSPC_SRGB: return "sRGB";
+    case OPJ_CLRSPC_GRAY: return "grayscale";
+    case OPJ_CLRSPC_SYCC: return "sYCC";
+    case OPJ_CLRSPC_EYCC: return "e-sYCC";
+    case OPJ_CLRSPC_CMYK: return "CMYK";
+    case OPJ_CLRSPC_UNSPECIFIED: return "unspecified";
+    default: return "unknown";
+    }
+}
+
+const char *progression_order_name(OPJ_PROG_ORDER order)
+{
+    switch (order)
+    {
+    case OPJ_LRCP: return "LRCP";
+    case OPJ_RLCP: return "RLCP";
+    case OPJ_RPCL: return "RPCL";
+    case OPJ_PCRL: return "PCRL";
+    case OPJ_CPRL: return "CPRL";
+    default: return "unknown";
+    }
+}
+
+json header_entry(const json &value, string_view str, string_view type, string_view description)
+{
+    return json{{"value", value}, {"string", str}, {"type", type}, {"description", description}};
+}
+
+/// Reads component `c` of `img` at reference-grid pixel (x, y), normalized to [0,1] or [-1,1] when signed.
+/**
+    A component may be subsampled, carrying its own origin and spacing on the reference grid and fewer
+    samples than the image has pixels.
+*/
+float component_value(const opj_image_t *img, uint32_t c, int x, int y)
+{
+    const opj_image_comp_t &comp = img->comps[c];
+
+    const int64_t sx = ((int64_t)img->x0 + x) / (int64_t)comp.dx - (int64_t)comp.x0;
+    const int64_t sy = ((int64_t)img->y0 + y) / (int64_t)comp.dy - (int64_t)comp.y0;
+    const int64_t cx = std::clamp<int64_t>(sx >> comp.factor, 0, (int64_t)comp.w - 1);
+    const int64_t cy = std::clamp<int64_t>(sy >> comp.factor, 0, (int64_t)comp.h - 1);
+
+    const uint32_t magnitude_bits = comp.prec - (comp.sgnd ? 1u : 0u);
+    const double   scale          = 1.0 / (double)(((uint64_t)1 << magnitude_bits) - 1ull);
+    return float(comp.data[cy * (int64_t)comp.w + cx] * scale);
+}
+
+/// Converts sYCC to RGB in place, over the first three of `n` interleaved channels.
+void sycc_to_rgb(float *pixels, size_t num_pixels, int n, bool chroma_is_signed)
+{
+    const float offset = chroma_is_signed ? 0.f : 0.5f;
+    for (size_t i = 0; i < num_pixels; ++i)
+    {
+        float      *p = pixels + i * n;
+        const float y = p[0], cb = p[1] - offset, cr = p[2] - offset;
+        p[0] = y + 1.402f * cr;
+        p[1] = y - 0.344136f * cb - 0.714136f * cr;
+        p[2] = y + 1.772f * cb;
+    }
+}
+
+} // namespace
+
+json get_j2k_info() { return json{{"enabled", true}, {"name", "OpenJPEG"}, {"version", opj_version()}}; }
+
+bool is_j2k_image(istream &is) noexcept
+{
+    auto start = is.tellg();
+    bool ret   = false;
+    try
+    {
+        uint8_t magic[12] = {0};
+        is.read(reinterpret_cast<char *>(magic), sizeof(magic));
+        const auto got = (size_t)is.gcount();
+
+        // a bare codestream opens with SOC immediately followed by SIZ; a JP2-family file with the
+        // signature box
+        if (got >= 4 && magic[0] == 0xFF && magic[1] == 0x4F && magic[2] == 0xFF && magic[3] == 0x51)
+            ret = true;
+        else if (got >= sizeof(k_jp2_signature) && memcmp(magic, k_jp2_signature, sizeof(k_jp2_signature)) == 0)
+            ret = true;
+    }
+    catch (...)
+    {
+    }
+
+    is.clear();
+    is.seekg(start);
+    return ret;
+}
+
+namespace
+{
+
+/// Decodes one codestream into an Image, applying the color pipeline `opts` asks for.
+/**
+    `cs` is what the decoder reads, which for the JP2 syntax is the whole file rather than the codestream
+    alone, so `syntax` names the bytes the codestream markers actually start at.
+*/
+ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, const Jp2Boxes &boxes, string_view filename,
+                           const ImageLoadOptions &opts)
+{
+    CodecPtr codec{opj_create_decompress(format), opj_destroy_codec};
+    if (!codec)
+        throw runtime_error{"Failed to create a JPEG 2000 decoder."};
+    install_handlers(codec.get());
+
+    opj_dparameters_t params;
+    opj_set_default_decoder_parameters(&params);
+    if (!opj_setup_decoder(codec.get(), &params))
+        throw runtime_error{"Failed to set up the JPEG 2000 decoder."};
+    opj_codec_set_threads(codec.get(), (int)std::max(1u, std::thread::hardware_concurrency()));
+    // a truncated codestream is worth as much of an image as it holds, which is what a viewer wants
+    opj_decoder_set_strict_mode(codec.get(), OPJ_FALSE);
+
+    MemStream ms{cs, 0};
+    StreamPtr stream{opj_stream_create(OPJ_J2K_STREAM_CHUNK_SIZE, OPJ_TRUE), opj_stream_destroy};
+    if (!stream)
+        throw runtime_error{"Failed to create a JPEG 2000 stream."};
+    opj_stream_set_user_data(stream.get(), &ms, nullptr);
+    opj_stream_set_user_data_length(stream.get(), cs.size);
+    opj_stream_set_read_function(stream.get(), mem_read);
+    opj_stream_set_skip_function(stream.get(), mem_skip);
+    opj_stream_set_seek_function(stream.get(), mem_seek);
+
+    OpjImgPtr img{nullptr, opj_image_destroy};
+    if (opj_image_t *raw = nullptr; opj_read_header(stream.get(), codec.get(), &raw) && raw)
+        img.reset(raw);
+    else
+        throw invalid_argument{"Failed to read the JPEG 2000 header."};
+
+    if (img->x1 <= img->x0 || img->y1 <= img->y0 || img->numcomps == 0)
+        throw invalid_argument{"JPEG 2000 image has an empty image region or no components."};
+    check_image_dimensions((int64_t)img->x1 - img->x0, (int64_t)img->y1 - img->y0, "JPEG 2000");
+    if (img->numcomps > k_max_components)
+        throw invalid_argument{fmt::format("JPEG 2000 image declares {} components.", img->numcomps)};
+
+    if (!opj_decode(codec.get(), stream.get(), img.get()))
+        throw runtime_error{"Failed to decode the JPEG 2000 image."};
+    opj_end_decompress(codec.get(), stream.get());
+
+    for (uint32_t c = 0; c < img->numcomps; ++c)
+        if (!img->comps[c].data || img->comps[c].w == 0 || img->comps[c].h == 0 || img->comps[c].prec == 0 ||
+            img->comps[c].prec > 31 || img->comps[c].dx == 0 || img->comps[c].dy == 0)
+            throw invalid_argument{fmt::format("JPEG 2000 component {} was not decoded.", c)};
+
+    const int2 size{(int)(img->x1 - img->x0), (int)(img->y1 - img->y0)};
+
+    OPJ_COLOR_SPACE cs_enum = img->color_space;
+    if (cs_enum == OPJ_CLRSPC_UNSPECIFIED || cs_enum == OPJ_CLRSPC_UNKNOWN)
+        cs_enum = img->numcomps <= 2 ? OPJ_CLRSPC_GRAY : OPJ_CLRSPC_SRGB;
+
+    const bool cmyk = cs_enum == OPJ_CLRSPC_CMYK && img->numcomps >= 4;
+    const bool gray = cs_enum == OPJ_CLRSPC_GRAY || img->numcomps < 3;
+
+    // the cdef box names the alpha component, which OpenJPEG reports per component and orders last; with no
+    // cdef, a second or fourth component is alpha by convention
+    uint32_t num_color = cmyk ? 4u : (gray ? 1u : 3u);
+    bool     has_alpha = false;
+    for (uint32_t c = 0; c < img->numcomps; ++c)
+        if (img->comps[c].alpha)
+            has_alpha = true;
+    if (!has_alpha && !cmyk)
+        has_alpha = img->numcomps == num_color + 1;
+    // a cdef box can name an alpha component without leaving a spare one, and the color components win
+    if (num_color + (has_alpha ? 1u : 0u) > img->numcomps)
+        has_alpha = false;
+
+    const uint32_t num_out_color = cmyk ? 3u : num_color;
+    const uint32_t num_extra     = img->numcomps - num_color - (has_alpha ? 1u : 0u);
+
+    vector<string> names;
+    if (num_out_color == 1)
+        names.push_back("Y");
+    else
+        names.insert(names.end(), {"R", "G", "B"});
+    if (has_alpha)
+        names.push_back("A");
+    for (uint32_t c = 0; c < num_extra; ++c) names.push_back(fmt::format("extra.{}", c));
+
+    const int  nc    = (int)names.size();
+    const auto image = make_shared<Image>(size, names);
+    image->filename  = filename;
+    // JPEG 2000 stores straight alpha unless a cdef box says otherwise, and OpenJPEG does not report that
+    image->set_transparency(has_alpha ? TransparencyType_Straight : TransparencyType_None,
+                            transparency_override_of(opts));
+    image->metadata["loader"] = "openjpeg";
+
+    uint32_t min_prec = img->comps[0].prec, max_prec = img->comps[0].prec;
+    bool     signed_samples = false, subsampled = false;
+    for (uint32_t c = 0; c < img->numcomps; ++c)
+    {
+        min_prec       = std::min(min_prec, img->comps[c].prec);
+        max_prec       = std::max(max_prec, img->comps[c].prec);
+        signed_samples = signed_samples || img->comps[c].sgnd;
+        subsampled     = subsampled || img->comps[c].dx != 1 || img->comps[c].dy != 1;
+    }
+    image->set_bits_per_sample((int)max_prec);
+    image->metadata["pixel format"] =
+        min_prec == max_prec ? fmt::format("{} channel{} x {}-bit {}", img->numcomps, img->numcomps == 1 ? "" : "s",
+                                           max_prec, signed_samples ? "signed" : "unsigned")
+                             : fmt::format("{} channels x {}-{}-bit {}", img->numcomps, min_prec, max_prec,
+                                           signed_samples ? "signed" : "unsigned");
+
+    auto &header = image->metadata["header"];
+    header["Color space"] =
+        header_entry(color_space_name(cs_enum), color_space_name(cs_enum), "string", "Color space of the codestream");
+    const bool high_throughput = codestream_is_high_throughput(syntax);
+    header["Block coder"] =
+        header_entry(high_throughput ? "HTJ2K" : "JPEG 2000", high_throughput ? "high-throughput (Part 15)" : "Part 1",
+                     "string", "Block coder the codestream needs");
+    if (!boxes.brand.empty())
+        header["Brand"] = header_entry(boxes.brand, boxes.brand, "string", "Major brand from the file type box");
+    if (subsampled)
+    {
+        set<string> distinct;
+        for (uint32_t c = 0; c < img->numcomps; ++c)
+            distinct.insert(fmt::format("{}:{}", img->comps[c].dx, img->comps[c].dy));
+        string ratios;
+        for (const auto &r : distinct) ratios += (ratios.empty() ? "" : ", ") + r;
+        header["Subsampling"] = header_entry(ratios, ratios, "string", "Component sampling on the reference grid");
+    }
+
+    if (opj_codestream_info_v2 *info = opj_get_cstr_info(codec.get()))
+    {
+        const auto &tile = info->m_default_tile_info;
+        if (info->tw > 1 || info->th > 1)
+        {
+            const string tiles = fmt::format("{} x {} tiles of {} x {}", info->tw, info->th, info->tdx, info->tdy);
+            header["Tiling"]   = header_entry(tiles, tiles, "string", "Tile grid of the codestream");
+        }
+        header["Quality layers"] =
+            header_entry(tile.numlayers, fmt::format("{}", tile.numlayers), "int", "Number of quality layers");
+        header["Progression order"] = header_entry(progression_order_name((OPJ_PROG_ORDER)tile.prg),
+                                                   progression_order_name((OPJ_PROG_ORDER)tile.prg), "string",
+                                                   "Order in which the packets are stored");
+        if (tile.tccp_info)
+        {
+            const uint32_t levels = tile.tccp_info[0].numresolutions > 0 ? tile.tccp_info[0].numresolutions - 1 : 0;
+            header["Decomposition levels"] =
+                header_entry(levels, fmt::format("{}", levels), "int", "Wavelet decomposition levels");
+            const char *wavelet = tile.tccp_info[0].qmfbid ? "5/3 reversible" : "9/7 irreversible";
+            header["Wavelet"]   = header_entry(wavelet, wavelet, "string", "Wavelet transform used");
+        }
+        opj_destroy_cstr_info(&info);
+    }
+
+    if (!boxes.exif.empty())
+    {
+        try
+        {
+            image->exif = Exif{boxes.exif};
+            if (image->exif.valid())
+                image->metadata["exif"] = image->exif.to_json();
+        }
+        catch (const exception &e)
+        {
+            spdlog::warn("Failed to parse EXIF data: {}", e.what());
+        }
+    }
+    // an 'xml ' box is where several encoders put XMP, there being no XMP box in Part 1
+    image->xmp_data = !boxes.xmp.empty() ? boxes.xmp : boxes.xml;
+
+    Timer         timer;
+    const size_t  num_pixels = (size_t)size.x * size.y;
+    const int     n_src      = (int)img->numcomps;
+    vector<float> samples(num_pixels * n_src);
+
+    const int block_size = std::max(1, 1024 * 1024 / std::max(1, size.x));
+    parallel_for(blocked_range<int>(0, size.y, block_size),
+                 [&](int begin_y, int end_y, int, int)
+                 {
+                     for (int y = begin_y; y < end_y; ++y)
+                         for (int x = 0; x < size.x; ++x)
+                         {
+                             float *p = samples.data() + ((size_t)y * size.x + x) * n_src;
+                             for (int c = 0; c < n_src; ++c) p[c] = component_value(img.get(), (uint32_t)c, x, y);
+                         }
+                 });
+
+    if ((cs_enum == OPJ_CLRSPC_SYCC || cs_enum == OPJ_CLRSPC_EYCC) && num_out_color == 3)
+        sycc_to_rgb(samples.data(), num_pixels, n_src, img->comps[1].sgnd != 0);
+
+    vector<float> pixels;
+    if (!cmyk)
+        // every component is its own channel, so the gather already has the layout the image wants
+        pixels = std::move(samples);
+    else
+    {
+        // CMYK stores ink coverage, and its four components become three, shifting everything after them
+        pixels.resize(num_pixels * nc);
+        for (size_t i = 0; i < num_pixels; ++i)
+        {
+            const float *src = samples.data() + i * n_src;
+            float       *out = pixels.data() + i * nc;
+            const float  k   = 1.f - src[3];
+            for (int c = 0; c < 3; ++c) out[c] = (1.f - src[c]) * k;
+            for (int c = 3; c < nc; ++c) out[c] = src[c + 1];
+        }
+    }
+
+    const int3 buffer_size{size.x, size.y, nc};
+    string     profile_desc;
+    unpremultiply_before_transfer(pixels.data(), buffer_size, image->transparency);
+    if (!boxes.icc.empty())
+        image->icc_data.assign(boxes.icc.data, boxes.icc.data + boxes.icc.size);
+
+    Chromaticities chr;
+    if (opts.override_profile)
+    {
+        spdlog::info("Ignoring embedded color profile and linearizing using requested transfer function: {}",
+                     transfer_function_name(opts.tf_override));
+        if (linearize_pixels(pixels.data(), buffer_size, gamut_chromaticities(opts.gamut_override), opts.tf_override,
+                             opts.keep_primaries, &profile_desc, &chr))
+            image->chromaticities = chr;
+        profile_desc += " (user override)";
+    }
+    else if (!image->icc_data.empty() &&
+             ICCProfile(image->icc_data)
+                 .linearize_pixels(pixels.data(), buffer_size, opts.keep_primaries, &profile_desc, &chr))
+    {
+        spdlog::info("Linearizing colors using ICC profile.");
+        image->chromaticities = chr;
+    }
+    else if (linearize_pixels(pixels.data(), buffer_size, Chromaticities(), TransferFunction::sRGB, opts.keep_primaries,
+                              &profile_desc, &chr))
+    {
+        // Part 1 signals no transfer function, and both enumerated RGB spaces it defines are sRGB-encoded
+        spdlog::info("Linearizing colors using the sRGB transfer function: {}", profile_desc);
+        image->chromaticities = chr;
+    }
+    repremultiply_after_transfer(pixels.data(), buffer_size, image->transparency);
+    image->metadata["color profile"] = profile_desc;
+
+    for (int c = 0; c < nc; ++c)
+        image->channels[c].copy_from_interleaved(pixels.data(), size.x, size.y, nc, c, [](float v) { return v; });
+
+    spdlog::debug("Decoding {}x{} JPEG 2000 image took {} seconds.", size.x, size.y, timer.elapsed() / 1000.f);
+    return image;
+}
+
+} // namespace
+
+vector<ImagePtr> load_j2k_image(istream &is, string_view filename, const ImageLoadOptions &opts)
+{
+    ScopedMDC mdc{"IO", "J2K"};
+    if (!is_j2k_image(is))
+        throw invalid_argument{"Not a JPEG 2000 file"};
+
+    is.clear();
+    is.seekg(0, ios::end);
+    const size_t raw_size = (size_t)is.tellg();
+    is.seekg(0, ios::beg);
+
+    vector<uint8_t> raw(raw_size);
+    is.read(reinterpret_cast<char *>(raw.data()), raw_size);
+    if ((size_t)is.gcount() != raw_size)
+        throw invalid_argument{fmt::format("Failed to read {} bytes, got {}", raw_size, (size_t)is.gcount())};
+
+    const Bytes all{raw.data(), raw_size};
+    const bool  boxed =
+        raw_size >= sizeof(k_jp2_signature) && memcmp(raw.data(), k_jp2_signature, sizeof(k_jp2_signature)) == 0;
+
+    Jp2Boxes boxes;
+    if (boxed)
+        parse_jp2_boxes(all, boxes);
+
+    ImGuiTextFilter filter{opts.channel_selector.c_str()};
+    filter.Build();
+
+    vector<ImagePtr> images;
+    if (boxed)
+    {
+        // OpenJPEG's JP2 reader handles the whole file, applying its palette and channel definitions; the
+        // extracted codestreams are the fallback for the family members it does not parse, such as JPM
+        try
+        {
+            const Bytes first = boxes.codestreams.empty() ? all : boxes.codestreams.front();
+            images.push_back(decode_codestream(all, first, OPJ_CODEC_JP2, boxes, filename, opts));
+        }
+        catch (const exception &e)
+        {
+            if (boxes.codestreams.empty())
+                throw;
+            spdlog::warn("Reading '{}' as a JP2 failed ({}); decoding its {} codestream(s) directly.", filename,
+                         e.what(), boxes.codestreams.size());
+        }
+    }
+
+    if (images.empty())
+    {
+        const vector<Bytes> streams = boxed ? boxes.codestreams : vector<Bytes>{all};
+        for (size_t i = 0; i < streams.size(); ++i)
+        {
+            const string partname = streams.size() > 1 ? fmt::format("codestream {:04}", i) : "";
+            if (!partname.empty() && !filter.PassFilter(partname.c_str()))
+                continue;
+
+            auto image      = decode_codestream(streams[i], streams[i], OPJ_CODEC_J2K, boxes, filename, opts);
+            image->partname = partname;
+            images.push_back(image);
+        }
+    }
+
+    if (images.empty())
+        throw invalid_argument{"No JPEG 2000 codestream could be decoded."};
+
+    return images;
+}
+
+void save_j2k_image(const Image &img, ostream &os, string_view filename, const J2KSaveOptions *params)
+{
+    if (!params)
+        throw invalid_argument("J2KSaveOptions pointer is null.");
+
+    ScopedMDC mdc{"IO", "J2K"};
+    Timer     timer;
+
+    const int bit_depth = k_bit_depths[std::clamp(params->bit_depth_index, 0, k_num_bit_depths - 1)];
+
+    int  w = 0, h = 0, n = 0;
+    auto pixels = img.as_interleaved<uint16_t>(&w, &h, &n, params->gain, params->tf, params->dither);
+    if (!pixels || w <= 0 || h <= 0 || n < 1 || n > 4)
+        throw runtime_error{"JPEG 2000: unsupported image dimensions or channel count"};
+
+    const bool has_alpha = group_has_alpha(img.groups[img.selected_group].type);
+    // one and two component images are grayscale and grayscale+alpha, but a two-channel U,V pair is neither,
+    // so it pads out to RGB with a zero third component as the viewport draws it
+    if (n == 2 && !has_alpha)
+    {
+        const size_t           num_pixels = (size_t)w * h;
+        unique_ptr<uint16_t[]> widened{new uint16_t[num_pixels * 3]};
+        for (size_t i = 0; i < num_pixels; ++i)
+        {
+            widened[i * 3 + 0] = pixels[i * 2 + 0];
+            widened[i * 3 + 1] = pixels[i * 2 + 1];
+            widened[i * 3 + 2] = 0;
+        }
+        pixels = std::move(widened);
+        n      = 3;
+    }
+
+    opj_image_cmptparm_t cmptparm[4];
+    memset(cmptparm, 0, sizeof(cmptparm));
+    for (int c = 0; c < n; ++c)
+    {
+        cmptparm[c].prec = (OPJ_UINT32)bit_depth;
+        cmptparm[c].bpp  = (OPJ_UINT32)bit_depth;
+        cmptparm[c].sgnd = 0;
+        cmptparm[c].dx   = 1;
+        cmptparm[c].dy   = 1;
+        cmptparm[c].w    = (OPJ_UINT32)w;
+        cmptparm[c].h    = (OPJ_UINT32)h;
+    }
+
+    OpjImgPtr img_out{opj_image_create((OPJ_UINT32)n, cmptparm, n >= 3 ? OPJ_CLRSPC_SRGB : OPJ_CLRSPC_GRAY),
+                      opj_image_destroy};
+    if (!img_out)
+        throw runtime_error{"JPEG 2000: failed to allocate the image"};
+
+    img_out->x0 = 0;
+    img_out->y0 = 0;
+    img_out->x1 = (OPJ_UINT32)w;
+    img_out->y1 = (OPJ_UINT32)h;
+    if (has_alpha)
+        img_out->comps[n - 1].alpha = 1;
+
+    const int shift = 16 - bit_depth;
+    for (int c = 0; c < n; ++c)
+    {
+        OPJ_INT32 *dst = img_out->comps[c].data;
+        for (size_t i = 0, num = (size_t)w * h; i < num; ++i) dst[i] = (OPJ_INT32)(pixels[i * n + c] >> shift);
+    }
+
+    opj_cparameters_t cp;
+    opj_set_default_encoder_parameters(&cp);
+    cp.tcp_numlayers  = 1;
+    cp.cp_disto_alloc = 1;
+    cp.irreversible   = params->reversible ? 0 : 1;
+    // OpenJPEG reads a rate of 0 as lossless
+    cp.tcp_rates[0] = params->reversible ? 0.f : std::max(1.f, params->ratio);
+    cp.tcp_mct      = (n >= 3 && params->mct) ? 1 : 0;
+    // each decomposition halves the image, and OpenJPEG refuses a level count the smaller side cannot take
+    int max_levels = 1;
+    while ((std::min(w, h) >> max_levels) > 0 && max_levels < 32) ++max_levels;
+    cp.numresolution = std::clamp(params->num_resolutions, 1, max_levels);
+
+    CodecPtr codec{opj_create_compress(params->container == J2KContainer::J2K ? OPJ_CODEC_J2K : OPJ_CODEC_JP2),
+                   opj_destroy_codec};
+    if (!codec)
+        throw runtime_error{"JPEG 2000: failed to create an encoder"};
+    install_handlers(codec.get());
+
+    if (!opj_setup_encoder(codec.get(), &cp, img_out.get()))
+        throw runtime_error{"JPEG 2000: failed to set up the encoder"};
+    opj_codec_set_threads(codec.get(), (int)std::max(1u, std::thread::hardware_concurrency()));
+
+    OutStream out;
+    StreamPtr stream{opj_stream_create(OPJ_J2K_STREAM_CHUNK_SIZE, OPJ_FALSE), opj_stream_destroy};
+    if (!stream)
+        throw runtime_error{"JPEG 2000: failed to create a stream"};
+    opj_stream_set_user_data(stream.get(), &out, nullptr);
+    opj_stream_set_write_function(stream.get(), out_write);
+    opj_stream_set_skip_function(stream.get(), out_skip);
+    opj_stream_set_seek_function(stream.get(), out_seek);
+
+    spdlog::info("Saving {}-channel, {}x{} pixels {}-bit {} JPEG 2000 image.", n, w, h, bit_depth,
+                 params->reversible ? "lossless" : "lossy");
+
+    if (!opj_start_compress(codec.get(), img_out.get(), stream.get()) || !opj_encode(codec.get(), stream.get()) ||
+        !opj_end_compress(codec.get(), stream.get()))
+        throw runtime_error{"JPEG 2000: failed to encode the image"};
+
+    os.write(reinterpret_cast<const char *>(out.bytes.data()), (streamsize)out.bytes.size());
+    if (!os.good())
+        throw runtime_error{"JPEG 2000: failed to write the encoded image"};
+
+    spdlog::info("Saved JPEG 2000 image to \"{}\" in {} seconds.", filename, timer.elapsed() / 1000.f);
+}
+
+void save_j2k_image(const Image &img, ostream &os, string_view filename, float gain, bool lossless, int bit_depth,
+                    J2KContainer container, TransferFunction tf, bool dither)
+{
+    J2KSaveOptions opts;
+    opts.gain       = gain;
+    opts.tf         = tf;
+    opts.dither     = dither;
+    opts.reversible = lossless;
+    opts.container  = container;
+    opts.bit_depth_index =
+        (int)(std::find(k_bit_depths, k_bit_depths + k_num_bit_depths, bit_depth) - k_bit_depths) % k_num_bit_depths;
+    save_j2k_image(img, os, filename, &opts);
+}
+
+J2KSaveOptions *j2k_parameters_gui(J2KContainer container)
+{
+    s_opts.container = container;
+
+    if (ImGui::PE::Begin("JPEG 2000 Save Options",
+                         ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize))
+    {
+        ImGui::TableSetupColumn("one", ImGuiTableColumnFlags_None);
+        ImGui::TableSetupColumn("two", ImGuiTableColumnFlags_WidthStretch);
+
+        ImGui::PE::Entry(
+            "Gain",
+            [&]
+            {
+                ImGui::BeginGroup();
+                ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - ImGui::IconButtonSize().x -
+                                        ImGui::GetStyle().ItemInnerSpacing.x);
+                auto changed = ImGui::SliderFloat("##Gain", &s_opts.gain, 0.1f, 10.0f);
+                ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
+                if (ImGui::IconButton(ICON_MY_EXPOSURE))
+                    s_opts.gain = exp2f(hdrview()->exposure());
+                ImGui::Tooltip("Set gain from the current viewport exposure value.");
+                ImGui::EndGroup();
+                return changed;
+            },
+            "Multiply the pixels by this value before saving.");
+
+        ImGui::PE::Entry(
+            "Transfer function",
+            [&]
+            {
+                if (ImGui::BeginCombo("##Transfer function", transfer_function_name(s_opts.tf).c_str()))
+                {
+                    for (int i = TransferFunction::Linear; i <= TransferFunction::DCI_P3; ++i)
+                    {
+                        bool is_selected = (s_opts.tf.type == (TransferFunction::Type_)i);
+                        if (ImGui::Selectable(
+                                transfer_function_name({(TransferFunction::Type_)i, s_opts.tf.gamma}).c_str(),
+                                is_selected))
+                            s_opts.tf.type = (TransferFunction::Type_)i;
+                        if (is_selected)
+                            ImGui::SetItemDefaultFocus();
+                    }
+                    ImGui::EndCombo();
+                }
+                return true;
+            },
+            "Encode the pixel values using this transfer function.\nWARNING: JPEG 2000 records no transfer "
+            "function of its own, so other software will read this file as sRGB.");
+
+        if (s_opts.tf.type == TransferFunction::Gamma)
+            ImGui::PE::SliderFloat("Gamma", &s_opts.tf.gamma, 0.1f, 5.f, "%.3f", 0,
+                                   "When using a gamma transfer function, this is the gamma value to use.");
+
+        ImGui::PE::Combo("Bit depth", &s_opts.bit_depth_index,
+                         "8-bit\0"
+                         "12-bit\0"
+                         "16-bit\0");
+        ImGui::PE::Checkbox("Dither", &s_opts.dither);
+        ImGui::PE::Checkbox("Lossless", &s_opts.reversible,
+                            "Compress with the reversible 5/3 wavelet, which reproduces the samples exactly. "
+                            "Turn off for the irreversible 9/7 wavelet at a chosen compression ratio.");
+        if (!s_opts.reversible)
+            ImGui::PE::SliderFloat("Compression ratio", &s_opts.ratio, 1.f, 200.f, "%.0f:1",
+                                   ImGuiSliderFlags_Logarithmic, "Target ratio of uncompressed to compressed size.");
+        ImGui::PE::SliderInt("Resolutions", &s_opts.num_resolutions, 1, 10, "%d", ImGuiSliderFlags_None,
+                             "Number of resolution levels in the wavelet pyramid, which is what lets a decoder "
+                             "read a reduced-size image without decoding all of it.");
+        ImGui::PE::Checkbox("Component transform", &s_opts.mct,
+                            "Decorrelate the three color components before the wavelet, which compresses RGB "
+                            "images considerably better.");
+
+        ImGui::PE::End();
+    }
+
+    if (ImGui::Button("Reset options to defaults"))
+        s_opts = J2KSaveOptions{};
+
+    return &s_opts;
+}
+
+#endif // HDRVIEW_ENABLE_J2K

--- a/src/imageio/j2k.cpp
+++ b/src/imageio/j2k.cpp
@@ -68,7 +68,6 @@ void save_j2k_image(const Image &, ostream &, string_view, float, bool, int, J2K
 
 #include <algorithm>
 #include <cstring>
-#include <optional>
 #include <set>
 #include <thread>
 
@@ -150,28 +149,22 @@ bool read_box(Bytes in, Box &box, size_t &total)
 /// What the JP2 boxes around a codestream say, for the parts OpenJPEG does not report itself.
 struct Jp2Boxes
 {
-    string             brand;
-    Bytes              icc;
-    vector<uint8_t>    exif;
-    vector<uint8_t>    xmp;
-    vector<uint8_t>    xml;
-    vector<Bytes>      codestreams;
-    optional<uint32_t> enum_cs;
+    string          brand;
+    Bytes           icc;
+    vector<uint8_t> exif;
+    vector<uint8_t> xmp;
+    vector<uint8_t> xml;
+    vector<Bytes>   codestreams;
 };
 
-/// Reads the 'colr' box body: an enumerated color space or a restricted ICC profile.
+/// Takes the restricted ICC profile out of a 'colr' box body, for the paths OpenJPEG does not parse itself.
+/**
+    Its enumerated color space needs no reading here: OpenJPEG reports that one as opj_image_t::color_space.
+*/
 void parse_colr(Bytes box, Jp2Boxes &out)
 {
-    if (box.size < 3)
-        return;
-
-    const uint8_t meth = box.data[0];
-    if (meth == 1 && box.size >= 7)
-    {
-        if (!out.enum_cs)
-            out.enum_cs = read_u32(box.data + 3);
-    }
-    else if ((meth == 2 || meth == 3) && box.size > 3 && out.icc.empty())
+    const uint8_t meth = box.size >= 3 ? box.data[0] : 0;
+    if ((meth == 2 || meth == 3) && box.size > 3 && out.icc.empty())
         out.icc = box.subspan(3, box.size - 3);
 }
 
@@ -382,6 +375,11 @@ void sycc_to_rgb(float *pixels, size_t num_pixels, int n, bool chroma_is_signed)
 
 json get_j2k_info() { return json{{"enabled", true}, {"name", "OpenJPEG"}, {"version", opj_version()}}; }
 
+/// Whether `is` opens with either JPEG 2000 syntax.
+/**
+    OpenJPEG publishes no such test: opj_create_decompress() has to be told which syntax to expect, and the
+    magic bytes that decide it live in its command-line tools rather than in the library.
+*/
 bool is_j2k_image(istream &is) noexcept
 {
     auto start = is.tellg();
@@ -621,7 +619,11 @@ ImagePtr decode_codestream(Bytes cs, Bytes syntax, OPJ_CODEC_FORMAT format, cons
     const int3 buffer_size{size.x, size.y, nc};
     string     profile_desc;
     unpremultiply_before_transfer(pixels.data(), buffer_size, image->transparency);
-    if (!boxes.icc.empty())
+    // OpenJPEG hands over the profile it read from the 'colr' box, but only for the syntaxes whose boxes it
+    // parses, and it also parks CIELab parameters in the same field under a length of zero
+    if (img->icc_profile_buf && img->icc_profile_len > 0)
+        image->icc_data.assign(img->icc_profile_buf, img->icc_profile_buf + img->icc_profile_len);
+    else if (!boxes.icc.empty())
         image->icc_data.assign(boxes.icc.data, boxes.icc.data + boxes.icc.size);
 
     Chromaticities chr;

--- a/src/imageio/j2k.h
+++ b/src/imageio/j2k.h
@@ -1,0 +1,41 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#pragma once
+
+#include "colorspace.h"
+#include "fwd.h"
+#include "image_loader.h"
+
+#include <istream>
+#include <string_view>
+
+#include "json.h"
+
+// return a JSON object describing the OpenJPEG backend
+json get_j2k_info();
+
+// should not throw
+bool is_j2k_image(std::istream &is) noexcept;
+// throws on error
+std::vector<ImagePtr> load_j2k_image(std::istream &is, std::string_view filename, const ImageLoadOptions &opts = {});
+
+/// Which of the JPEG 2000 file syntaxes to write.
+enum class J2KContainer
+{
+    JP2 = 0, ///< the JP2 file format: boxes carrying color and metadata around the codestream
+    J2K,     ///< a bare codestream, with no boxes and so nowhere to record a color space
+};
+
+struct J2KSaveOptions;
+/// Draws the options for writing `container`, whose choice of syntax the file's extension fixes.
+J2KSaveOptions *j2k_parameters_gui(J2KContainer container);
+// throws on error
+void save_j2k_image(const Image &img, std::ostream &os, std::string_view filename, const J2KSaveOptions *params);
+// throws on error
+void save_j2k_image(const Image &img, std::ostream &os, std::string_view filename, float gain = 1.f,
+                    bool lossless = true, int bit_depth = 16, J2KContainer container = J2KContainer::JP2,
+                    TransferFunction tf = TransferFunction::sRGB, bool dither = true);

--- a/src/imageio/j2k.h
+++ b/src/imageio/j2k.h
@@ -31,8 +31,9 @@ enum class J2KContainer
 };
 
 struct J2KSaveOptions;
-/// Draws the options for writing `container`, whose choice of syntax the file's extension fixes.
-J2KSaveOptions *j2k_parameters_gui(J2KContainer container);
+J2KSaveOptions *j2k_parameters_gui();
+/// The extension for the syntax `params` asks for, since the two share one entry in the save dialog.
+const char *j2k_extension(const J2KSaveOptions *params);
 // throws on error
 void save_j2k_image(const Image &img, std::ostream &os, std::string_view filename, const J2KSaveOptions *params);
 // throws on error

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -314,9 +314,8 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
 
         int num_channels = samples_per_pixel;
 
-        // libtiff's RGBA interface converts CMYK by a formula of its own that no profile informs, which
-        // costs a print profile's rendering entirely. A file carrying one takes the ordinary path instead,
-        // and its four ink samples reach ICCProfile intact.
+        // libtiff's RGBA interface converts CMYK by a formula of its own that no profile informs, so a file
+        // carrying one takes the ordinary path and its four ink samples reach ICCProfile intact
         bool cmyk_via_icc = false;
         if (is_cmyk)
         {
@@ -890,8 +889,8 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
         unpremultiply_before_transfer(float_pixels.data(), size, image->transparency);
 
-        // a priority that ran is the end of it; one that could not is not, and the file's own tags still have
-        // to say how to read the samples
+        // a priority that could not be applied has to fall through, or the samples keep the encoding the
+        // file stored them in
         bool linearized = opts.override_profile;
 
         if (opts.override_profile)

--- a/src/imageio/tiff.cpp
+++ b/src/imageio/tiff.cpp
@@ -314,7 +314,20 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
 
         int num_channels = samples_per_pixel;
 
-        if ((photometric == PHOTOMETRIC_YCBCR && compression_type != COMPRESSION_JPEG) || is_cmyk || is_lab)
+        // libtiff's RGBA interface converts CMYK by a formula of its own that no profile informs, which
+        // costs a print profile's rendering entirely. A file carrying one takes the ordinary path instead,
+        // and its four ink samples reach ICCProfile intact.
+        bool cmyk_via_icc = false;
+        if (is_cmyk)
+        {
+            uint32_t       icc_size = 0;
+            const uint8_t *icc_data = nullptr;
+            if (TIFFGetField(tif, TIFFTAG_ICCPROFILE, &icc_size, &icc_data) && icc_size > 0)
+                cmyk_via_icc = ICCProfile(icc_data, icc_size).is_CMYK();
+        }
+
+        if ((photometric == PHOTOMETRIC_YCBCR && compression_type != COMPRESSION_JPEG) || (is_cmyk && !cmyk_via_icc) ||
+            is_lab)
         {
             const char *color_space = is_cmyk ? "CMYK" : (is_lab ? "Lab" : "YCbCr");
             spdlog::debug("Using RGBA interface for {} image", color_space);
@@ -391,7 +404,7 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         // only guess when the file said nothing; an EXTRASAMPLES tag naming EXTRASAMPLE_UNSPECIFIED is the
         // file saying the extra sample is arbitrary data
         bool assumed = false;
-        if (!has_alpha && !has_extra_samples && num_channels == 4)
+        if (!has_alpha && !has_extra_samples && num_channels == 4 && photometric != PHOTOMETRIC_SEPARATED)
         {
             has_alpha = true;
             // straight is the likelier reading for an unlabeled RGBA TIFF, but it is a guess
@@ -877,6 +890,10 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         // inverting the transfer function does not commute with multiplication by alpha; see alpha.h
         unpremultiply_before_transfer(float_pixels.data(), size, image->transparency);
 
+        // a priority that ran is the end of it; one that could not is not, and the file's own tags still have
+        // to say how to read the samples
+        bool linearized = opts.override_profile;
+
         if (opts.override_profile)
         {
             // Priority 1: User override (highest priority) - use gamut_override and tf_override
@@ -893,13 +910,19 @@ vector<ImagePtr> load_image(TIFF *tif, tdir_t dir, int sub_id, int sub_chain_id,
         {
             // Priority 2: ICC profile
             if (ICCProfile(image->icc_data)
-                    .linearize_pixels(float_pixels.data(), size, opts.keep_primaries, &profile_desc, &chr))
+                    .linearize_pixels(float_pixels.data(), size, opts.keep_primaries, &profile_desc, &chr,
+                                      /* cmyk_is_inverted */ false))
             {
                 spdlog::info("Linearizing colors using ICC profile.");
                 image->chromaticities = chr;
+                linearized            = true;
             }
+            else
+                spdlog::warn("Could not linearize through the embedded ICC profile; reading what the file's "
+                             "own tags say instead.");
         }
-        else
+
+        if (!linearized)
         {
             // Priority 3: TRANSFERFUNCTION tag + chromaticities. The curve is a table of 2^BitsPerSample
             // entries, which only a palette or integer image small enough to index is meant to carry.
@@ -1146,7 +1169,8 @@ vector<ImagePtr> load_sub_images(TIFF *tif, tdir_t dir, const ImageLoadOptions &
                 throw invalid_argument{"Failed to read sub IFD."};
 
             int j = 0;
-            do {
+            do
+            {
                 auto sub_images = load_image(tif, dir, i, j, opts);
                 for (auto sub_image : sub_images) images.push_back(sub_image);
                 ++j;
@@ -1258,7 +1282,8 @@ vector<ImagePtr> load_tiff_image(istream &is, string_view filename, const ImageL
     vector<ImagePtr> images;
 
     // TIFF files can contain multiple directories (sub-images)
-    do {
+    do
+    {
 
         tdir_t dir = TIFFCurrentDirectory(tif);
 

--- a/tests/test_export_roundtrip.cpp
+++ b/tests/test_export_roundtrip.cpp
@@ -20,6 +20,7 @@
 #include "imageio/exr.h"
 #include "imageio/heif.h"
 #include "imageio/image_loader.h"
+#include "imageio/j2k.h"
 #include "imageio/jpg.h"
 #include "imageio/jxl.h"
 #include "imageio/pfm.h"
@@ -102,6 +103,18 @@ const Writer k_writers[] = {
     {"jpg", ".jpg", Cap_Lossy,
      [](const Image &i, std::ostream &o, TransferFunction t)
      { save_jpg_image(i, o, "a.jpg", 1.f, t.type == TransferFunction::sRGB, false, 100, false); }},
+#endif
+#if HDRVIEW_ENABLE_J2K
+    // both syntaxes, and both ends of the bit depths the dialog offers
+    {"jp2_16", ".jp2", Cap_Alpha,
+     [](const Image &i, std::ostream &o, TransferFunction t)
+     { save_j2k_image(i, o, "a.jp2", 1.f, true, 16, J2KContainer::JP2, t, false); }},
+    {"jp2_8", ".jp2", Cap_Alpha,
+     [](const Image &i, std::ostream &o, TransferFunction t)
+     { save_j2k_image(i, o, "a.jp2", 1.f, true, 8, J2KContainer::JP2, t, false); }},
+    {"j2k", ".j2k", Cap_Alpha,
+     [](const Image &i, std::ostream &o, TransferFunction t)
+     { save_j2k_image(i, o, "a.j2k", 1.f, true, 16, J2KContainer::J2K, t, false); }},
 #endif
 #if HDRVIEW_ENABLE_LIBWEBP
     {"webp", ".webp", Cap_Alpha,

--- a/tests/test_export_roundtrip.cpp
+++ b/tests/test_export_roundtrip.cpp
@@ -109,6 +109,9 @@ const Writer k_writers[] = {
     {"jp2_16", ".jp2", Cap_Alpha,
      [](const Image &i, std::ostream &o, TransferFunction t)
      { save_j2k_image(i, o, "a.jp2", 1.f, true, 16, J2KContainer::JP2, t, false); }},
+    {"jp2_10", ".jp2", Cap_Alpha,
+     [](const Image &i, std::ostream &o, TransferFunction t)
+     { save_j2k_image(i, o, "a.jp2", 1.f, true, 10, J2KContainer::JP2, t, false); }},
     {"jp2_8", ".jp2", Cap_Alpha,
      [](const Image &i, std::ostream &o, TransferFunction t)
      { save_j2k_image(i, o, "a.jp2", 1.f, true, 8, J2KContainer::JP2, t, false); }},

--- a/tests/test_icc_gray_alpha.cpp
+++ b/tests/test_icc_gray_alpha.cpp
@@ -11,6 +11,8 @@
 #if HDRVIEW_ENABLE_LCMS2
 
 #include <cstdint>
+#include <fstream>
+#include <string>
 #include <vector>
 
 namespace
@@ -99,5 +101,54 @@ TEST_CASE("a gray ICC profile still linearizes a single-channel buffer")
         CHECK(pixels[i] == doctest::Approx(linearized).epsilon(1e-4));
     }
 }
+
+#ifdef HDRVIEW_TEST_LCMS_TESTBED_DIR
+
+TEST_CASE("a CMYK ICC profile converts ink to color, and only inverts it when told to")
+{
+    // lcms's own CMYK printer profile. It says of itself that it is not suitable for real use, which is
+    // beside the point: its color space is CMYK, and that is the property the conversion turns on.
+    std::ifstream in(std::string(HDRVIEW_TEST_LCMS_TESTBED_DIR) + "/test1.icc", std::ios::binary);
+    REQUIRE(in.good());
+    const std::string bytes{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+    ICCProfile        profile{reinterpret_cast<const uint8_t *>(bytes.data()), bytes.size()};
+    REQUIRE(profile.valid());
+    REQUIRE(profile.is_CMYK());
+
+    // bare paper and a solid hit of black, as a file storing ink directly writes them
+    const auto ink = [] { return std::vector<float>{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f}; };
+
+    // A CMYK profile has no primaries of its own to keep, so the default has to convert anyway rather than
+    // asking for colorants that are not there and giving up.
+    for (bool keep_primaries : {true, false})
+    {
+        CAPTURE(keep_primaries);
+        auto pixels = ink();
+        REQUIRE(profile.linearize_pixels(pixels.data(), int3{2, 1, 4}, keep_primaries, nullptr, nullptr,
+                                         /*cmyk_is_inverted*/ false));
+
+        for (int c = 0; c < 3; ++c)
+        {
+            CAPTURE(c);
+            CHECK(pixels[c] > 0.5f);     // paper
+            CHECK(pixels[4 + c] < 0.2f); // solid black
+        }
+        CHECK(pixels[3] == doctest::Approx(1.f)); // the conversion writes an opaque alpha
+    }
+
+    // Adobe's JPEGs store the same ink inverted, and nothing in the profile says which convention a file
+    // used, so the caller states it. Bare paper is what separates the two: read the wrong way up it is not
+    // an absence of ink but a full hit of every one.
+    auto inverted = ink();
+    REQUIRE(profile.linearize_pixels(inverted.data(), int3{2, 1, 4}, /*keep_primaries*/ false, nullptr, nullptr,
+                                     /*cmyk_is_inverted*/ true));
+    for (int c = 0; c < 3; ++c)
+    {
+        CAPTURE(c);
+        CHECK(inverted[c] < 0.2f);
+    }
+}
+
+#endif // HDRVIEW_TEST_LCMS_TESTBED_DIR
 
 #endif // HDRVIEW_ENABLE_LCMS2

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -81,8 +81,9 @@ OPJ_BOOL out_seek(OPJ_OFF_T offset, void *user_data)
 
 /// A lossless JPEG 2000 file holding `comps` verbatim, built by OpenJPEG rather than by our own writer.
 /**
-    Going straight to the library is what lets these cases cover component shapes HDRView's writer never
-    emits: precisions other than 8, 12 and 16, signed samples, and subsampled components.
+    HDRView writes one component shape: unsigned samples at full rate, 8, 12 or 16 bits deep. Going straight
+    to the library is what lets these cases read the rest of what a codestream may declare, so the reader is
+    covered past what a round trip through the writer can reach.
 */
 std::string encode_with_openjpeg(int w, int h, const std::vector<Component> &comps, OPJ_COLOR_SPACE cs,
                                  OPJ_CODEC_FORMAT format)

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -172,6 +172,34 @@ std::string with_extra_boxes(const std::string &jp2, const std::string &extra)
     return jp2.substr(0, at - 4) + extra + jp2.substr(at - 4);
 }
 
+/// A little-endian TIFF holding one IFD0 entry, which is what an EXIF block is.
+std::string exif_blob(uint16_t tag, uint16_t value)
+{
+    std::string out;
+    out += "II";
+    put(out, (uint16_t)42);
+    put(out, (uint32_t)8);
+    put(out, (uint16_t)1);
+    put(out, tag);
+    put(out, (uint16_t)3); // SHORT
+    put(out, (uint32_t)1);
+    put(out, value);
+    put(out, (uint16_t)0);
+    put(out, (uint32_t)0);
+    return out;
+}
+
+/// The body of a 'uuid' box: the sixteen identifying bytes followed by the payload.
+std::string uuid_payload(const uint8_t uuid[16], const std::string &payload)
+{
+    return std::string((const char *)uuid, 16) + payload;
+}
+
+constexpr uint8_t k_xmp_uuid[16]  = {0xBE, 0x7A, 0xCF, 0xCB, 0x97, 0xA9, 0x42, 0xE8,
+                                     0x9C, 0x71, 0x99, 0x94, 0x91, 0xE3, 0xAF, 0xAC};
+constexpr uint8_t k_exif_uuid[16] = {0x4A, 0x70, 0x67, 0x54, 0x69, 0x66, 0x66, 0x45,
+                                     0x78, 0x69, 0x66, 0x2D, 0x3E, 0x4A, 0x50, 0x32};
+
 } // namespace
 
 TEST_CASE("Component precision and signedness decode to the range they encode")
@@ -298,6 +326,42 @@ TEST_CASE("The sniff accepts both JPEG 2000 syntaxes and nothing else")
     {
         std::istringstream in(other, std::ios::binary);
         CHECK_FALSE(is_j2k_image(in));
+    }
+}
+
+TEST_CASE("A JP2's EXIF and XMP boxes reach the metadata the info panel reads")
+{
+    std::vector<int32_t> wrote;
+    const auto           plain = ramp_codestream(8, false, 4, 4, wrote, OPJ_CODEC_JP2);
+
+    const std::string xmp = "<?xpacket begin=\"\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n"
+                            "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n"
+                            "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n"
+                            "<rdf:Description rdf:about=\"\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\" "
+                            "xmp:CreatorTool=\"HDRView\"/>\n"
+                            "</rdf:RDF>\n</x:xmpmeta>\n<?xpacket end=\"w\"?>";
+
+    // writers disagree over whether the EXIF box repeats JPEG's "Exif\0\0" marker before the TIFF header
+    for (const std::string prefix : {std::string{}, std::string("Exif\0\0", 6)})
+    {
+        CAPTURE(prefix.size());
+
+        // 0x0112 is Orientation, and 3 is a 180-degree rotation
+        const auto with_meta =
+            with_extra_boxes(plain, box("uuid", uuid_payload(k_exif_uuid, prefix + exif_blob(0x0112, 3))) +
+                                        box("uuid", uuid_payload(k_xmp_uuid, xmp)));
+
+        // through load_image(), since finalize() is what turns the raw buffers into the metadata tree
+        const auto img = load_bytes(with_meta, "meta.jp2");
+        REQUIRE(img);
+
+        REQUIRE(img->metadata.contains("exif"));
+        REQUIRE(img->metadata["exif"].is_object());
+        CHECK(img->metadata["exif"].dump().find("Orientation") != std::string::npos);
+
+        REQUIRE(img->metadata.contains("xmp"));
+        REQUIRE(img->metadata["xmp"].is_object());
+        CHECK(img->metadata["xmp"]["xmp"]["CreatorTool"] == "HDRView");
     }
 }
 

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -574,9 +574,55 @@ TEST_CASE("Every file in a real JPEG 2000 corpus either decodes or is refused")
     CAPTURE(decoded);
     CAPTURE(refused);
     CAPTURE(high_throughput);
-    // a corpus that decoded nothing would pass every check above without testing anything
+    // a corpus that decoded nothing would pass every check above without testing anything. Whether it holds
+    // any high-throughput files is its business, not this test's, so that one is only reported.
     CHECK(decoded > 0);
-    CHECK(high_throughput > 0);
+}
+
+// The same photograph saved twice by Photoshop, once RGB and once CMYK, which is the only way to check the
+// ink conversion end to end: the profile that drives it is half a megabyte and cannot be vendored here.
+TEST_CASE("A CMYK rendition agrees with the RGB one of the same photograph")
+{
+    namespace fs = std::filesystem;
+
+    const fs::path dir  = HDRVIEW_TEST_J2K_DIR;
+    const fs::path rgb  = dir / "buddha-rgb.jpf";
+    const fs::path cmyk = dir / "buddha-cmyk.jpf";
+    if (!fs::exists(rgb) || !fs::exists(cmyk))
+        return;
+
+    const auto load = [](const fs::path &p, const ImageLoadOptions &opts)
+    {
+        std::ifstream in(p, std::ios::binary);
+        REQUIRE(in.good());
+        auto images = load_j2k_image(in, p.filename().string(), opts);
+        REQUIRE(images.size() == 1);
+        return images.front();
+    };
+
+    // first as the app loads it: CMYK has no primaries of its own to keep, so the profile has to be applied
+    // even under the default that keeps them
+    CHECK(load(cmyk, ImageLoadOptions{})->metadata.value("color profile", std::string{}).find("SWOP") !=
+          std::string::npos);
+
+    // then both to sRGB primaries, which is what makes the two directly comparable
+    ImageLoadOptions opts;
+    opts.keep_primaries = false;
+    const auto a = load(rgb, opts), b = load(cmyk, opts);
+    REQUIRE(a->size() == b->size());
+    REQUIRE(a->channels.size() == 3);
+    // the conversion writes RGB over the four ink channels and leaves the fourth opaque
+    REQUIRE(b->channels.size() == 4);
+    // SWOP's gamut is far short of the RGB rendition's, so saturated pixels clip; the average is what says
+    // the ink was read the right way up, since reading it inverted puts this above 0.25
+    for (int c = 0; c < 3; ++c)
+    {
+        CAPTURE(c);
+        double sum = 0.;
+        for (int y = 0; y < a->size().y; ++y)
+            for (int x = 0; x < a->size().x; ++x) sum += std::abs(double(a->channels[c](x, y) - b->channels[c](x, y)));
+        CHECK(sum / ((double)a->size().x * a->size().y) < 0.05);
+    }
 }
 
 #endif // HDRVIEW_TEST_J2K_DIR

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -618,15 +618,7 @@ TEST_CASE("Every rendition of one photograph decodes to the same picture")
             continue;
 
         CAPTURE(path.filename().string());
-        const string name = path.filename().string();
-        const bool   cmyk = name.find("-cmyk") != string::npos;
-
-        // A CMYK TIFF is left out because it is a standing bug in the TIFF loader, not in anything this
-        // file covers: libtiff's RGBA interface converts the ink itself, ignoring the profile, and
-        // tiff.cpp applies no transfer function when an ICC profile fails to apply, so the image reads
-        // back about twice as bright as it should.
-        if (cmyk && (name.find(".tif") != string::npos))
-            continue;
+        const bool cmyk = path.filename().string().find("-cmyk") != string::npos;
 
         // first as the app loads it. A CMYK profile has no primaries of its own to keep, so it has to be
         // applied even under the default that keeps them, and its name is what says that it was.
@@ -640,8 +632,9 @@ TEST_CASE("Every rendition of one photograph decodes to the same picture")
         REQUIRE(got);
         REQUIRE(got->size() == want->size());
 
-        // a CMYK rendition clips where SWOP's gamut falls short, and the lossy ones move samples, so the
-        // average is what carries: ink read the wrong way up puts this above 0.25
+        // a CMYK rendition clips where SWOP's gamut falls short and the lossy ones move samples, so the
+        // average is what carries: ink read the wrong way up puts this above 0.25, and a transfer function
+        // never applied puts it near 0.2
         for (int c = 0; c < 3; ++c)
         {
             CAPTURE(c);

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -88,7 +88,7 @@ OPJ_BOOL out_seek(OPJ_OFF_T offset, void *user_data)
     covered past what a round trip through the writer can reach.
 */
 std::string encode_with_openjpeg(int w, int h, const std::vector<Component> &comps, OPJ_COLOR_SPACE cs,
-                                 OPJ_CODEC_FORMAT format, int x0 = 0, int y0 = 0)
+                                 OPJ_CODEC_FORMAT format, int x0 = 0, int y0 = 0, const std::string &icc = {})
 {
     std::vector<opj_image_cmptparm_t> parms(comps.size());
     std::memset(parms.data(), 0, parms.size() * sizeof(opj_image_cmptparm_t));
@@ -121,6 +121,16 @@ std::string encode_with_openjpeg(int w, int h, const std::vector<Component> &com
     {
         REQUIRE(comps[c].samples.size() == (size_t)img->comps[c].w * img->comps[c].h);
         std::memcpy(img->comps[c].data, comps[c].samples.data(), comps[c].samples.size() * sizeof(int32_t));
+    }
+
+    // OpenJPEG writes a 'colr' box of method 2 around whatever profile the image carries, and frees the
+    // buffer with the image, so it has to own it
+    if (!icc.empty())
+    {
+        img->icc_profile_buf = (OPJ_BYTE *)malloc(icc.size());
+        REQUIRE(img->icc_profile_buf != nullptr);
+        std::memcpy(img->icc_profile_buf, icc.data(), icc.size());
+        img->icc_profile_len = (OPJ_UINT32)icc.size();
     }
 
     opj_cparameters_t cp;
@@ -524,6 +534,43 @@ TEST_CASE("A codestream declaring impossible dimensions is refused before it is 
 
     CHECK_THROWS_AS(load_bytes(load_j2k_image, j2k, "huge.j2k"), std::exception);
 }
+
+#ifdef HDRVIEW_TEST_LCMS_TESTBED_DIR
+
+// lcms's own CMYK printer profile, which is a real one with real tables and says of itself that it is not
+// suitable for real use. That is all this needs: a profile whose color space is CMYK, so the conversion has
+// something to run through.
+TEST_CASE("CMYK ink decodes through the file's profile, and the right way up")
+{
+    std::ifstream in(std::string(HDRVIEW_TEST_LCMS_TESTBED_DIR) + "/test1.icc", std::ios::binary);
+    REQUIRE(in.good());
+    const std::string icc{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+    REQUIRE(icc.size() > 128);
+
+    // two pixels of known ink: bare paper, and a solid hit of black
+    const std::vector<int32_t> none(2, 0);
+    std::vector<int32_t>       black{0, 255};
+    const auto                 bytes = encode_with_openjpeg(
+        2, 1, {{8, false, 1, 1, none}, {8, false, 1, 1, none}, {8, false, 1, 1, none}, {8, false, 1, 1, black}},
+        OPJ_CLRSPC_CMYK, OPJ_CODEC_JP2, 0, 0, icc);
+
+    // as the app loads it, since a CMYK profile has to be applied even under the default that keeps primaries
+    const auto img = load_bytes(load_j2k_image, bytes, "cmyk.jp2");
+    REQUIRE(img);
+    CHECK(img->metadata.value("color profile", std::string{}).find("Test profile") != string::npos);
+    REQUIRE(img->channels.size() >= 3);
+
+    // paper is lighter than solid black ink. Reading the ink inverted swaps the two, and failing to convert
+    // at all leaves both at the C, M and Y that are zero in each.
+    for (int c = 0; c < 3; ++c)
+    {
+        CAPTURE(c);
+        CHECK(img->channels[c](0, 0) > 0.5f);
+        CHECK(img->channels[c](1, 0) < 0.2f);
+    }
+}
+
+#endif // HDRVIEW_TEST_LCMS_TESTBED_DIR
 
 #ifdef HDRVIEW_TEST_J2K_DIR
 

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -1,0 +1,447 @@
+//
+// Copyright (C) Wojciech Jarosz. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can
+// be found in the LICENSE.txt file.
+//
+
+#include <doctest/doctest.h>
+
+#include "colorspace.h"
+#include "image.h"
+#include "imageio/j2k.h"
+
+#include "test_support.h"
+
+#include <openjpeg.h>
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace hdrview_test;
+
+namespace
+{
+
+/// Options that leave the decoded samples as the codestream stored them, normalized to [0,1].
+ImageLoadOptions raw_load_options()
+{
+    ImageLoadOptions opts;
+    opts.override_profile = true;
+    opts.tf_override      = TransferFunction::Linear;
+    opts.gamut_override   = ColorGamut_sRGB_BT709;
+    return opts;
+}
+
+/// One component of a codestream to be built by encode_with_openjpeg().
+struct Component
+{
+    uint32_t             prec = 8;
+    bool                 sgnd = false;
+    uint32_t             dx = 1, dy = 1;
+    std::vector<int32_t> samples; ///< dx/dy-subsampled, so ceil(w/dx) x ceil(h/dy) of them
+};
+
+struct OutStream
+{
+    std::string bytes;
+    size_t      pos = 0;
+};
+
+OPJ_SIZE_T out_write(void *buffer, OPJ_SIZE_T count, void *user_data)
+{
+    auto *o = static_cast<OutStream *>(user_data);
+    if (o->pos + count > o->bytes.size())
+        o->bytes.resize(o->pos + count);
+    std::memcpy(&o->bytes[o->pos], buffer, count);
+    o->pos += count;
+    return count;
+}
+
+OPJ_OFF_T out_skip(OPJ_OFF_T count, void *user_data)
+{
+    auto *o = static_cast<OutStream *>(user_data);
+    o->pos += (size_t)count;
+    if (o->pos > o->bytes.size())
+        o->bytes.resize(o->pos);
+    return count;
+}
+
+OPJ_BOOL out_seek(OPJ_OFF_T offset, void *user_data)
+{
+    auto *o = static_cast<OutStream *>(user_data);
+    o->pos  = (size_t)offset;
+    if (o->pos > o->bytes.size())
+        o->bytes.resize(o->pos);
+    return OPJ_TRUE;
+}
+
+/// A lossless JPEG 2000 file holding `comps` verbatim, built by OpenJPEG rather than by our own writer.
+/**
+    Going straight to the library is what lets these cases cover component shapes HDRView's writer never
+    emits: precisions other than 8, 12 and 16, signed samples, and subsampled components.
+*/
+std::string encode_with_openjpeg(int w, int h, const std::vector<Component> &comps, OPJ_COLOR_SPACE cs,
+                                 OPJ_CODEC_FORMAT format)
+{
+    std::vector<opj_image_cmptparm_t> parms(comps.size());
+    std::memset(parms.data(), 0, parms.size() * sizeof(opj_image_cmptparm_t));
+    for (size_t c = 0; c < comps.size(); ++c)
+    {
+        parms[c].prec = comps[c].prec;
+        parms[c].bpp  = comps[c].prec;
+        parms[c].sgnd = comps[c].sgnd ? 1 : 0;
+        parms[c].dx   = comps[c].dx;
+        parms[c].dy   = comps[c].dy;
+        parms[c].w    = (uint32_t)((w + comps[c].dx - 1) / comps[c].dx);
+        parms[c].h    = (uint32_t)((h + comps[c].dy - 1) / comps[c].dy);
+    }
+
+    opj_image_t *img = opj_image_create((uint32_t)comps.size(), parms.data(), cs);
+    REQUIRE(img != nullptr);
+    img->x0 = img->y0 = 0;
+    img->x1           = (uint32_t)w;
+    img->y1           = (uint32_t)h;
+    for (size_t c = 0; c < comps.size(); ++c)
+    {
+        REQUIRE(comps[c].samples.size() == (size_t)img->comps[c].w * img->comps[c].h);
+        std::memcpy(img->comps[c].data, comps[c].samples.data(), comps[c].samples.size() * sizeof(int32_t));
+    }
+
+    opj_cparameters_t cp;
+    opj_set_default_encoder_parameters(&cp);
+    cp.tcp_numlayers  = 1;
+    cp.cp_disto_alloc = 1;
+    cp.tcp_rates[0]   = 0.f;
+    cp.irreversible   = 0;
+    cp.numresolution  = 1;
+
+    opj_codec_t *codec = opj_create_compress(format);
+    REQUIRE(codec != nullptr);
+    REQUIRE(opj_setup_encoder(codec, &cp, img));
+
+    OutStream     out;
+    opj_stream_t *stream = opj_stream_create(OPJ_J2K_STREAM_CHUNK_SIZE, OPJ_FALSE);
+    REQUIRE(stream != nullptr);
+    opj_stream_set_user_data(stream, &out, nullptr);
+    opj_stream_set_write_function(stream, out_write);
+    opj_stream_set_skip_function(stream, out_skip);
+    opj_stream_set_seek_function(stream, out_seek);
+
+    const bool ok =
+        opj_start_compress(codec, img, stream) && opj_encode(codec, stream) && opj_end_compress(codec, stream);
+    opj_stream_destroy(stream);
+    opj_destroy_codec(codec);
+    opj_image_destroy(img);
+    REQUIRE(ok);
+
+    out.bytes.resize(out.pos);
+    return out.bytes;
+}
+
+/// A gray codestream whose samples run over the whole range `prec` and `sgnd` can hold.
+std::string ramp_codestream(uint32_t prec, bool sgnd, int w, int h, std::vector<int32_t> &wrote,
+                            OPJ_CODEC_FORMAT format = OPJ_CODEC_JP2)
+{
+    const int64_t top = ((int64_t)1 << (prec - (sgnd ? 1 : 0))) - 1;
+    const int64_t bot = sgnd ? -top : 0;
+
+    wrote.clear();
+    for (int i = 0; i < w * h; ++i) wrote.push_back((int32_t)(bot + (top - bot) * i / std::max(1, w * h - 1)));
+
+    return encode_with_openjpeg(w, h, {{prec, sgnd, 1, 1, wrote}}, OPJ_CLRSPC_GRAY, format);
+}
+
+/// Wraps `payload` in a box of type `type`.
+std::string box(const char type[5], const std::string &payload)
+{
+    std::string out;
+    put(out, (uint32_t)(8 + payload.size()), Endian::Big);
+    out += std::string(type, 4);
+    return out + payload;
+}
+
+/// Splices extra top-level boxes into a JP2 file, just before its codestream box.
+std::string with_extra_boxes(const std::string &jp2, const std::string &extra)
+{
+    const size_t at = jp2.find("jp2c");
+    REQUIRE(at != std::string::npos);
+    return jp2.substr(0, at - 4) + extra + jp2.substr(at - 4);
+}
+
+} // namespace
+
+TEST_CASE("Component precision and signedness decode to the range they encode")
+{
+    // the reader takes any precision up to 31, but OpenJPEG's reversible encoder overflows past 24, so the
+    // sweep stops where a codestream can still be built
+    for (uint32_t prec : {1u, 2u, 4u, 8u, 10u, 12u, 16u, 24u})
+        for (bool sgnd : {false, true})
+        {
+            if (prec == 1 && sgnd)
+                continue; // a signed one-bit component has no magnitude bits
+
+            CAPTURE(prec);
+            CAPTURE(sgnd);
+
+            std::vector<int32_t> wrote;
+            const auto           bytes = ramp_codestream(prec, sgnd, 8, 4, wrote);
+            const auto           img   = load_bytes(load_j2k_image, bytes, "ramp.jp2", raw_load_options());
+            REQUIRE(img);
+            REQUIRE(img->channels.size() == 1);
+            REQUIRE(img->channels[0].bits_per_sample == (int)prec);
+
+            const double top = (double)(((int64_t)1 << (prec - (sgnd ? 1 : 0))) - 1);
+            for (size_t i = 0; i < wrote.size(); ++i)
+                CHECK(img->channels[0](int(i)) == doctest::Approx(wrote[i] / top).epsilon(1e-6));
+        }
+}
+
+TEST_CASE("A subsampled component is upsampled onto the reference grid")
+{
+    const int w = 8, h = 4;
+
+    // luma at full rate, chroma at half in both directions, all three constant per chroma sample so the
+    // expected value at every pixel is the chroma sample covering it
+    std::vector<int32_t> y(w * h), cb((w / 2) * (h / 2)), cr((w / 2) * (h / 2));
+    for (int i = 0; i < w * h; ++i) y[i] = 128;
+    for (size_t i = 0; i < cb.size(); ++i)
+    {
+        cb[i] = int32_t(128 + i);
+        cr[i] = int32_t(128 - (int)i);
+    }
+
+    const auto bytes = encode_with_openjpeg(w, h, {{8, false, 1, 1, y}, {8, false, 2, 2, cb}, {8, false, 2, 2, cr}},
+                                            OPJ_CLRSPC_SRGB, OPJ_CODEC_JP2);
+    const auto img   = load_bytes(load_j2k_image, bytes, "subsampled.jp2", raw_load_options());
+    REQUIRE(img);
+    REQUIRE(img->channels.size() == 3);
+
+    for (int py = 0; py < h; ++py)
+        for (int px = 0; px < w; ++px)
+        {
+            CAPTURE(px);
+            CAPTURE(py);
+            const size_t c = (size_t)(py / 2) * (w / 2) + px / 2;
+            CHECK(img->channels[1](px, py) == doctest::Approx(cb[c] / 255.).epsilon(1e-5));
+            CHECK(img->channels[2](px, py) == doctest::Approx(cr[c] / 255.).epsilon(1e-5));
+        }
+}
+
+TEST_CASE("Both JPEG 2000 syntaxes decode to the same pixels")
+{
+    std::vector<int32_t> wrote;
+    const auto           jp2 = ramp_codestream(12, false, 8, 4, wrote, OPJ_CODEC_JP2);
+    const auto           j2k = ramp_codestream(12, false, 8, 4, wrote, OPJ_CODEC_J2K);
+
+    const auto from_jp2 = load_bytes(load_j2k_image, jp2, "ramp.jp2", raw_load_options());
+    const auto from_j2k = load_bytes(load_j2k_image, j2k, "ramp.j2k", raw_load_options());
+    REQUIRE(from_jp2);
+    REQUIRE(from_j2k);
+    CHECK(samples(from_jp2) == samples(from_j2k));
+
+    // only the boxed syntax records a brand, and only it can carry a color space or metadata
+    CHECK(from_jp2->metadata["header"].contains("Brand"));
+    CHECK_FALSE(from_j2k->metadata["header"].contains("Brand"));
+}
+
+TEST_CASE("A lossy write is smaller than a lossless one and stays close to the samples")
+{
+    const int2 size{64, 64};
+    // smooth content, since a lossy codec's error bound says nothing about a synthetic discontinuity: at
+    // 20:1 OpenJPEG moves a per-pixel sawtooth by the whole range
+    auto img = test_image(size, 3, [&](int c, int x, int y)
+                          { return 0.1f + 0.8f * float(x + y + 4 * c) / float(size.x + size.y + 8); });
+
+    std::ostringstream lossless(std::ios::binary), lossy(std::ios::binary);
+    save_j2k_image(*img, lossless, "a.jp2", 1.f, true, 8, J2KContainer::JP2, TransferFunction::Linear, false);
+    save_j2k_image(*img, lossy, "b.jp2", 1.f, false, 8, J2KContainer::JP2, TransferFunction::Linear, false);
+    CHECK(lossy.str().size() < lossless.str().size());
+
+    const auto decoded = load_bytes(load_j2k_image, lossy.str(), "b.jp2", raw_load_options());
+    REQUIRE(decoded);
+
+    double worst = 0., total = 0.;
+    for (int c = 0; c < 3; ++c)
+        for (int y = 0; y < size.y; ++y)
+            for (int x = 0; x < size.x; ++x)
+            {
+                const double e = std::abs(double(decoded->channels[c](x, y) - img->channels[c](x, y)));
+                worst          = std::max(worst, e);
+                total += e;
+            }
+    CHECK(worst > 0.);
+    CHECK(worst < 0.05);
+    CHECK(total / (3 * size.x * size.y) < 0.01);
+}
+
+TEST_CASE("The sniff accepts both JPEG 2000 syntaxes and nothing else")
+{
+    std::vector<int32_t> wrote;
+    for (const auto &bytes :
+         {ramp_codestream(8, false, 4, 4, wrote, OPJ_CODEC_JP2), ramp_codestream(8, false, 4, 4, wrote, OPJ_CODEC_J2K)})
+    {
+        std::istringstream in(bytes, std::ios::binary);
+        CHECK(is_j2k_image(in));
+        CHECK(in.tellg() == std::streampos(0));
+    }
+
+    // a JPEG SOI, a PNG signature, an ISOBMFF ftyp and an empty file are all near misses
+    for (const std::string &other : {std::string("\xFF\xD8\xFF\xE0", 4), std::string("\x89PNG\r\n\x1A\n", 8),
+                                     std::string("\0\0\0\x18"
+                                                 "ftypavif",
+                                                 12),
+                                     std::string()})
+    {
+        std::istringstream in(other, std::ios::binary);
+        CHECK_FALSE(is_j2k_image(in));
+    }
+}
+
+TEST_CASE("A JP2 file's ICC profile and XMP reach the image")
+{
+    std::vector<int32_t> wrote;
+    const auto           plain = ramp_codestream(8, false, 4, 4, wrote, OPJ_CODEC_JP2);
+
+    const std::string xmp = "<?xpacket begin=\"\"?><x:xmpmeta xmlns:x=\"adobe:ns:meta/\"></x:xmpmeta>";
+    std::string       uuid_payload(16, '\0');
+    const uint8_t     xmp_uuid[16] = {0xBE, 0x7A, 0xCF, 0xCB, 0x97, 0xA9, 0x42, 0xE8,
+                                      0x9C, 0x71, 0x99, 0x94, 0x91, 0xE3, 0xAF, 0xAC};
+    std::memcpy(&uuid_payload[0], xmp_uuid, 16);
+
+    const auto img = load_bytes(load_j2k_image, with_extra_boxes(plain, box("uuid", uuid_payload + xmp)), "meta.jp2");
+    REQUIRE(img);
+    CHECK(std::string(img->xmp_data.begin(), img->xmp_data.end()) == xmp);
+}
+
+TEST_CASE("A JP2 whose codestream OpenJPEG cannot read as a JP2 still decodes from its jp2c box")
+{
+    std::vector<int32_t> wrote;
+    auto                 jp2 = ramp_codestream(8, false, 4, 4, wrote, OPJ_CODEC_JP2);
+
+    // the brand is all that says which family member this is, and a reader that trusts it alone fails here
+    const size_t brand_at = jp2.find("ftyp");
+    REQUIRE(brand_at != std::string::npos);
+    jp2.replace(brand_at + 4, 4, "jpm ");
+    // and the header box is what OpenJPEG's JP2 reader needs, so without it only the fallback can work
+    const size_t header_at = jp2.find("jp2h");
+    REQUIRE(header_at != std::string::npos);
+    jp2.replace(header_at, 4, "junk");
+
+    const auto img = load_bytes(load_j2k_image, jp2, "compound.jpm", raw_load_options());
+    REQUIRE(img);
+    REQUIRE(img->channels.size() == 1);
+    for (size_t i = 0; i < wrote.size(); ++i)
+        CHECK(img->channels[0](int(i)) == doctest::Approx(wrote[i] / 255.).epsilon(1e-5));
+}
+
+TEST_CASE("Truncated and corrupted JPEG 2000 files are refused rather than crashing")
+{
+    std::vector<int32_t> wrote;
+    const auto           valid = ramp_codestream(8, false, 16, 16, wrote, OPJ_CODEC_JP2);
+
+    int decoded = 0, refused = 0;
+    for (size_t cut = 1; cut < valid.size(); cut += 7)
+    {
+        CAPTURE(cut);
+        try
+        {
+            if (load_bytes(load_j2k_image, valid.substr(0, cut), "cut.jp2"))
+                ++decoded;
+        }
+        catch (const std::exception &)
+        {
+            ++refused;
+        }
+    }
+    CHECK(decoded + refused > 0);
+
+    for (size_t at = 0; at < valid.size(); at += 11)
+    {
+        CAPTURE(at);
+        std::string flipped = valid;
+        flipped[at]         = (char)(~(uint8_t)flipped[at]);
+        try
+        {
+            load_bytes(load_j2k_image, flipped, "flipped.jp2");
+        }
+        catch (const std::exception &)
+        {
+        }
+    }
+}
+
+TEST_CASE("A codestream declaring impossible dimensions is refused before it is decoded")
+{
+    std::vector<int32_t> wrote;
+    auto                 j2k = ramp_codestream(8, false, 4, 4, wrote, OPJ_CODEC_J2K);
+
+    // SIZ follows SOC: FF4F FF51 Lsiz(2) Rsiz(2) Xsiz(4) Ysiz(4)
+    REQUIRE(j2k.size() > 16);
+    for (int i = 0; i < 4; ++i)
+    {
+        j2k[8 + i]  = (char)0x7F;
+        j2k[12 + i] = (char)0x7F;
+    }
+
+    CHECK_THROWS_AS(load_bytes(load_j2k_image, j2k, "huge.j2k"), std::exception);
+}
+
+#ifdef HDRVIEW_TEST_J2K_DIR
+
+#include <filesystem>
+
+// A corpus of real files, most derived from one source image, holding what encoders actually emit:
+// palettes, tiles, ICC profiles, several precisions, HTJ2K codestreams, and deliberately damaged files.
+TEST_CASE("Every file in a real JPEG 2000 corpus either decodes or is refused")
+{
+    namespace fs = std::filesystem;
+
+    int decoded = 0, refused = 0, high_throughput = 0;
+    for (const auto &entry : fs::directory_iterator(HDRVIEW_TEST_J2K_DIR))
+    {
+        if (!entry.is_regular_file())
+            continue;
+
+        const auto path = entry.path();
+        CAPTURE(path.filename().string());
+
+        std::ifstream in(path, std::ios::binary);
+        REQUIRE(in.good());
+        if (!is_j2k_image(in))
+            continue;
+
+        try
+        {
+            const auto images = load_j2k_image(in, path.filename().string());
+            REQUIRE_FALSE(images.empty());
+            for (const auto &img : images)
+            {
+                CHECK(img->size().x > 0);
+                CHECK(img->size().y > 0);
+                CHECK_FALSE(img->channels.empty());
+                for (const auto &ch : img->channels) CHECK(ch.size() == img->size());
+                // each header entry is an object of value/string/type/description, as the info panel wants
+                if (img->metadata["header"]["Block coder"].value("value", std::string{}) == "HTJ2K")
+                    ++high_throughput;
+            }
+            ++decoded;
+        }
+        catch (const std::exception &)
+        {
+            ++refused;
+        }
+    }
+
+    CAPTURE(decoded);
+    CAPTURE(refused);
+    CAPTURE(high_throughput);
+    // a corpus that decoded nothing would pass every check above without testing anything
+    CHECK(decoded > 0);
+    CHECK(high_throughput > 0);
+}
+
+#endif // HDRVIEW_TEST_J2K_DIR

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -357,6 +357,19 @@ TEST_CASE("Both JPEG 2000 syntaxes decode to the same pixels")
     CHECK_FALSE(from_j2k->metadata["header"].contains("Brand"));
 }
 
+TEST_CASE("A bit depth the writer does not offer is refused, not quietly changed")
+{
+    auto img = test_image(int2{4, 4}, 3, [](int, int, int) { return 0.5f; });
+
+    std::ostringstream out(std::ios::binary);
+    for (int bits : {8, 10, 12, 16})
+    {
+        CAPTURE(bits);
+        CHECK_NOTHROW(save_j2k_image(*img, out, "a.jp2", 1.f, true, bits));
+    }
+    CHECK_THROWS_AS(save_j2k_image(*img, out, "a.jp2", 1.f, true, 11), std::exception);
+}
+
 TEST_CASE("A lossy write is smaller than a lossless one and stays close to the samples")
 {
     const int2 size{64, 64};

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -591,8 +591,7 @@ TEST_CASE("Every rendition of one photograph decodes to the same picture")
     if (!fs::exists(reference))
         return;
 
-    // load_image() reports a rendition this build cannot read by returning nothing rather than by throwing,
-    // as it does for a CMYK PSD, which stb refuses
+    // load_image() never throws: a file nothing can read comes back as an empty vector, as a CMYK PSD does
     const auto load = [](const fs::path &p, const ImageLoadOptions &opts) -> ImagePtr
     {
         std::ifstream in(p, std::ios::binary);

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -297,6 +297,39 @@ TEST_CASE("A subsampled component is upsampled onto the reference grid")
         }
 }
 
+TEST_CASE("A fourth component is alpha or ink depending on what the color space says")
+{
+    const int              w = 4, h = 2;
+    std::vector<Component> comps;
+    for (int c = 0; c < 4; ++c)
+    {
+        std::vector<int32_t> samples(w * h);
+        for (int i = 0; i < w * h; ++i) samples[i] = (c * 40 + i * 8) % 256;
+        comps.push_back({8, false, 1, 1, samples});
+    }
+
+    // sRGB's fourth component is opacity, and the viewport treats it as such; CMYK's is black ink, and
+    // reading it as opacity would make a dark image transparent
+    const auto rgba = load_bytes(load_j2k_image, encode_with_openjpeg(w, h, comps, OPJ_CLRSPC_SRGB, OPJ_CODEC_JP2),
+                                 "rgba.jp2", raw_load_options());
+    REQUIRE(rgba);
+    REQUIRE(rgba->channels.size() == 4);
+    CHECK(rgba->channels[3].name == "A");
+    CHECK(rgba->transparency != TransparencyType_None);
+
+    const auto cmyk = load_bytes(load_j2k_image, encode_with_openjpeg(w, h, comps, OPJ_CLRSPC_CMYK, OPJ_CODEC_JP2),
+                                 "cmyk.jp2", raw_load_options());
+    REQUIRE(cmyk);
+    REQUIRE(cmyk->channels.size() == 4);
+    CHECK(cmyk->channels[3].name == "K");
+    CHECK(cmyk->transparency == TransparencyType_None);
+
+    // and with nothing to convert the ink with, the samples are left alone rather than guessed at
+    for (int c = 0; c < 4; ++c)
+        for (int i = 0; i < w * h; ++i)
+            CHECK(cmyk->channels[c](i) == doctest::Approx(comps[c].samples[i] / 255.).epsilon(1e-5));
+}
+
 TEST_CASE("Both JPEG 2000 syntaxes decode to the same pixels")
 {
     std::vector<int32_t> wrote;

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -36,6 +36,8 @@ ImageLoadOptions raw_load_options()
     return opts;
 }
 
+int ceil_div(int a, int b) { return (a + b - 1) / b; }
+
 /// One component of a codestream to be built by encode_with_openjpeg().
 struct Component
 {
@@ -86,7 +88,7 @@ OPJ_BOOL out_seek(OPJ_OFF_T offset, void *user_data)
     covered past what a round trip through the writer can reach.
 */
 std::string encode_with_openjpeg(int w, int h, const std::vector<Component> &comps, OPJ_COLOR_SPACE cs,
-                                 OPJ_CODEC_FORMAT format)
+                                 OPJ_CODEC_FORMAT format, int x0 = 0, int y0 = 0)
 {
     std::vector<opj_image_cmptparm_t> parms(comps.size());
     std::memset(parms.data(), 0, parms.size() * sizeof(opj_image_cmptparm_t));
@@ -97,15 +99,24 @@ std::string encode_with_openjpeg(int w, int h, const std::vector<Component> &com
         parms[c].sgnd = comps[c].sgnd ? 1 : 0;
         parms[c].dx   = comps[c].dx;
         parms[c].dy   = comps[c].dy;
-        parms[c].w    = (uint32_t)((w + comps[c].dx - 1) / comps[c].dx);
-        parms[c].h    = (uint32_t)((h + comps[c].dy - 1) / comps[c].dy);
+        // a component holds the grid points from ceil(x0/dx) up to ceil(x1/dx), which is not ceil(w/dx)
+        // once the image has an origin
+        parms[c].w = (uint32_t)(ceil_div(x0 + w, (int)comps[c].dx) - ceil_div(x0, (int)comps[c].dx));
+        parms[c].h = (uint32_t)(ceil_div(y0 + h, (int)comps[c].dy) - ceil_div(y0, (int)comps[c].dy));
     }
 
     opj_image_t *img = opj_image_create((uint32_t)comps.size(), parms.data(), cs);
     REQUIRE(img != nullptr);
-    img->x0 = img->y0 = 0;
-    img->x1           = (uint32_t)w;
-    img->y1           = (uint32_t)h;
+    // the reference grid carries absolute edges, so an image with an origin runs from x0 to x0 + w
+    img->x0 = (uint32_t)x0;
+    img->y0 = (uint32_t)y0;
+    img->x1 = (uint32_t)(x0 + w);
+    img->y1 = (uint32_t)(y0 + h);
+    for (size_t c = 0; c < comps.size(); ++c)
+    {
+        img->comps[c].x0 = (uint32_t)ceil_div(x0, (int)comps[c].dx);
+        img->comps[c].y0 = (uint32_t)ceil_div(y0, (int)comps[c].dy);
+    }
     for (size_t c = 0; c < comps.size(); ++c)
     {
         REQUIRE(comps[c].samples.size() == (size_t)img->comps[c].w * img->comps[c].h);
@@ -229,9 +240,35 @@ TEST_CASE("Component precision and signedness decode to the range they encode")
         }
 }
 
+TEST_CASE("An image whose origin is not at zero decodes at the size it covers")
+{
+    const int            w = 6, h = 4;
+    std::vector<int32_t> samples(w * h);
+    for (int i = 0; i < w * h; ++i) samples[i] = i * 4;
+
+    for (auto origin : {std::pair{0, 0}, std::pair{1, 0}, std::pair{17, 12}})
+    {
+        CAPTURE(origin.first);
+        CAPTURE(origin.second);
+
+        const auto bytes = encode_with_openjpeg(w, h, {{8, false, 1, 1, samples}}, OPJ_CLRSPC_GRAY, OPJ_CODEC_JP2,
+                                                origin.first, origin.second);
+        const auto img   = load_bytes(load_j2k_image, bytes, "offset.jp2", raw_load_options());
+        REQUIRE(img);
+
+        // the image is what the grid covers, x1 - x0, not what its far edge is numbered
+        CHECK(img->size().x == w);
+        CHECK(img->size().y == h);
+        for (int i = 0; i < w * h; ++i) CHECK(img->channels[0](i) == doctest::Approx(samples[i] / 255.).epsilon(1e-5));
+    }
+}
+
 TEST_CASE("A subsampled component is upsampled onto the reference grid")
 {
     const int w = 8, h = 4;
+    // an origin as well, since a component's own origin is ceil(x0/dx): addressing that mixes the two grids
+    // agrees with addressing that does not until both are in play at once
+    const int x0 = 16, y0 = 12;
 
     // luma at full rate, chroma at half in both directions, all three constant per chroma sample so the
     // expected value at every pixel is the chroma sample covering it
@@ -244,7 +281,7 @@ TEST_CASE("A subsampled component is upsampled onto the reference grid")
     }
 
     const auto bytes = encode_with_openjpeg(w, h, {{8, false, 1, 1, y}, {8, false, 2, 2, cb}, {8, false, 2, 2, cr}},
-                                            OPJ_CLRSPC_SRGB, OPJ_CODEC_JP2);
+                                            OPJ_CLRSPC_SRGB, OPJ_CODEC_JP2, x0, y0);
     const auto img   = load_bytes(load_j2k_image, bytes, "subsampled.jp2", raw_load_options());
     REQUIRE(img);
     REQUIRE(img->channels.size() == 3);

--- a/tests/test_j2k_io.cpp
+++ b/tests/test_j2k_io.cpp
@@ -579,50 +579,82 @@ TEST_CASE("Every file in a real JPEG 2000 corpus either decodes or is refused")
     CHECK(decoded > 0);
 }
 
-// The same photograph saved twice by Photoshop, once RGB and once CMYK, which is the only way to check the
-// ink conversion end to end: the profile that drives it is half a megabyte and cannot be vendored here.
-TEST_CASE("A CMYK rendition agrees with the RGB one of the same photograph")
+// One photograph saved by Photoshop in several formats and color modes, which is the only way to check the
+// ink conversion end to end: the CMYK profile that drives it is half a megabyte and cannot be vendored here.
+// Every rendition should read back as the same picture, whatever loader and color space it arrives through.
+TEST_CASE("Every rendition of one photograph decodes to the same picture")
 {
     namespace fs = std::filesystem;
 
-    const fs::path dir  = HDRVIEW_TEST_J2K_DIR;
-    const fs::path rgb  = dir / "buddha-rgb.jpf";
-    const fs::path cmyk = dir / "buddha-cmyk.jpf";
-    if (!fs::exists(rgb) || !fs::exists(cmyk))
+    const fs::path dir       = HDRVIEW_TEST_J2K_DIR;
+    const fs::path reference = dir / "buddha-rgb.jpf";
+    if (!fs::exists(reference))
         return;
 
-    const auto load = [](const fs::path &p, const ImageLoadOptions &opts)
+    // load_image() reports a rendition this build cannot read by returning nothing rather than by throwing,
+    // as it does for a CMYK PSD, which stb refuses
+    const auto load = [](const fs::path &p, const ImageLoadOptions &opts) -> ImagePtr
     {
         std::ifstream in(p, std::ios::binary);
         REQUIRE(in.good());
-        auto images = load_j2k_image(in, p.filename().string(), opts);
+        auto images = load_image(in, p.filename().string(), opts);
+        if (images.empty())
+            return nullptr;
         REQUIRE(images.size() == 1);
         return images.front();
     };
 
-    // first as the app loads it: CMYK has no primaries of its own to keep, so the profile has to be applied
-    // even under the default that keeps them
-    CHECK(load(cmyk, ImageLoadOptions{})->metadata.value("color profile", std::string{}).find("SWOP") !=
-          std::string::npos);
+    // both sides to sRGB primaries, which is what makes renditions in different spaces comparable
+    ImageLoadOptions comparable;
+    comparable.keep_primaries = false;
+    const auto want           = load(reference, comparable);
+    REQUIRE(want);
 
-    // then both to sRGB primaries, which is what makes the two directly comparable
-    ImageLoadOptions opts;
-    opts.keep_primaries = false;
-    const auto a = load(rgb, opts), b = load(cmyk, opts);
-    REQUIRE(a->size() == b->size());
-    REQUIRE(a->channels.size() == 3);
-    // the conversion writes RGB over the four ink channels and leaves the fourth opaque
-    REQUIRE(b->channels.size() == 4);
-    // SWOP's gamut is far short of the RGB rendition's, so saturated pixels clip; the average is what says
-    // the ink was read the right way up, since reading it inverted puts this above 0.25
-    for (int c = 0; c < 3; ++c)
+    int compared = 0;
+    for (const auto &entry : fs::directory_iterator(dir))
     {
-        CAPTURE(c);
-        double sum = 0.;
-        for (int y = 0; y < a->size().y; ++y)
-            for (int x = 0; x < a->size().x; ++x) sum += std::abs(double(a->channels[c](x, y) - b->channels[c](x, y)));
-        CHECK(sum / ((double)a->size().x * a->size().y) < 0.05);
+        const auto path = entry.path();
+        if (!entry.is_regular_file() || path.filename().string().rfind("buddha-", 0) != 0 || path == reference)
+            continue;
+
+        CAPTURE(path.filename().string());
+        const string name = path.filename().string();
+        const bool   cmyk = name.find("-cmyk") != string::npos;
+
+        // A CMYK TIFF is left out because it is a standing bug in the TIFF loader, not in anything this
+        // file covers: libtiff's RGBA interface converts the ink itself, ignoring the profile, and
+        // tiff.cpp applies no transfer function when an ICC profile fails to apply, so the image reads
+        // back about twice as bright as it should.
+        if (cmyk && (name.find(".tif") != string::npos))
+            continue;
+
+        // first as the app loads it. A CMYK profile has no primaries of its own to keep, so it has to be
+        // applied even under the default that keeps them, and its name is what says that it was.
+        const auto as_shown = load(path, ImageLoadOptions{});
+        if (!as_shown)
+            continue;
+        if (cmyk)
+            CHECK(as_shown->metadata.value("color profile", std::string{}).find("SWOP") != string::npos);
+
+        const auto got = load(path, comparable);
+        REQUIRE(got);
+        REQUIRE(got->size() == want->size());
+
+        // a CMYK rendition clips where SWOP's gamut falls short, and the lossy ones move samples, so the
+        // average is what carries: ink read the wrong way up puts this above 0.25
+        for (int c = 0; c < 3; ++c)
+        {
+            CAPTURE(c);
+            double sum = 0.;
+            for (int y = 0; y < want->size().y; ++y)
+                for (int x = 0; x < want->size().x; ++x)
+                    sum += std::abs(double(want->channels[c](x, y) - got->channels[c](x, y)));
+            CHECK(sum / ((double)want->size().x * want->size().y) < 0.05);
+        }
+        ++compared;
     }
+    CAPTURE(compared);
+    CHECK(compared > 0);
 }
 
 #endif // HDRVIEW_TEST_J2K_DIR

--- a/tests/test_tiff_io.cpp
+++ b/tests/test_tiff_io.cpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <cstring>
+#include <fstream>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -83,6 +84,35 @@ std::vector<unsigned char> tiff_raw_samples(const std::string &bytes)
     return {bytes.begin() + offset, bytes.begin() + offset + count};
 }
 
+#ifdef HDRVIEW_TEST_LCMS_TESTBED_DIR
+/// A 2x1 8-bit CMYK uncompressed TIFF carrying `icc`; pixel 0 is bare paper, pixel 1 a solid hit of black.
+std::string cmyk_tiff(const std::string &icc)
+{
+    std::vector<TiffEntry> entries{
+        {256, 4, 1, 2, {}},                       // ImageWidth
+        {257, 4, 1, 1, {}},                       // ImageLength
+        {258, 3, 4, 0, {8, 0, 8, 0, 8, 0, 8, 0}}, // BitsPerSample
+        {259, 3, 1, 1, {}},                       // Compression: none
+        {262, 3, 1, 5, {}},                       // Photometric: SEPARATED, which is to say ink
+        {277, 3, 1, 4, {}},                       // SamplesPerPixel
+        {278, 4, 1, 1, {}},                       // RowsPerStrip
+        {284, 3, 1, 1, {}},                       // PlanarConfiguration: chunky
+        {332, 3, 1, 1, {}},                       // InkSet: CMYK
+        {34675, 7, (uint32_t)icc.size(), 0, std::vector<uint8_t>(icc.begin(), icc.end())}, // ICCProfile
+    };
+
+    return tiff_bytes(Endian::Little, entries, {0, 0, 0, 0, 0, 0, 0, 0xff});
+}
+
+/// lcms's own CMYK printer profile, which libjxl carries in-tree.
+std::string cmyk_profile()
+{
+    std::ifstream in(std::string(HDRVIEW_TEST_LCMS_TESTBED_DIR) + "/test1.icc", std::ios::binary);
+    REQUIRE(in.good());
+    return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+#endif
+
 ImagePtr load_tiff(const std::string &bytes)
 {
     auto img = load_bytes(load_tiff_image, bytes, "rgba.tif");
@@ -150,6 +180,28 @@ TEST_CASE("What a TIFF declares about its fourth sample, and what an override do
             CHECK(img->groups[1].type == ChannelGroup::Single_Channel);
         }
     }
+
+#ifdef HDRVIEW_TEST_LCMS_TESTBED_DIR
+    // A separated image's fourth sample is black ink and never coverage, whatever EXTRASAMPLES is absent.
+    // Reading it as alpha would make the solid black pixel transparent instead of dark.
+    {
+        auto img = load_bytes(cmyk_tiff(cmyk_profile()), "cmyk.tif");
+        REQUIRE(img);
+        CHECK(img->transparency == TransparencyType_None);
+        CHECK_FALSE(img->alpha_is_transparency());
+
+        // the profile is what converts the ink, and applying it means the loader read the four samples
+        // itself rather than taking libtiff's RGBA interface, which converts them by a formula of its own
+        CHECK(img->metadata.value("color profile", std::string{}).find("Test profile") != std::string::npos);
+        REQUIRE(img->channels.size() >= 3);
+        for (int c = 0; c < 3; ++c)
+        {
+            CAPTURE(c);
+            CHECK(img->channels[c](0, 0) > 0.5f); // bare paper
+            CHECK(img->channels[c](1, 0) < 0.2f); // solid black
+        }
+    }
+#endif
 }
 
 TEST_CASE("A TIFF's alpha kind decides how many times its samples are multiplied by coverage")


### PR DESCRIPTION
`HDRVIEW_ENABLE_J2K` has been on for a while, but it only ever configured libheif's plugins, so a JPEG 2000 codestream was readable inside an ISOBMFF item and a plain `.jp2` was not — `is_heif_image()` wants `"ftyp"` at byte 4, where a JP2 has `"jP  "`, so those files fell through every loader.

`imageio/j2k.cpp` reads both syntaxes (the boxed JP2 file format and a bare codestream) and writes them, on OpenJPEG, which the tree already carried for libheif. Testing it against real files then turned up a set of colour bugs in the **shared** ICC code, which is why this PR reaches past JPEG 2000.

## JPEG 2000

- **OpenJPEG decodes HTJ2K.** Its `ht_dec.c` has handled high-throughput codestreams since 2.5.0, so Part 15 needs no second library: `.jph` and `.jhc` files from OpenJPH, OpenHTJ2K, Grok and OpenJPEG itself all decode, and Rsiz bit 14 reports which block coder a file wanted.
- **Components are read individually**, not as a packed image, since a codestream need not have one sample layout: each carries its own precision, signedness and sampling on the reference grid. Chroma at half rate, an ERDAS file's 8-bit RGB beside a 1-bit alpha mask, and a 257-component conformance file all read correctly.
- OpenJPEG is now fetched whenever no installed copy answers, rather than only under Emscripten. That closes a build hole: Windows CI installs no openjpeg, so J2K-in-HEIF has never decoded in a Windows build. `.hej2` also joins `Image::loadable_formats()`, which had nothing for the HEIF-wrapped J2K the app could already decode.

## CMYK and ICC, across formats

A Photoshop-written CMYK JP2 showed that `ICCProfile::linearize_pixels()` **abandoned the transform for any CMYK profile** under its default `keep_primaries`: it asks `linearized_profile()` for the output, which reads RGB colorants that CMYK has none of, so it gave up and the caller fell through to treating ink as sRGB. Every CMYK JPEG HDRView has opened was affected the same way.

Then the ink came out inverted. lcms wants CMYK in [0,100] with 100 as full ink, and the scaling was `(1 - v) * 100` unconditionally, right for Adobe's JPEGs and backwards for JPEG 2000 and TIFF. Nothing in a profile says which way a file stores it, so the caller now does, via `cmyk_is_inverted` (defaulted to true, so JPEG and JPEG XL keep the behaviour they were written against).

A CMYK **TIFF** needed two more: `tiff.cpp` treated the ICC profile as terminal and applied no transfer function at all when one failed — reaching any TIFF whose profile cannot be applied, not just CMYK ones — and libtiff's RGBA interface converted the ink by its own formula without ever reading the profile. A CMYK TIFF with a profile now takes the ordinary read path and reaches `ICCProfile` with its four samples intact.

Recoverable EXIF trouble is a warning rather than an error, and `load_image()`'s contract is written down: it never throws, and reports failure by returning nothing.

## Measured

One photograph saved seven ways, all brought to sRGB primaries and compared against the RGB JPEG 2000. Mean absolute error per channel:

| rendition | before | after |
|---|---|---|
| CMYK JP2 | 0.27 | **0.010** |
| CMYK JPEG | profile dropped | **0.012** |
| CMYK TIFF | 0.199 (2x too bright) | **0.011** |
| RGB JPEG / JXL / TIFF / AVIF | — | 0.010–0.013 |

## Tests

The three JPEG 2000 writers join `test_export_roundtrip.cpp`'s existing sweep. `tests/test_j2k_io.cpp` takes the decode side: precision and signedness from 1 to 24 bits, subsampled components, images whose origin is not at zero, both syntaxes agreeing pixel for pixel, the `jp2c` fallback, EXIF and XMP through `finalize()`, and truncation and bit flips at every offset. All synthetic, so all of it runs in CI.

The CMYK cases went into the tests that already ask their question rather than into a file of their own: the conversion beside the gray+alpha cases in `test_icc_gray_alpha.cpp`, where it reaches `ICCProfile` directly and so covers every format at once, and the TIFF reading into `test_tiff_io.cpp`'s "What a TIFF declares about its fourth sample". **Both run in CI**, on the CMYK printer profile lcms ships in its testbed, which libjxl carries in-tree — no fixture is vendored.

Mutation-checked throughout: the normalization divisor fails 425 assertions, the component addressing 56, the image origin 39, the writer's bit-depth shift 23, the CMYK inversion 3, the TIFF routing 1, and a separated image's fourth sample 2. Three tests that could never have failed were found this way and fixed.

Two sweeps stay opt-in, needing data that cannot be vendored: `HDRVIEW_TEST_J2K_DIR` points at a JPEG 2000 corpus (against `openpreserve/jpylyzer-test-files` the loader decodes 70 files and refuses 29, every refusal one that set marks invalid) and, if the renditions of one photograph are beside it, compares them.

## Still open

- **JPEG XL CMYK** is unverified — neither `cjxl` nor Photoshop will write one. It shares the fixed code path; only its ink convention is unconfirmed, and it keeps the previous default.
- CMYK renditions disagree about the `transparency` they report across loaders.
- A CMYK PSD does not load at all: stb refuses non-RGB PSDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)