### PR TITLE
Let each annotation size say whether it is image or screen pixels

### DIFF
--- a/src/annotations.cpp
+++ b/src/annotations.cpp
@@ -446,8 +446,13 @@ int handle_at(const Annotation &a, float2 screen_pos, const VgTransform &xform, 
     float2    handles[Annotation::MaxHandles];
     const int count = annotation_handles(a, handles, &xform);
     for (int i = 0; i < count; ++i)
-        if (length(xform.to_screen(handles[i]) - screen_pos) <= radius)
+    {
+        // A handle is drawn as a square of this half-size, so the square is what answers: measured as a
+        // radius, its own corners fall outside it, and those are what a corner handle is grabbed by.
+        const float2 d = abs(xform.to_screen(handles[i]) - screen_pos);
+        if (std::max(d.x, d.y) <= radius)
             return i;
+    }
     return -1;
 }
 

--- a/src/annotations.cpp
+++ b/src/annotations.cpp
@@ -77,10 +77,11 @@ void append_arrow(std::vector<VgCommand> &out, const Annotation &a, float scale)
     const float2 dir  = along / length;
     const float2 perp = float2{-dir.y, dir.x};
 
-    // The head is proportioned in screen pixels, like the stroke it terminates, and goes out in image
-    // coordinates with the rest of the geometry; hence the division by the scale.
-    const float head_len =
-        std::min(k_head_length * a.stroke_width / std::max(scale, 1e-6f), k_max_head_fraction * length);
+    // The head is proportioned in multiples of the stroke and goes out in image coordinates with the rest
+    // of the geometry, so the stroke is brought into them first: a screen-pixel one by way of the zoom, an
+    // image-pixel one being there already.
+    const float  stroke    = a.stroke_width * stroke_width_scale(a, scale) / std::max(scale, 1e-6f);
+    const float  head_len  = std::min(k_head_length * stroke, k_max_head_fraction * length);
     const float  head_half = head_len * (k_head_half_width / k_head_length);
     const float2 base      = a.p1() - dir * head_len;
 
@@ -362,16 +363,22 @@ void screen_extent(const Annotation &a, const VgTransform &xform, float2 &lo, fl
 
 } // namespace
 
