### PR TITLE
Drop the ICC profile serializer nothing calls

### DIFF
--- a/src/imageio/icc.cpp
+++ b/src/imageio/icc.cpp
@@ -449,21 +449,6 @@ bool ICCProfile::linearize_pixels(float *pixels, int3 size, bool keep_primaries,
     return false;
 }
 
-std::vector<uint8_t> ICCProfile::dump_to_memory() const
-{
-    if (!valid())
-        return {};
-
-    std::vector<uint8_t> data;
-    cmsUInt32Number      size;
-    cmsSaveProfileToMem(get(), nullptr, &size);
-    data.resize(size);
-    if (cmsSaveProfileToMem(get(), reinterpret_cast<void *>(data.data()), &size))
-        return data;
-
-    return {};
-}
-
 #else
 
 // Stubs for builds without LCMS2 which just return failure for operations that require LCMS functionality.
@@ -473,16 +458,15 @@ ICCProfile::ICCProfile(const uint8_t *icc_profile, size_t icc_profile_size) : m_
     parse_icc_cicp_tag(icc_profile, icc_profile_size, m_cicp);
 }
 ICCProfile::~ICCProfile() {}
-ICCProfile           ICCProfile::linear_RGB(const Chromaticities           &/*chr*/) { return ICCProfile(nullptr); }
-ICCProfile           ICCProfile::linear_Gray(const float2           &/*whitepoint*/) { return ICCProfile(nullptr); }
-ICCProfile           ICCProfile::linearized_profile(Chromaticities           */*c*/) const { return ICCProfile(nullptr); }
-int                  ICCProfile::lcms_version() { return 0; }
-std::string          ICCProfile::description() const { return std::string(); }
-bool                 ICCProfile::extract_chromaticities(Chromaticities                 */*c*/) const { return false; }
-std::vector<uint8_t> ICCProfile::dump_to_memory() const { return {}; }
-bool                 ICCProfile::is_CMYK() const { return false; }
-bool                 ICCProfile::is_RGB() const { return false; }
-bool                 ICCProfile::is_Gray() const { return false; }
+ICCProfile  ICCProfile::linear_RGB(const Chromaticities  &/*chr*/) { return ICCProfile(nullptr); }
+ICCProfile  ICCProfile::linear_Gray(const float2  &/*whitepoint*/) { return ICCProfile(nullptr); }
+ICCProfile  ICCProfile::linearized_profile(Chromaticities  */*c*/) const { return ICCProfile(nullptr); }
+int         ICCProfile::lcms_version() { return 0; }
+std::string ICCProfile::description() const { return std::string(); }
+bool        ICCProfile::extract_chromaticities(Chromaticities        */*c*/) const { return false; }
+bool        ICCProfile::is_CMYK() const { return false; }
+bool        ICCProfile::is_RGB() const { return false; }
+bool        ICCProfile::is_Gray() const { return false; }
 
 bool ICCProfile::transform_pixels(float * /*pixels*/, int3 /*size*/, const ICCProfile & /*profile_in*/,
                                   const ICCProfile & /*profile_out*/, bool /*cmyk_is_inverted*/)

--- a/src/imageio/icc.h
+++ b/src/imageio/icc.h
@@ -98,8 +98,6 @@ public:
     */
     CICPProfile cicp() const;
 
-    std::vector<uint8_t> dump_to_memory() const;
-
     bool is_CMYK() const; ///< Check if this is a CMYK profile.
     bool is_RGB() const;  ///< Check if this is a RGB profile.
     bool is_Gray() const; ///< Check if this is a Grayscale profile.


### PR DESCRIPTION
`ICCProfile::dump_to_memory()` serializes a parsed profile back to bytes. Nothing has ever called it.

It arrived with the `ICCProfile` class in f9f6e34 (Dec 2025) and `git log -S` over the whole history turns up only that commit — no call site has ever existed, on any branch, in `src/`, `tests/` or `tests/gui/`.

## Why nothing is waiting on it

The question worth asking is whether some export path *should* have been using it and simply never got wired up. It shouldn't:

- **No writer embeds a color profile at all.** There is no `png_set_iCCP`, no `TIFFTAG_ICCPROFILE`, no `JxlEncoderSetICCProfile`, and `save_heif_image` sets no nclx either. Every use of nclx in `heif.cpp` is on the decode side. Exports rely on being written in a stated space instead.
- **A writer that did embed one wouldn't need this.** `Image::icc_data` already holds the file's original profile bytes, so passthrough embedding writes those directly.

Serialization only earns its place alongside a profile HDRView *synthesizes* to describe the export — say `linear_RGB(chr)` for a linear TIFF. That's a feature, not a missing line, and it can bring back whatever shape it needs.

## Verification

- `git grep` across all tracked files, plus untracked, plus `origin/feature/user-annotations` — the three hits are the declaration and its two definitions.
- 322 tests pass; `HDRView --help` runs.
- The stub half of the change is in the `#else` branch for builds without LCMS2, which **no configuration compiles** — `find_package(LCMS2 REQUIRED)` makes `HDRVIEW_ENABLE_LCMS2=1` unconditional. I compiled `icc.cpp` directly with it forced to `0` to confirm that path still builds.

## On the diff size

Removing the declaration takes the longest type out of an aligned run of stubs, so clang-format narrows the other nine. That realignment is the only other change in the file — checked by formatting the whole file under `.clang-format` and confirming those nine lines are the sole difference.

## Noted, not acted on

That whole `#else` stub block is unreachable for the same reason: LCMS2 cannot be turned off. Worth deciding separately whether it is a fallback worth keeping or should follow this function out.