+float font_size_scale(const Annotation &a, float scale) { return a.font_size_relative ? std::max(scale, 1e-6f) : 1.f; }
+
+float stroke_width_scale(const Annotation &a, float scale)
+{
+    return a.stroke_width_relative ? std::max(scale, 1e-6f) : 1.f;
+}
+
 bool text_extent(const Annotation &a, const VgTransform &xform, float2 &lo, float2 &extent)
 {
     if (a.shape != Annotation::Shape::Text || !xform.measure_text)
         return false;
 
-    // Measured at the size that is stored, which keeps the glyphs baked at one size however far the view
-    // is zoomed. Measuring is linear in the size, so what comes back scales into image coordinates: a
-    // relative size is already in them, and an absolute one is screen pixels and divides by the zoom.
+    // Measured at the size that is stored, which keeps the glyphs baked at one size however far the view is
+    // zoomed, then taken to the screen and back down into image coordinates.
     const float2 measured = xform.measure_text(a.font_face, a.font_size, a.text);
-    extent                = a.font_size_relative ? measured : measured / std::max(xform.scale, 1e-6f);
+    extent                = measured * font_size_scale(a, xform.scale) / std::max(xform.scale, 1e-6f);
     lo                    = a.p0() - text_anchor_offset(a.text_align, extent);
 
     // Zero wide until something is typed, but a line tall from the start, so a text annotation shows where
@@ -454,7 +461,7 @@ int annotation_at(const std::vector<Annotation> &annotations, float2 screen_pos,
 
         // The stroke straddles the outline, so half of it widens the target along with the slop; a
         // relative width is in image pixels and has to be brought up to the screen to be added to them.
-        const float stroke = a.stroke_width * (a.stroke_width_relative ? xform.scale : 1.f);
+        const float stroke = a.stroke_width * stroke_width_scale(a, xform.scale);
         const float tol    = slop + stroke * 0.5f;
         const bool  filled = a.fill_color.w > 0.f;
 

--- a/src/annotations.cpp
+++ b/src/annotations.cpp
@@ -106,18 +106,20 @@ void append_arrow(std::vector<VgCommand> &out, const Annotation &a, float scale)
 
 void to_json(json &j, const Annotation &a)
 {
-    j              = json::object();
-    j["shape"]     = g_shape_ids[size_t(a.shape) < std::size(g_shape_ids) ? size_t(a.shape) : 0];
-    j["points"]    = a.points;
-    j["stroke"]    = a.stroke_color;
-    j["fill"]      = a.fill_color;
-    j["width"]     = a.stroke_width;
-    j["font_size"] = a.font_size;
-    j["font_face"] = a.font_face;
-    j["align"]     = a.text_align;
-    j["smooth"]    = a.smooth;
-    j["visible"]   = a.visible;
-    j["locked"]    = a.locked;
+    j                   = json::object();
+    j["shape"]          = g_shape_ids[size_t(a.shape) < std::size(g_shape_ids) ? size_t(a.shape) : 0];
+    j["points"]         = a.points;
+    j["stroke"]         = a.stroke_color;
+    j["fill"]           = a.fill_color;
+    j["width"]          = a.stroke_width;
+    j["font_size"]      = a.font_size;
+    j["font_face"]      = a.font_face;
+    j["width_relative"] = a.stroke_width_relative;
+    j["size_relative"]  = a.font_size_relative;
+    j["align"]          = a.text_align;
+    j["smooth"]         = a.smooth;
+    j["visible"]        = a.visible;
+    j["locked"]         = a.locked;
 
     // Omitted when empty, which is the common case: a shape with no text and no label of its own.
     if (!a.text.empty())
@@ -146,15 +148,17 @@ void from_json(const json &j, Annotation &a)
     if (j.contains("fill"))
         j.at("fill").get_to(a.fill_color);
 
-    a.stroke_width = j.value("width", a.stroke_width);
-    a.font_size    = j.value("font_size", a.font_size);
-    a.font_face    = j.value<std::string>("font_face", a.font_face);
-    a.text_align   = j.value("align", a.text_align);
-    a.smooth       = j.value("smooth", a.smooth);
-    a.visible      = j.value("visible", a.visible);
-    a.locked       = j.value("locked", a.locked);
-    a.text         = j.value<std::string>("text", a.text);
-    a.label        = j.value<std::string>("label", a.label);
+    a.stroke_width          = j.value("width", a.stroke_width);
+    a.font_size             = j.value("font_size", a.font_size);
+    a.font_face             = j.value<std::string>("font_face", a.font_face);
+    a.stroke_width_relative = j.value("width_relative", a.stroke_width_relative);
+    a.font_size_relative    = j.value("size_relative", a.font_size_relative);
+    a.text_align            = j.value("align", a.text_align);
+    a.smooth                = j.value("smooth", a.smooth);
+    a.visible               = j.value("visible", a.visible);
+    a.locked                = j.value("locked", a.locked);
+    a.text                  = j.value<std::string>("text", a.text);
+    a.label                 = j.value<std::string>("label", a.label);
 }
 
 const std::vector<AnnotationFace> &annotation_font_faces()
@@ -207,14 +211,16 @@ void append_vg_commands(std::vector<VgCommand> &out, const Annotation &a, float 
     {
         // The interpreter draws text in the *fill* color, so the one color the user picked goes there.
         out.push_back(cmd(VgCommand::Type::FontFace, {}, a.font_face));
-        out.push_back(cmd(VgCommand::Type::FontSize, {a.font_size, float(VgCommand::Relative)}));
+        out.push_back(cmd(VgCommand::Type::FontSize,
+                          {a.font_size, float(a.font_size_relative ? VgCommand::Relative : VgCommand::Absolute)}));
         out.push_back(cmd(VgCommand::Type::TextAlign, {float(a.text_align)}));
         out.push_back(cmd(VgCommand::Type::FillColor, color_floats(a.stroke_color)));
         out.push_back(cmd(VgCommand::Type::Text, {a.p0().x, a.p0().y}, a.text));
         return;
     }
 
-    out.push_back(cmd(VgCommand::Type::StrokeWidth, {a.stroke_width, float(VgCommand::Absolute)}));
+    out.push_back(cmd(VgCommand::Type::StrokeWidth,
+                      {a.stroke_width, float(a.stroke_width_relative ? VgCommand::Relative : VgCommand::Absolute)}));
     out.push_back(cmd(VgCommand::Type::StrokeColor, color_floats(a.stroke_color)));
 
     if (a.shape == Annotation::Shape::Arrow)
@@ -361,10 +367,12 @@ bool text_extent(const Annotation &a, const VgTransform &xform, float2 &lo, floa
     if (a.shape != Annotation::Shape::Text || !xform.measure_text)
         return false;
 
-    // Measured at the size that is stored, which is already image pixels, so what comes back is the box in
-    // image coordinates with no zoom in it either way.
-    extent = xform.measure_text(a.font_face, a.font_size, a.text);
-    lo     = a.p0() - text_anchor_offset(a.text_align, extent);
+    // Measured at the size that is stored, which keeps the glyphs baked at one size however far the view
+    // is zoomed. Measuring is linear in the size, so what comes back scales into image coordinates: a
+    // relative size is already in them, and an absolute one is screen pixels and divides by the zoom.
+    const float2 measured = xform.measure_text(a.font_face, a.font_size, a.text);
+    extent                = a.font_size_relative ? measured : measured / std::max(xform.scale, 1e-6f);
+    lo                    = a.p0() - text_anchor_offset(a.text_align, extent);
     return extent.x > 0.f && extent.y > 0.f;
 }
 
@@ -441,8 +449,10 @@ int annotation_at(const std::vector<Annotation> &annotations, float2 screen_pos,
         if (!a.visible || a.locked)
             continue;
 
-        // The stroke straddles the outline, so half of it widens the target along with the slop.
-        const float tol    = slop + a.stroke_width * 0.5f;
+        // The stroke straddles the outline, so half of it widens the target along with the slop; a
+        // relative width is in image pixels and has to be brought up to the screen to be added to them.
+        const float stroke = a.stroke_width * (a.stroke_width_relative ? xform.scale : 1.f);
+        const float tol    = slop + stroke * 0.5f;
         const bool  filled = a.fill_color.w > 0.f;
 
         switch (a.shape)

--- a/src/annotations.cpp
+++ b/src/annotations.cpp
@@ -373,7 +373,10 @@ bool text_extent(const Annotation &a, const VgTransform &xform, float2 &lo, floa
     const float2 measured = xform.measure_text(a.font_face, a.font_size, a.text);
     extent                = a.font_size_relative ? measured : measured / std::max(xform.scale, 1e-6f);
     lo                    = a.p0() - text_anchor_offset(a.text_align, extent);
-    return extent.x > 0.f && extent.y > 0.f;
+
+    // Zero wide until something is typed, but a line tall from the start, so a text annotation shows where
+    // it is the moment it is placed.
+    return extent.y > 0.f;
 }
 
 bool text_screen_box(const Annotation &a, const VgTransform &xform, float2 &lo, float2 &hi)

--- a/src/annotations.h
+++ b/src/annotations.h
@@ -153,7 +153,7 @@ std::vector<VgCommand> to_vg_commands(const std::vector<Annotation> &annotations
 */
 int annotation_handles(const Annotation &a, float2 out[Annotation::MaxHandles], const VgTransform *xform = nullptr);
 
-/// Index of the handle of \p a within \p radius of \p screen_pos, or -1 if none is.
+/// Index of \p a's handle whose square of half-size \p radius holds \p screen_pos, or -1 if none does.
 int handle_at(const Annotation &a, float2 screen_pos, const VgTransform &xform, float radius);
 
 /// The polyline \p a is drawn as: its points, or the curve sampled through them.

--- a/src/annotations.h
+++ b/src/annotations.h
@@ -114,6 +114,16 @@ struct Annotation
 void to_json(json &j, const Annotation &a);
 void from_json(const json &j, Annotation &a);
 
+/// Screen pixels per unit of \p a's font size, and of its stroke width: \p scale when that size is
+/// relative, and one when it is not.
+/**
+    These are the only places that say what the two flags mean; everything that has to know asks here.
+    Measuring is linear in a font's size, so a string measured at font_size scales by the first into screen
+    pixels, and dividing by \p scale again brings it back to image ones.
+*/
+float font_size_scale(const Annotation &a, float scale);
+float stroke_width_scale(const Annotation &a, float scale);
+
 /// Where \p a's text sits, in image coordinates, or false when \p xform cannot measure it.
 bool text_extent(const Annotation &a, const VgTransform &xform, float2 &lo, float2 &extent);
 

--- a/src/annotations.h
+++ b/src/annotations.h
@@ -61,8 +61,17 @@ struct Annotation
     /// Interior of a closed shape. Alpha zero means unfilled, which is the default and the common case.
     float4 fill_color{0.f, 0.f, 0.f, 0.f};
 
-    float stroke_width = 2.f;  ///< Screen pixels, so it neither thickens nor shrinks as the view is zoomed
-    float font_size    = 16.f; ///< Shape::Text only, in image pixels, so it zooms with what it labels
+    float stroke_width = 2.f;
+    float font_size    = 16.f; ///< Shape::Text only
+
+    /// Whether each size is in image pixels, and so zooms with what it marks, or in screen pixels.
+    /**
+        The protocol carries this per command, as VgCommand::ScaleKind, and these are what it is set from.
+        A stroke defaults to screen pixels, so a line stays visible however far out the view is, and a font
+        to image pixels, so a string stays the size of the feature it labels.
+    */
+    bool stroke_width_relative = false;
+    bool font_size_relative    = true;
     /// Which face a Shape::Text is drawn in, as a NanoVG face name; see annotation_font_faces().
     std::string font_face = "sans";
     /// VgCommand::TextAlign flags, saying where p0 sits relative to the text it anchors.

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -345,6 +345,8 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
     if (clicked)
         ImGui::OpenPopup("##units");
 
+    // Under the field's own bottom-left, where a combo puts its list, instead of wherever the cursor was.
+    ImGui::SetNextWindowPos(ImVec2(field_lo.x, field_hi.y));
     if (ImGui::BeginPopup("##units"))
     {
         // Converted at the zoom it is switched under, so the size on screen is what it was.

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -263,11 +263,9 @@ void HDRViewApp::draw_text_editing() const
     const float line_h = hi.y - lo.y;
     auto        place  = [&](int offset)
     {
-        // Measured for a font of a.font_size screen pixels, which is what the size already is when it is
-        // absolute; a relative one is image pixels and reaches the screen by way of the zoom.
-        const int   n     = std::clamp(offset, 0, int(a.text.size()));
-        const float width = xform.measure_text(a.font_face, a.font_size, a.text.substr(0, size_t(n))).x;
-        return a.font_size_relative ? width * xform.scale : width;
+        const int n = std::clamp(offset, 0, int(a.text.size()));
+        return xform.measure_text(a.font_face, a.font_size, a.text.substr(0, size_t(n))).x *
+               font_size_scale(a, xform.scale);
     };
 
     if (state->HasSelection())
@@ -321,12 +319,11 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
 
     // DragFloat centers its value across the whole frame with no way to ask for anything else, which in a
     // narrow field runs it under the menu. So the drag is given nothing to draw and the value is drawn
-    // here, centered in what the menu leaves -- except while it is being typed into, when the input box
-    // draws and aligns its own.
+    // here, centered in what the menu leaves. While it is being typed into, the input box draws its own.
     const bool typing = ImGui::TempInputIsActive(ImGui::GetID("##value"));
 
-    // The drag takes the whole width; the menu is laid over its right-hand end, so the two are one frame
-    // rather than two side by side.
+    // The drag takes the whole width and the menu is laid over its right-hand end, so the two read as one
+    // frame.
     ImGui::SetNextItemAllowOverlap();
     ImGui::SetNextItemWidth(width);
     bool changed = ImGui::DragFloat("##value", &value, speed, lo_limit, hi_limit, typing ? format : "");

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -308,7 +308,7 @@ static std::string row_name(const Annotation &a, float width)
     current \p scale, so what is on screen does not jump when the unit under it changes.
 */
 static bool size_drag(const char *id, float &value, bool &relative, float speed, float lo_limit, float hi_limit,
-                      float scale, float width, bool left_align = false)
+                      float scale, float width)
 {
     const ImGuiStyle &style  = ImGui::GetStyle();
     const float       arrow  = ImGui::GetFrameHeight();
@@ -316,10 +316,11 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
 
     ImGui::PushID(id);
 
-    // DragFloat centers its value with no way to ask for anything else, and in a narrow field that runs it
-    // under the menu. So the drag is given nothing to draw and the value is drawn here instead -- except
-    // while it is being typed into, when the input box draws and aligns its own.
-    const bool typing = !left_align || ImGui::TempInputIsActive(ImGui::GetID("##value"));
+    // DragFloat centers its value across the whole frame with no way to ask for anything else, which in a
+    // narrow field runs it under the menu. So the drag is given nothing to draw and the value is drawn
+    // here, centered in what the menu leaves -- except while it is being typed into, when the input box
+    // draws and aligns its own.
+    const bool typing = ImGui::TempInputIsActive(ImGui::GetID("##value"));
 
     // The drag takes the whole width; the menu is laid over its right-hand end, so the two are one frame
     // rather than two side by side.
@@ -345,11 +346,16 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
     ImGui::RenderArrow(draw_list, ImVec2(at.x + style.FramePadding.y, at.y + style.FramePadding.y),
                        ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Down, 1.f);
 
+    ImGui::SetItemTooltip("The unit this size is measured in.");
+
     if (!typing)
     {
         char shown[64];
         snprintf(shown, sizeof(shown), format, value);
-        draw_list->AddText(ImVec2(field_lo.x + style.FramePadding.x, field_lo.y + style.FramePadding.y),
+
+        const float text_w = ImGui::CalcTextSize(shown).x;
+        const float from = field_lo.x + style.FramePadding.x, to = at.x;
+        draw_list->AddText(ImVec2(from + ImMax(0.f, (to - from - text_w) * 0.5f), field_lo.y + style.FramePadding.y),
                            ImGui::GetColorU32(ImGuiCol_Text), shown);
     }
 
@@ -838,7 +844,7 @@ void HDRViewApp::draw_annotation_controls(Annotation &a)
 
         ImGui::TableNextColumn();
         restyled |= size_drag("width", a.stroke_width, a.stroke_width_relative, 0.05f, 0.01f, 512.f,
-                              viewport_transform().scale, ImGui::GetContentRegionAvail().x, true);
+                              viewport_transform().scale, ImGui::GetContentRegionAvail().x);
 
         // Restyling the annotation in hand also sets what the next one will look like, so a color or a
         // width chosen once carries forward instead of being forgotten when the selection is dropped.

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -263,8 +263,11 @@ void HDRViewApp::draw_text_editing() const
     const float line_h = hi.y - lo.y;
     auto        place  = [&](int offset)
     {
-        const int n = std::clamp(offset, 0, int(a.text.size()));
-        return xform.measure_text(a.font_face, a.font_size, a.text.substr(0, size_t(n))).x * xform.scale;
+        // Measured for a font of a.font_size screen pixels, which is what the size already is when it is
+        // absolute; a relative one is image pixels and reaches the screen by way of the zoom.
+        const int   n     = std::clamp(offset, 0, int(a.text.size()));
+        const float width = xform.measure_text(a.font_face, a.font_size, a.text.substr(0, size_t(n))).x;
+        return a.font_size_relative ? width * xform.scale : width;
     };
 
     if (state->HasSelection())

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -249,8 +249,9 @@ void HDRViewApp::draw_text_editing() const
 
     auto *draw_list = ImGui::GetBackgroundDrawList();
 
-    // Boxed, so a selected string reads as selected even where its corners are not yet in reach.
-    draw_list->AddRect(lo - 2.f, hi + 2.f, ImGui::GetColorU32(ImGuiCol_Border));
+    // Boxed, so a selected string reads as selected. On the box itself, not a couple of pixels outside it,
+    // since its corners are where the handles are and a click has to land on what it can see.
+    draw_list->AddRect(lo, hi, ImGui::GetColorU32(ImGuiCol_Border));
 
     // Dear ImGui draws the caret and the selection inside InputTextEx, which cannot be called from out
     // here; the state behind it can be read, so the same marks are drawn from it.

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -301,34 +301,41 @@ static std::string row_name(const Annotation &a, float width)
     return name + "...";
 }
 
-/// A size, with the unit it is measured in chosen from a menu inside the field.
+/// A size, with the unit it is measured in chosen from a menu at the end of the field.
 /**
     The protocol carries a scale kind on each of the two sizes it has, so both are offered: image pixels,
     which zoom with what they mark, and screen pixels, which do not. Switching converts \p value at the
     current \p scale, so what is on screen does not jump when the unit under it changes.
 */
 static bool size_drag(const char *id, float &value, bool &relative, float speed, float lo_limit, float hi_limit,
-                      float scale)
+                      float scale, float width)
 {
+    const ImGuiStyle &style = ImGui::GetStyle();
+    const float       arrow = ImGui::GetFrameHeight();
+
     ImGui::PushID(id);
 
-    // The drag fills the field, and the menu sits over its right-hand end.
-    ImGui::SetNextItemAllowOverlap();
-    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::SetNextItemWidth(ImMax(width - arrow, arrow));
     bool changed = ImGui::DragFloat("##value", &value, speed, lo_limit, hi_limit, relative ? "%.2f img" : "%.1f px");
     ImGui::SetItemTooltip("%s", relative ? "Image pixels: zooms with what it marks."
                                          : "Screen pixels: the same size however far the view is zoomed.");
+    const float height = ImGui::GetItemRectSize().y;
 
-    const ImVec2 field_lo = ImGui::GetItemRectMin(), field_hi = ImGui::GetItemRectMax();
-    const float  arrow_w = ImGui::GetFrameHeight() * 0.7f;
+    // Drawn the way BeginCombo draws its own arrow -- a button-colored box rounded on the right, with the
+    // arrow inset by the frame padding at full size -- so the two read as the same control.
+    ImGui::SameLine(0.f, 0.f);
+    const ImVec2 at      = ImGui::GetCursorScreenPos();
+    const bool   clicked = ImGui::InvisibleButton("##units", ImVec2(arrow, height));
 
-    ImGui::SetCursorScreenPos(ImVec2(field_hi.x - arrow_w, field_lo.y));
-    if (ImGui::InvisibleButton("##units", ImVec2(arrow_w, field_hi.y - field_lo.y)))
+    auto *draw_list = ImGui::GetWindowDrawList();
+    draw_list->AddRectFilled(at, ImVec2(at.x + arrow, at.y + height),
+                             ImGui::GetColorU32(ImGui::IsItemHovered() ? ImGuiCol_ButtonHovered : ImGuiCol_Button),
+                             style.FrameRounding, ImDrawFlags_RoundCornersRight);
+    ImGui::RenderArrow(draw_list, ImVec2(at.x + style.FramePadding.y, at.y + style.FramePadding.y),
+                       ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Down, 1.f);
+
+    if (clicked)
         ImGui::OpenPopup("##units");
-
-    ImGui::RenderArrow(ImGui::GetWindowDrawList(),
-                       ImVec2(field_hi.x - arrow_w, field_lo.y + ImGui::GetStyle().FramePadding.y),
-                       ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Down, 0.7f);
 
     if (ImGui::BeginPopup("##units"))
     {
@@ -698,9 +705,8 @@ void HDRViewApp::draw_font_popup(Annotation &a, const ImVec2 &frame_padding, flo
     }
 
     ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
-    ImGui::SetNextItemWidth(EmSize(7));
     if (size_drag("size", a.font_size, a.font_size_relative, 0.25f, Annotation::MinFontSize, Annotation::MaxFontSize,
-                  viewport_transform().scale))
+                  viewport_transform().scale, EmSize(9)))
     {
         m_annotation_style.font_size          = a.font_size;
         m_annotation_style.font_size_relative = a.font_size_relative;
@@ -808,7 +814,7 @@ void HDRViewApp::draw_annotation_controls(Annotation &a)
 
         ImGui::TableNextColumn();
         restyled |= size_drag("width", a.stroke_width, a.stroke_width_relative, 0.05f, 0.01f, 512.f,
-                              viewport_transform().scale);
+                              viewport_transform().scale, ImGui::GetContentRegionAvail().x);
 
         // Restyling the annotation in hand also sets what the next one will look like, so a color or a
         // width chosen once carries forward instead of being forgotten when the selection is dropped.

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -308,18 +308,24 @@ static std::string row_name(const Annotation &a, float width)
     current \p scale, so what is on screen does not jump when the unit under it changes.
 */
 static bool size_drag(const char *id, float &value, bool &relative, float speed, float lo_limit, float hi_limit,
-                      float scale, float width)
+                      float scale, float width, bool left_align = false)
 {
-    const ImGuiStyle &style = ImGui::GetStyle();
-    const float       arrow = ImGui::GetFrameHeight();
+    const ImGuiStyle &style  = ImGui::GetStyle();
+    const float       arrow  = ImGui::GetFrameHeight();
+    const char       *format = relative ? "%.2f img" : "%.1f px";
 
     ImGui::PushID(id);
+
+    // DragFloat centers its value with no way to ask for anything else, and in a narrow field that runs it
+    // under the menu. So the drag is given nothing to draw and the value is drawn here instead -- except
+    // while it is being typed into, when the input box draws and aligns its own.
+    const bool typing = !left_align || ImGui::TempInputIsActive(ImGui::GetID("##value"));
 
     // The drag takes the whole width; the menu is laid over its right-hand end, so the two are one frame
     // rather than two side by side.
     ImGui::SetNextItemAllowOverlap();
     ImGui::SetNextItemWidth(width);
-    bool changed = ImGui::DragFloat("##value", &value, speed, lo_limit, hi_limit, relative ? "%.2f img" : "%.1f px");
+    bool changed = ImGui::DragFloat("##value", &value, speed, lo_limit, hi_limit, typing ? format : "");
     ImGui::SetItemTooltip("%s", relative ? "Image pixels: zooms with what it marks."
                                          : "Screen pixels: the same size however far the view is zoomed.");
 
@@ -338,6 +344,14 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
                              style.FrameRounding, ImDrawFlags_RoundCornersRight);
     ImGui::RenderArrow(draw_list, ImVec2(at.x + style.FramePadding.y, at.y + style.FramePadding.y),
                        ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Down, 1.f);
+
+    if (!typing)
+    {
+        char shown[64];
+        snprintf(shown, sizeof(shown), format, value);
+        draw_list->AddText(ImVec2(field_lo.x + style.FramePadding.x, field_lo.y + style.FramePadding.y),
+                           ImGui::GetColorU32(ImGuiCol_Text), shown);
+    }
 
     // The menu was placed by hand, so the layout goes on from where the field left it.
     ImGui::SetCursorScreenPos(resume);
@@ -824,7 +838,7 @@ void HDRViewApp::draw_annotation_controls(Annotation &a)
 
         ImGui::TableNextColumn();
         restyled |= size_drag("width", a.stroke_width, a.stroke_width_relative, 0.05f, 0.01f, 512.f,
-                              viewport_transform().scale, ImGui::GetContentRegionAvail().x);
+                              viewport_transform().scale, ImGui::GetContentRegionAvail().x, true);
 
         // Restyling the annotation in hand also sets what the next one will look like, so a color or a
         // width chosen once carries forward instead of being forgotten when the selection is dropped.

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -353,10 +353,10 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
         char shown[64];
         snprintf(shown, sizeof(shown), format, value);
 
-        const float text_w = ImGui::CalcTextSize(shown).x;
-        const float from = field_lo.x + style.FramePadding.x, to = at.x;
-        draw_list->AddText(ImVec2(from + ImMax(0.f, (to - from - text_w) * 0.5f), field_lo.y + style.FramePadding.y),
-                           ImGui::GetColorU32(ImGuiCol_Text), shown);
+        // Centered in what the menu leaves, and cut off there: a value too long for the room would run
+        // under the arrow, which is what a narrow panel produces.
+        ImGui::RenderTextClipped(ImVec2(field_lo.x + style.FramePadding.x, field_lo.y), ImVec2(at.x, field_hi.y), shown,
+                                 nullptr, nullptr, ImVec2(0.5f, 0.5f));
     }
 
     // The menu was placed by hand, so the layout goes on from where the field left it.
@@ -670,13 +670,16 @@ void HDRViewApp::draw_annotations_window()
 }
 
 /// The "Add:" label and the picker that says which shape the tool draws next, as one table cell.
-void HDRViewApp::draw_shape_picker(bool named)
+void HDRViewApp::draw_shape_picker(bool named, bool labeled)
 {
     ImGui::TableNextColumn();
     const auto &style = ImGui::GetStyle();
-    ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Add:");
-    ImGui::SameLine(0.f, style.ItemInnerSpacing.x);
+    if (labeled)
+    {
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Add:");
+        ImGui::SameLine(0.f, style.ItemInnerSpacing.x);
+    }
     ImGui::SetNextItemWidth(-FLT_MIN);
     const std::string preview = named ? fmt::format("{} {}", annotation_shape_icon(m_annotation_shape),
                                                     annotation_shape_name(m_annotation_shape))
@@ -826,7 +829,11 @@ void HDRViewApp::draw_annotation_controls(Annotation &a)
     // names out as well.
     const float avail = ImGui::GetContentRegionAvail().x;
     const bool  named = avail >= colors_w + width_min + add_text_w + combo_wide + 3.f * style.CellPadding.x;
-    const float add_w = add_text_w + (named ? combo_wide : combo_narrow);
+
+    // Narrower still and the word goes too, before the columns start running over one another; the picker's
+    // own icon says what it is.
+    const bool  labeled = avail >= colors_w + width_min + add_text_w + combo_narrow + 3.f * style.CellPadding.x;
+    const float add_w   = (labeled ? add_text_w : 0.f) + (named ? combo_wide : combo_narrow);
 
     if (ImGui::BeginTable("##AnnotationControls", 3,
                           ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_NoPadOuterX |
@@ -837,7 +844,7 @@ void HDRViewApp::draw_annotation_controls(Annotation &a)
         ImGui::TableSetupColumn("width", ImGuiTableColumnFlags_WidthStretch, 1.f);
         ImGui::TableNextRow();
 
-        draw_shape_picker(named);
+        draw_shape_picker(named, labeled);
 
         ImGui::TableNextColumn();
         bool restyled = ImGui::StrokeFillSwatches("Colors", a.stroke_color, a.fill_color);

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -315,24 +315,32 @@ static bool size_drag(const char *id, float &value, bool &relative, float speed,
 
     ImGui::PushID(id);
 
-    ImGui::SetNextItemWidth(ImMax(width - arrow, arrow));
+    // The drag takes the whole width; the menu is laid over its right-hand end, so the two are one frame
+    // rather than two side by side.
+    ImGui::SetNextItemAllowOverlap();
+    ImGui::SetNextItemWidth(width);
     bool changed = ImGui::DragFloat("##value", &value, speed, lo_limit, hi_limit, relative ? "%.2f img" : "%.1f px");
     ImGui::SetItemTooltip("%s", relative ? "Image pixels: zooms with what it marks."
                                          : "Screen pixels: the same size however far the view is zoomed.");
-    const float height = ImGui::GetItemRectSize().y;
 
-    // Drawn the way BeginCombo draws its own arrow -- a button-colored box rounded on the right, with the
-    // arrow inset by the frame padding at full size -- so the two read as the same control.
-    ImGui::SameLine(0.f, 0.f);
-    const ImVec2 at      = ImGui::GetCursorScreenPos();
-    const bool   clicked = ImGui::InvisibleButton("##units", ImVec2(arrow, height));
+    const ImVec2 field_lo = ImGui::GetItemRectMin(), field_hi = ImGui::GetItemRectMax();
+    const ImVec2 resume = ImGui::GetCursorScreenPos();
+
+    // Drawn the way BeginCombo draws its own arrow: a button-colored box over the end of the frame, rounded
+    // on the right, with the arrow inset by the frame padding at full size.
+    const ImVec2 at{field_hi.x - arrow, field_lo.y};
+    ImGui::SetCursorScreenPos(at);
+    const bool clicked = ImGui::InvisibleButton("##units", ImVec2(arrow, field_hi.y - field_lo.y));
 
     auto *draw_list = ImGui::GetWindowDrawList();
-    draw_list->AddRectFilled(at, ImVec2(at.x + arrow, at.y + height),
+    draw_list->AddRectFilled(at, field_hi,
                              ImGui::GetColorU32(ImGui::IsItemHovered() ? ImGuiCol_ButtonHovered : ImGuiCol_Button),
                              style.FrameRounding, ImDrawFlags_RoundCornersRight);
     ImGui::RenderArrow(draw_list, ImVec2(at.x + style.FramePadding.y, at.y + style.FramePadding.y),
                        ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Down, 1.f);
+
+    // The menu was placed by hand, so the layout goes on from where the field left it.
+    ImGui::SetCursorScreenPos(resume);
 
     if (clicked)
         ImGui::OpenPopup("##units");

--- a/src/app-annotations.cpp
+++ b/src/app-annotations.cpp
@@ -18,6 +18,29 @@
 using namespace std;
 using namespace HelloImGui;
 
+/// The icon the panel and the shape picker show for \p shape.
+static const char *annotation_shape_icon(Annotation::Shape shape)
+{
+    switch (shape)
+    {
+    case Annotation::Shape::Rect: return ICON_MY_SHAPE_RECT;
+    case Annotation::Shape::Ellipse: return ICON_MY_SHAPE_ELLIPSE;
+    case Annotation::Shape::Line: return ICON_MY_SHAPE_LINE;
+    case Annotation::Shape::Arrow: return ICON_MY_SHAPE_ARROW;
+    case Annotation::Shape::Text: return ICON_MY_SHAPE_TEXT;
+    case Annotation::Shape::Freehand: return ICON_MY_SHAPE_FREEHAND;
+    default: return ICON_MY_ANNOTATE;
+    }
+}
+
+void HDRViewApp::set_annotation_shape(Annotation::Shape shape)
+{
+    m_annotation_shape = shape;
+
+    // The tool's button says which shape it will draw, so the palette shows the choice without being asked.
+    action(mouse_mode_action_name(MouseMode_Annotate)).icon = annotation_shape_icon(shape);
+}
+
 int HDRViewApp::active_annotation() const
 {
     auto img = current_image();
@@ -278,19 +301,55 @@ static std::string row_name(const Annotation &a, float width)
     return name + "...";
 }
 
-/// The icon the panel and the shape picker show for \p shape.
-static const char *annotation_shape_icon(Annotation::Shape shape)
+/// A size, with the unit it is measured in chosen from a menu inside the field.
+/**
+    The protocol carries a scale kind on each of the two sizes it has, so both are offered: image pixels,
+    which zoom with what they mark, and screen pixels, which do not. Switching converts \p value at the
+    current \p scale, so what is on screen does not jump when the unit under it changes.
+*/
+static bool size_drag(const char *id, float &value, bool &relative, float speed, float lo_limit, float hi_limit,
+                      float scale)
 {
-    switch (shape)
+    ImGui::PushID(id);
+
+    // The drag fills the field, and the menu sits over its right-hand end.
+    ImGui::SetNextItemAllowOverlap();
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    bool changed = ImGui::DragFloat("##value", &value, speed, lo_limit, hi_limit, relative ? "%.2f img" : "%.1f px");
+    ImGui::SetItemTooltip("%s", relative ? "Image pixels: zooms with what it marks."
+                                         : "Screen pixels: the same size however far the view is zoomed.");
+
+    const ImVec2 field_lo = ImGui::GetItemRectMin(), field_hi = ImGui::GetItemRectMax();
+    const float  arrow_w = ImGui::GetFrameHeight() * 0.7f;
+
+    ImGui::SetCursorScreenPos(ImVec2(field_hi.x - arrow_w, field_lo.y));
+    if (ImGui::InvisibleButton("##units", ImVec2(arrow_w, field_hi.y - field_lo.y)))
+        ImGui::OpenPopup("##units");
+
+    ImGui::RenderArrow(ImGui::GetWindowDrawList(),
+                       ImVec2(field_hi.x - arrow_w, field_lo.y + ImGui::GetStyle().FramePadding.y),
+                       ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Down, 0.7f);
+
+    if (ImGui::BeginPopup("##units"))
     {
-    case Annotation::Shape::Rect: return ICON_MY_SHAPE_RECT;
-    case Annotation::Shape::Ellipse: return ICON_MY_SHAPE_ELLIPSE;
-    case Annotation::Shape::Line: return ICON_MY_SHAPE_LINE;
-    case Annotation::Shape::Arrow: return ICON_MY_SHAPE_ARROW;
-    case Annotation::Shape::Text: return ICON_MY_SHAPE_TEXT;
-    case Annotation::Shape::Freehand: return ICON_MY_SHAPE_FREEHAND;
-    default: return ICON_MY_ANNOTATE;
+        // Converted at the zoom it is switched under, so the size on screen is what it was.
+        const float zoom = std::max(scale, 1e-6f);
+        if (ImGui::Selectable("Relative px (zooms with the image)", relative) && !relative)
+        {
+            value /= zoom;
+            relative = changed = true;
+        }
+        if (ImGui::Selectable("Absolute px (fixed on screen)", !relative) && relative)
+        {
+            value *= zoom;
+            relative = false;
+            changed  = true;
+        }
+        ImGui::EndPopup();
     }
+
+    ImGui::PopID();
+    return changed;
 }
 
 void HDRViewApp::draw_annotations_window()
@@ -595,7 +654,7 @@ void HDRViewApp::draw_shape_picker(bool named)
             if (ImGui::Selectable(
                     fmt::format("{} {}", annotation_shape_icon(shape), annotation_shape_name(shape)).c_str(),
                     is_selected))
-                m_annotation_shape = shape;
+                set_annotation_shape(shape);
             if (is_selected)
                 ImGui::SetItemDefaultFocus();
         }
@@ -639,10 +698,13 @@ void HDRViewApp::draw_font_popup(Annotation &a, const ImVec2 &frame_padding, flo
     }
 
     ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
-    ImGui::SetNextItemWidth(EmSize(6));
-    if (ImGui::DragFloat("##size", &a.font_size, 0.25f, Annotation::MinFontSize, Annotation::MaxFontSize, "%.0f px"))
-        m_annotation_style.font_size = a.font_size;
-    ImGui::SetItemTooltip("Image pixels, so the text grows and shrinks with what it labels.");
+    ImGui::SetNextItemWidth(EmSize(7));
+    if (size_drag("size", a.font_size, a.font_size_relative, 0.25f, Annotation::MinFontSize, Annotation::MaxFontSize,
+                  viewport_transform().scale))
+    {
+        m_annotation_style.font_size          = a.font_size;
+        m_annotation_style.font_size_relative = a.font_size_relative;
+    }
 
     // Which corner or edge of the string lands on the point it was placed at, which is what NanoVG's
     // align flags say. Each square carries a dot where its own anchor sits, drawn because FontAwesome has
@@ -745,17 +807,17 @@ void HDRViewApp::draw_annotation_controls(Annotation &a)
         bool restyled = ImGui::StrokeFillSwatches("Colors", a.stroke_color, a.fill_color);
 
         ImGui::TableNextColumn();
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        restyled |= ImGui::DragFloat("##width", &a.stroke_width, 0.05f, 0.5f, 32.f, "%.1f px");
-        ImGui::SetItemTooltip("Stroke width in screen pixels, so it does not change with zoom.");
+        restyled |= size_drag("width", a.stroke_width, a.stroke_width_relative, 0.05f, 0.01f, 512.f,
+                              viewport_transform().scale);
 
         // Restyling the annotation in hand also sets what the next one will look like, so a color or a
         // width chosen once carries forward instead of being forgotten when the selection is dropped.
         if (restyled && &a != &m_annotation_style)
         {
-            m_annotation_style.stroke_color = a.stroke_color;
-            m_annotation_style.fill_color   = a.fill_color;
-            m_annotation_style.stroke_width = a.stroke_width;
+            m_annotation_style.stroke_color          = a.stroke_color;
+            m_annotation_style.fill_color            = a.fill_color;
+            m_annotation_style.stroke_width          = a.stroke_width;
+            m_annotation_style.stroke_width_relative = a.stroke_width_relative;
         }
 
         ImGui::EndTable();

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1325,7 +1325,15 @@ void HDRViewApp::setup_actions(ImGuiKey modKey, const vector<DockableWindowExtra
                        tool_icons[i],
                        tool_chords[i],
                        0,
-                       [this, i]() { set_mouse_mode(i); },
+                       [this, i]()
+                       {
+                           // The tool's own key cycles what it draws once it is the tool in hand.
+                           if (i == MouseMode_Annotate && m_mouse_mode == MouseMode_Annotate)
+                               set_annotation_shape(
+                                   Annotation::Shape((int(m_annotation_shape) + 1) % int(Annotation::Shape::COUNT)));
+                           else
+                               set_mouse_mode(i);
+                       },
                        always_enabled,
                        false,
                        &m_mouse_mode_enabled[i]});

--- a/src/app.h
+++ b/src/app.h
@@ -823,6 +823,9 @@ private:
     */
     bool m_mouse_mode_enabled[MouseMode_COUNT] = {true, false, false, false};
 
+    /// Choose the shape the annotate tool draws; the tool's own icon follows it.
+    void set_annotation_shape(Annotation::Shape shape);
+
     /// Which shape the annotate tool draws, and the look every new annotation starts with.
     Annotation::Shape m_annotation_shape = Annotation::Shape::Rect;
     Annotation        m_annotation_style;

--- a/src/app.h
+++ b/src/app.h
@@ -534,7 +534,7 @@ private:
     void draw_annotations_window();
     /// The one row of controls the annotations panel edits an annotation, or the next one's look, through.
     void draw_annotation_controls(Annotation &a);
-    void draw_shape_picker(bool named);
+    void draw_shape_picker(bool named, bool labeled);
     /// Face and size for a text annotation, in a popup off its row's font button.
     void draw_font_popup(Annotation &a, const ImVec2 &frame_padding, float item_spacing_x);
     void draw_about_dialog(bool &);

--- a/tests/test_annotations.cpp
+++ b/tests/test_annotations.cpp
@@ -970,3 +970,39 @@ TEST_CASE("Text is baked at a handful of sizes, and at the same one however far 
 
 // That the zoom is not one of the things picking a baked size is what the box test above checks, by way of
 // the extent being the same at every zoom: nothing here takes a zoom to be independent of.
+
+TEST_CASE("A handle can be grabbed anywhere it is drawn")
+{
+    // Handles are drawn as squares of the hit radius, so the square is what has to answer: measured as a
+    // radius, a click on one of its own corners -- which is where a corner handle is aimed at -- misses,
+    // and the press falls through to whatever is under it.
+    constexpr float radius = 6.f;
+    const auto      x      = identity_transform();
+
+    for (auto shape : all_shapes())
+    {
+        CAPTURE(annotation_shape_name(shape));
+
+        const Annotation a = sample(shape);
+        float2           h[Annotation::MaxHandles];
+        const int        count = annotation_handles(a, h, &x);
+
+        for (int i = 0; i < count; ++i)
+        {
+            CAPTURE(i);
+            const float2 at = x.to_screen(h[i]);
+
+            // Every corner of the drawn square, just inside it.
+            const float e = radius - 0.5f;
+            for (float2 corner : {float2{-e, -e}, float2{e, -e}, float2{e, e}, float2{-e, e}})
+            {
+                CAPTURE(corner.x);
+                CAPTURE(corner.y);
+                CHECK(handle_at(a, at + corner, x, radius) >= 0);
+            }
+
+            // ...and well outside it, so the square has not simply grown without limit.
+            CHECK(handle_at(a, at + float2{4.f * radius, 4.f * radius}, x, radius) == -1);
+        }
+    }
+}

--- a/tests/test_annotations.cpp
+++ b/tests/test_annotations.cpp
@@ -551,7 +551,8 @@ bool same(const Annotation &a, const Annotation &b)
     return a.shape == b.shape && a.points == b.points && a.stroke_color == b.stroke_color &&
            a.fill_color == b.fill_color && a.stroke_width == b.stroke_width && a.font_size == b.font_size &&
            a.font_face == b.font_face && a.text_align == b.text_align && a.text == b.text && a.label == b.label &&
-           a.smooth == b.smooth && a.visible == b.visible && a.locked == b.locked;
+           a.smooth == b.smooth && a.visible == b.visible && a.locked == b.locked &&
+           a.stroke_width_relative == b.stroke_width_relative && a.font_size_relative == b.font_size_relative;
 }
 
 } // namespace
@@ -564,16 +565,18 @@ TEST_CASE("Every shape survives a trip through a session file")
 
         // Every field set away from its default, so a field the serializer forgets comes back as that
         // default and fails here rather than round-tripping by accident.
-        Annotation a   = sample(shape);
-        a.fill_color   = float4{0.25f, 0.5f, 0.75f, 0.5f};
-        a.text_align   = VgCommand::AlignRight | VgCommand::AlignBottom;
-        a.label        = "a label of its own";
-        a.visible      = false;
-        a.locked       = true;
-        a.stroke_width = 7.5f;
-        a.font_size    = 31.f;
-        a.font_face    = "mono-bold";
-        a.smooth       = true;
+        Annotation a            = sample(shape);
+        a.fill_color            = float4{0.25f, 0.5f, 0.75f, 0.5f};
+        a.text_align            = VgCommand::AlignRight | VgCommand::AlignBottom;
+        a.label                 = "a label of its own";
+        a.visible               = false;
+        a.locked                = true;
+        a.stroke_width          = 7.5f;
+        a.font_size             = 31.f;
+        a.font_face             = "mono-bold";
+        a.smooth                = true;
+        a.stroke_width_relative = true;
+        a.font_size_relative    = false;
 
         const Annotation b = json(a).get<Annotation>();
         CHECK(same(a, b));

--- a/tests/test_annotations.cpp
+++ b/tests/test_annotations.cpp
@@ -189,15 +189,17 @@ TEST_CASE("A filled shape draws more than the same shape unfilled")
     }
 }
 
-TEST_CASE("An arrow's head is proportioned in screen pixels")
+TEST_CASE("An arrow's head is proportioned in the unit its stroke is measured in")
 {
-    // The head is the one piece of geometry that has to be expressed in image coordinates while being
-    // sized like a screen quantity, so it is the one place the scale can be dropped or applied twice.
-    auto head_width_at = [](float scale)
+    // The head is a multiple of the stroke, expressed in image coordinates whatever the stroke is measured
+    // in, so it is where the zoom is most easily dropped or applied twice -- and it has to follow the
+    // stroke's own unit, growing on screen with the image only when the stroke does.
+    auto head_width_at = [](float scale, bool relative)
     {
-        Annotation a = sample(Annotation::Shape::Arrow);
-        a.p0()       = float2{0.f, 0.f};
-        a.p1()       = float2{1000.f, 0.f}; // long, so the head is never clamped by the shaft
+        Annotation a            = sample(Annotation::Shape::Arrow);
+        a.stroke_width_relative = relative;
+        a.p0()                  = float2{0.f, 0.f};
+        a.p1()                  = float2{1000.f, 0.f}; // long, so the head is never clamped by the shaft
 
         TestDrawList d;
         VgTransform  x = identity_transform();
@@ -210,19 +212,23 @@ TEST_CASE("An arrow's head is proportioned in screen pixels")
         return b.max_y - b.min_y;
     };
 
-    // Doubling the zoom must leave the head the same size on screen. Were the scale dropped, the head
-    // would double along with the image; were it applied twice, it would halve.
-    CHECK(head_width_at(2.f) == doctest::Approx(head_width_at(1.f)).epsilon(0.02f));
-    CHECK(head_width_at(4.f) == doctest::Approx(head_width_at(1.f)).epsilon(0.02f));
+    // A screen-pixel stroke keeps its head the same size on screen however far the view is zoomed. Were
+    // the zoom dropped, the head would grow with the image; were it applied twice, it would shrink.
+    CHECK(head_width_at(2.f, false) == doctest::Approx(head_width_at(1.f, false)).epsilon(0.02f));
+    CHECK(head_width_at(4.f, false) == doctest::Approx(head_width_at(1.f, false)).epsilon(0.02f));
 
-    // And the head is genuinely wider than the shaft, so the check above is measuring one.
+    // An image-pixel stroke draws a head that grows with the image, in step with the shaft it ends.
+    CHECK(head_width_at(2.f, true) == doctest::Approx(2.f * head_width_at(1.f, true)).epsilon(0.05f));
+    CHECK(head_width_at(4.f, true) == doctest::Approx(4.f * head_width_at(1.f, true)).epsilon(0.05f));
+
+    // And the head is genuinely wider than the shaft, so the checks above are measuring one.
     Annotation shaft_only = sample(Annotation::Shape::Line);
     shaft_only.p0()       = float2{0.f, 0.f};
     shaft_only.p1()       = float2{1000.f, 0.f};
     TestDrawList d;
     draw_vector_overlay(&d.list, to_vg_commands({shaft_only}, 1.f), identity_transform(), IM_COL32_WHITE);
     const auto sb = vertex_bounds(d.list);
-    CHECK(head_width_at(1.f) > (sb.max_y - sb.min_y) * 1.5f);
+    CHECK(head_width_at(1.f, false) > (sb.max_y - sb.min_y) * 1.5f);
 }
 
 TEST_CASE("Every shape reports a label without being given one")


### PR DESCRIPTION
Follows #223.

tev's protocol carries a `EScaleKind` — `Relative` or `Absolute` — on each of the two sizes it has, and
`Relative` means **image pixels multiplied by the zoom**, not a fraction of anything:

```cpp
case VgCommand::EType::StrokeWidth: {
    const float scale = (EScaleKind)(int)f[1] == EScaleKind::Relative
                            ? extractScale(displayWindowToNano) : 1.0f;
    nvgStrokeWidth(ctx, f[0] * scale);
}
```
— `tev/src/ImageCanvas.cpp:402`, with `FontSize` identical at `:495`

Annotations had one kind hardcoded for each: an absolute stroke width, a relative font size. Those are now
the annotation's own, defaulting to exactly what they were, so nothing changes until you ask it to.

## The control

The unit is picked from a menu inside the field, off an arrow at its right-hand end — the control showing
the number is the one that says what the number means, rather than a separate toggle beside it. The field
reads `2.0 px` or `0.25 img`, and the menu offers "Relative px (zooms with the image)" and "Absolute px
(fixed on screen)".

**Switching converts the value at the current zoom**, so the annotation does not jump: flipping `2.0 px` at
8× gives `0.25 img`, which is the same thickness on screen.

## Only two things followed from it

- Hit testing adds half the stroke to its slop, and a relative width is in image pixels, so it is brought
  up to the screen first.
- Nothing else. A string is still *measured* at the size that is stored, because measuring is linear in the
  size — which is what keeps the glyphs baked at a single size however far the view is zoomed, the fix from
  #223 that stopped the viewport crawling. The resize math is a dimensionless ratio and did not care.

Geometry gets no such control, and should not: every path command in the protocol is `Pos`/`Size` with no
scale kind, and radii are scaled unconditionally. Where a shape *is* has to be image space or it stops
marking the thing it was drawn on; only how thick the ink is has a choice.

## Also

`A` now cycles the shape once the annotate tool is already in hand, and the tool's button in the palette
carries the shape it will draw, so the choice is visible without opening the panel.

## Fixed under review

Six of these came out of trying it, and three were bugs the unit switch exposed rather than caused:

- **The arrowhead ignored the stroke's unit.** It is a multiple of the stroke laid out in image
  coordinates, so it divided by the zoom to get there — the conversion a screen-pixel stroke needs and an
  image-pixel one has already had. What each flag *means* is now said once, in `font_size_scale()` and
  `stroke_width_scale()`; three of the four converting sites had it written out by hand, and two of those
  three were wrong at some point.
- **The caret sat wrong in screen-pixel mode**, scaled by the zoom a second time. The box around it was
  right, which is why only the marks inside it moved.
- **A handle was drawn as a square and hit-tested as a circle**, so its own corners answered nothing — and
  a corner handle is aimed at by its corner. The box around a selected string was also drawn two pixels
  outside the corners the handles sit on. Between them, a first click on a text box's bottom-right corner
  moved it instead of resizing it.
- An empty text annotation had no box until a character was typed.
- The unit menu is drawn and placed the way a combo draws and places its own, over the end of the field
  rather than after it, opening beneath it rather than under the cursor.
- The control row keeps its value legible as the panel narrows: each field centres its own text in the room
  the menu leaves and clips it there, and the row sheds the word "Add:" one step before the columns begin
  running over one another.

## Verification

344 tests pass; builds clean on `linux-local`; `--help` smoke check passes. The session round trip covers
both new fields, with the fixture setting each away from its default — mutation-checked, dropping either
from the serializer fails it.

Two tests were broadened rather than added, each having covered half its property: the arrowhead test asked
only that the head hold its size on screen, which is true of one unit and not the other, and nothing
asserted that a handle can be grabbed anywhere it is drawn. Both were mutation-checked against the bug they
now catch — the circle-shaped hit test fails 112 of the second one's 140 assertions.

Not verified visually: the unit menu and the shape cycling. This machine has no display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y57sSWqP5MMFbHeyajn9MC
